### PR TITLE
Fix #7599 : Support internationalized strings for plugins

### DIFF
--- a/README.plugins
+++ b/README.plugins
@@ -16,6 +16,11 @@ The structure inside the plugin folder will be
 +------ pages
 +---------< Smarty Template files >
 +---------< PHP Files to process Smarty templates>
++------< lang
++---------< local name >
++------------< strings.txt >
++---------< local name >
++------------< strings.txt >
 
 Plugin Main Class:
 The plugin main class should reside directly under the plugins/<pluginname>
@@ -57,7 +62,9 @@ Utilities that will help in writing the plugin class and support files:
   available there, then it picks it up from the Global Defaults (Setup through the
   `config` method of the plugin) and then default to the "default" parameter provided
   in the method definition. See `plugin_config_get` in `plugin_api.php` for details
-
+* plugin_lang_get: Get a string value according to the language configured in 
+  TestLink for the current user. See lang directory in TLTest plugin for more info
+  
 Writing Templates that will help in Plugin Configuration:
 The user might want to create pages that will help in configuring a plugin at a
 testproject level or for all projects. These template files will need to reside

--- a/README.plugins
+++ b/README.plugins
@@ -12,15 +12,15 @@ the folder acts as the name of the plugin.
 The structure inside the plugin folder will be
 + plugins
 +--< Name of Plugin >
-+------ <Plugin Main Class File>
++------ < Plugin Main Class File >
 +------ pages
 +---------< Smarty Template files >
-+---------< PHP Files to process Smarty templates>
-+------< lang
-+---------< local name >
-+------------< strings.txt >
-+---------< local name >
-+------------< strings.txt >
++---------< PHP Files to process Smarty templates >
++------ lang
++---------< language code >
++------------ strings.txt
++---------< language code >
++------------ strings.txt
 
 Plugin Main Class:
 The plugin main class should reside directly under the plugins/<pluginname>

--- a/lib/functions/lang_api.php
+++ b/lib/functions/lang_api.php
@@ -5,8 +5,8 @@
  *
  * @filesource  lang_api.php
  * @package     TestLink
- * @copyright   2005-2013, TestLink community 
- * @link        http://www.teamst.org/index.php
+ * @copyright   2005-2016, TestLink community 
+ * @link        http://www.testlink.org
  *
  * @internal thanks
  * The functionality is based on Mantis BTS project code 
@@ -15,7 +15,7 @@
  *
  *
  * @internal revisions
- * @since 1.9.9
+ * @since 1.9.15
  * 20130913 - franciscom - TICKET 5916: It's impossible to login with browser set to italian language (or other language <> english)
  **/
 
