### PR TITLE
TICKET 0006980: Problem database MSSQL

### DIFF
--- a/install/sql/mssql/testlink_create_tables.sql
+++ b/install/sql/mssql/testlink_create_tables.sql
@@ -985,7 +985,7 @@ CREATE TABLE /*prefix*/testcase_relations (
   relation_type INT NOT NULL DEFAULT '1',
   author_id int NOT NULL,
   creation_ts datetime NOT NULL CONSTRAINT /*prefix*/DF_testcase_relations_creation_ts DEFAULT (getdate()),
-  CONSTRAINT /*prefix*/PK_req_relations PRIMARY KEY  CLUSTERED 
+  CONSTRAINT /*prefix*/PK_testcase_relations PRIMARY KEY  CLUSTERED 
   (
     id
   )  ON [PRIMARY]


### PR DESCRIPTION
The following SQL-Statement works for the "CREATE TABLE /*prefix*/testcase_relations":

CREATE TABLE /*prefix*/testcase_relations (
  id int IDENTITY(1,1) NOT NULL,
  source_id INT NOT NULL DEFAULT '0',
  destination_id INT NOT NULL DEFAULT '0',
  relation_type INT NOT NULL DEFAULT '1',
  author_id int NOT NULL,
  creation_ts datetime NOT NULL CONSTRAINT /*prefix*/DF_testcase_relations_creation_ts DEFAULT (getdate()),
  CONSTRAINT /*prefix*/PK_testcase_relations PRIMARY KEY CLUSTERED 
  (
    id
  ) ON [PRIMARY]
) ON [PRIMARY];

INSERT INTO /*prefix*/db_version (version,notes,upgrade_ts) VALUES ('DB 1.9.13','Test Link 1.9.13',GETDATE());

>> The problem was that "PK_req_relations" exists. So we changed it to "PK_testcase_relations"