@@ -64,6 +64,13 @@ function lang_get( $p_string, $p_lang = null, $bDontFireEvents = false)
   }
   else
   {
+	$t_plugin_current = plugin_get_current();
+	if( !is_null( $t_plugin_current ) ) {
+		lang_load( $t_lang, TL_PLUGIN_PATH . $t_plugin_current . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR . $t_lang . DIRECTORY_SEPARATOR);
+		if( isset($g_lang_strings[$t_lang][$p_string]) ) {
+			$loc_str = $g_lang_strings[$t_lang][$p_string];
+		}
+	}
     if( $t_lang != 'en_GB' )
     {
       // force load of english strings
@@ -211,20 +218,27 @@ function lang_get_smarty($params, &$smarty)
 
 /** 
  * Loads the specified language and stores it in $g_lang_strings,
+ * @param string $p_lang
+ * @param string $p_dir
  * to be used by lang_get
  */
-function lang_load( $p_lang ) {
+function lang_load( $p_lang, $p_dir = null ) {
   global $g_lang_strings, $g_active_language;
   global $TLS_STRINGFILE_CHARSET;
 
   $g_active_language  = $p_lang;
 
-  if ( isset( $g_lang_strings[ $p_lang ] ) ) {
-    return;
+  if( isset( $g_lang_strings[$p_lang] ) && is_null( $p_dir ) ) {
+	return;
   }
 
   $t_lang_dir_base = TL_ABS_PATH . 'locale' . DIRECTORY_SEPARATOR;
   $lang_resource_path = $t_lang_dir_base . $p_lang . DIRECTORY_SEPARATOR . 'strings.txt';
+  
+  if( !is_null( $p_dir ) && is_file( $p_dir . 'strings.txt' )) {
+	require( $p_dir . 'strings.txt' );
+  }
+  
   if (file_exists($lang_resource_path) && is_readable($lang_resource_path))
   {
     require($lang_resource_path);
@@ -242,7 +256,7 @@ function lang_load( $p_lang ) {
   else
   {
     require($t_lang_dir_base . 'en_GB' . DIRECTORY_SEPARATOR . 'description.php');
-    }
+  }
     
   // Allow overriding strings declared in the language file.
   // custom_strings_inc.php can use $g_active_language

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2514,6 +2514,7 @@ $TLS_href_platform_management = "Gestion de plateformes";
 $TLS_href_issuetracker_management = "Gestion du Gestionnaire d'anomalies";
 $TLS_href_reqmgrsystem_management = "Gestion du Gestionnaire d'exigences";
 $TLS_system_config = "Système";
+$TLS_title_plugins = "Plugins";
 
 
 // ----- contribution by asimon for req/reqspec search BUGID 2976 -----

--- a/plugins/TLTest/TLTest.php
+++ b/plugins/TLTest/TLTest.php
@@ -63,27 +63,27 @@ class TLTestPlugin extends TestlinkPlugin
   {
     $arg = func_get_args();   // To get all the arguments
     $db = $this->db;      // To show how to get a Database Connection
-    echo "This is a test";
+    echo plugin_lang_get("testsuite_display_message");
   }
 
   function bottom_link()
   {
-    return "<a href=''>Left Bottom Link</a>";
+    return "<a href=''>".plugin_lang_get('left_bottom_link')."</a>";
   }
 
   function top_link()
   {
-    return "<a href='" . plugin_page('config.php') . "'>Configure My Plugin</a>";
+    return "<a href='" . plugin_page('config.php') . "'>".plugin_lang_get('config')."</a>";
   }
 
   function right_top_link()
   {
-    return "<a href=''>Right Top Link</a>";
+    return "<a href=''>".plugin_lang_get('right_top_link')."</a>";
   }
 
   function right_bottom_link()
   {
-    return "<a href=''>Right Bottom Link</a>";
+    return "<a href=''>".plugin_lang_get('right_bottom_link')."</a>";
   }
 
 }

--- a/plugins/TLTest/lang/en_GB/strings.txt
+++ b/plugins/TLTest/lang/en_GB/strings.txt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * TestLink Open Source Project - http://testlink.sourceforge.net/
+ * This script is distributed under the GNU General Public License 2 or later.
+ *
+ * @filesource  TLTest.php
+ * @copyright   2005-2016, TestLink community
+ * @link        http://www.testlink.org/
+ *
+ */
+
+$TLS_plugin_TLTest_description = "Test Plugin";
+$TLS_plugin_TLTest_config = "Configure My Plugin";
+$TLS_plugin_TLTest_left_bottom_link = "Left Bottom Link";
+$TLS_plugin_TLTest_right_bottom_link = "Right Bottom Link";
+$TLS_plugin_TLTest_left_top_link = "Left Top Link";
+$TLS_plugin_TLTest_right_top_link = "Right Top Link";
+$TLS_plugin_TLTest_testsuite_display_message = "This is a test";
+$TLS_plugin_TLTest_config_page_saved = "Configuration Saved";
+$TLS_plugin_TLTest_config_page_header_message = "Sample Configuration";
+$TLS_plugin_TLTest_config_page_title = "Configuration for TLTest Plugin";
+$TLS_plugin_TLTest_config_label_config1 = "Configuration Item 1";
+$TLS_plugin_TLTest_config_label_config2 = "Configuration Item 2";
+$TLS_plugin_TLTest_config_label_save_button = "Save Config";

--- a/plugins/TLTest/lang/fr_FR/strings.txt
+++ b/plugins/TLTest/lang/fr_FR/strings.txt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * TestLink Open Source Project - http://testlink.sourceforge.net/
+ * This script is distributed under the GNU General Public License 2 or later.
+ *
+ * @filesource  TLTest.php
+ * @copyright   2005-2016, TestLink community
+ * @link        http://www.testlink.org/
+ *
+ */
+
+$TLS_plugin_TLTest_description = "Plugin de test";
+$TLS_plugin_TLTest_config = "Configurer Mon Plugin";
+$TLS_plugin_TLTest_left_bottom_link = "Lien en bas à gauche";
+$TLS_plugin_TLTest_right_bottom_link = "Lien en bas à droite";
+$TLS_plugin_TLTest_left_top_link = "Lien en haut à gauche";
+$TLS_plugin_TLTest_right_top_link = "Lien en haut à droite";
+$TLS_plugin_TLTest_testsuite_display_message = "Ceci est un test";
+$TLS_plugin_TLTest_config_page_saved = "Configuration Sauvegardée";
+$TLS_plugin_TLTest_config_page_header_message = "Exemple de configuration";
+$TLS_plugin_TLTest_config_page_title = "Configuration du plugin TLTest";
+$TLS_plugin_TLTest_config_label_config1 = "Configuration Item 1";
+$TLS_plugin_TLTest_config_label_config2 = "Configuration Item 2";
+$TLS_plugin_TLTest_config_label_save_button = "Enregistrer";

--- a/plugins/TLTest/pages/config.php
+++ b/plugins/TLTest/pages/config.php
@@ -17,7 +17,7 @@ if ($_POST['submit']) {   // Check if the form is submitted
   plugin_config_set('config1', $_POST['config1'], $_SESSION['testprojectID']);
   plugin_config_set('config2', $_POST['config2'], $_SESSION['testprojectID']);
 
-  $gui->message = "Configuration Saved";    // Confirm message
+  $gui->message = plugin_lang_get('config_page_saved');    // Confirm message
 
   // Assign to Smarty
   $smarty->assign('gui',$gui);
@@ -25,9 +25,13 @@ if ($_POST['submit']) {   // Check if the form is submitted
   return;
 }
 
-$gui->headerMessage = "Sample Configuration";
+$gui->headerMessage = plugin_lang_get('config_page_header_message');
+$gui->title = plugin_lang_get('config_page_title');
+$gui->labelConfig1 = plugin_lang_get('config_label_config1');
+$gui->labelConfig2 = plugin_lang_get('config_label_config2');
 $gui->config1 = plugin_config_get('config1', '', $_SESSION['testprojectID']);
 $gui->config2 = plugin_config_get('config2', '', $_SESSION['testprojectID']);
+$gui->labelSaveConfig = plugin_lang_get('config_label_save_button');
 
 $smarty->assign('gui',$gui);
 $smarty->display(plugin_file_path('config.tpl'));

--- a/plugins/TLTest/pages/config.tpl
+++ b/plugins/TLTest/pages/config.tpl
@@ -5,7 +5,7 @@
 *}
 
 {include 'inc_head.tpl'}
-<h1>Configuration for TLTest Plugin</h1>
+<h1>{$gui->title}</h1>
 <div class="workBack">
     {if $gui->message }
         <div class="user_feedback">
@@ -16,19 +16,19 @@
 
     <form method="POST">
         <div class="labelHolder">
-            <label>Configuration Item 1</label>
+            <label>{$gui->labelConfig1}</label>
         </div>
         <div>
             <input type="text" name="config1" value="{$gui->config1}"/>
         </div>
         <div class="labelHolder">
-            <label>Configuration Item 2</label>
+            <label>{$gui->labelConfig2}</label>
         </div>
         <div>
             <input type="number" name="config2" value="{$gui->config2}"/>
         </div>
         <div>
-            <input type="submit" name="submit" value="Save Config"/>
+            <input type="submit" name="submit" value="{$gui->labelSaveConfig}"/>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Add the ability to TestLink plugins to display content according to user
preferences