### PR TITLE
Move Events from testsuite class to wrapper.

### DIFF
--- a/lib/functions/testsuite.class.php
+++ b/lib/functions/testsuite.class.php
@@ -197,8 +197,6 @@ class testsuite extends tlObjectWithAttachments
       if ($result)
       {
         $ret['id'] = $tsuite_id;
-        $ctx = array('id' => $tsuite_id,'name' => $name,'details' => $details);
-        event_signal('EVENT_TEST_SUITE_CREATE', $ctx);
       }
     }
     
@@ -243,11 +241,6 @@ class testsuite extends tlObjectWithAttachments
       {
         $ret['msg'] = $this->db->error_msg();
       } 
-      else 
-      {
-        $ctx = array('id' => $id,'name' => $name,'details' => $details);
-        event_signal('EVENT_TEST_SUITE_UPDATE', $ctx);
-      }
     }
     else
     {

--- a/lib/functions/testsuite.class.php
+++ b/lib/functions/testsuite.class.php
@@ -197,6 +197,12 @@ class testsuite extends tlObjectWithAttachments
       if ($result)
       {
         $ret['id'] = $tsuite_id;
+
+        if (defined(TL_APICALL))
+        {
+            $ctx = array('id' => $tsuite_id,'name' => $name,'details' => $details);     
+            event_signal('EVENT_TEST_SUITE_CREATE', $ctx);
+        }
       }
     }
     
@@ -241,6 +247,14 @@ class testsuite extends tlObjectWithAttachments
       {
         $ret['msg'] = $this->db->error_msg();
       } 
+      else
+      {
+        if (defined(TL_APICALL))
+        {
+          $ctx = array('id' => $id,'name' => $name,'details' => $details);
+          event_signal('EVENT_TEST_SUITE_UPDATE', $ctx);
+        }
+      }
     }
     else
     {

--- a/lib/testcases/containerEdit.php
+++ b/lib/testcases/containerEdit.php
@@ -19,6 +19,7 @@ require_once("../../config.inc.php");
 require_once("common.php");
 require_once("opt_transfer.php");
 require_once("web_editor.php");
+require_once('event_api.php');
 $editorCfg=getWebEditorCfg('design');
 require_once(require_web_editor($editorCfg['type']));
 
@@ -682,6 +683,10 @@ function addTestSuite(&$tsuiteMgr,&$argsObj,$container,&$hash)
             $tsuiteMgr->addKeywords($ret['id'],explode(",",$argsObj->assigned_keyword_list));
         }
         writeCustomFieldsToDB($tsuiteMgr->db,$argsObj->tprojectID,$ret['id'],$hash);
+
+        // Send Events to plugins 
+        $ctx = array('id' => $ret['id'],'name' => $container['container_name'],'details' => $container['details']);
+        event_signal('EVENT_TEST_SUITE_CREATE', $ctx);
     }
     return $op;
 }
@@ -771,6 +776,10 @@ function updateTestSuite(&$tsuiteMgr,&$argsObj,$container,&$hash)
       $tsuiteMgr->addKeywords($argsObj->testsuiteID,explode(",",$argsObj->assigned_keyword_list));
     }
     writeCustomFieldsToDB($tsuiteMgr->db,$argsObj->tprojectID,$argsObj->testsuiteID,$hash);
+
+    /* Send events to plugins */
+    $ctx = array('id' => $argsObj->testsuiteID,'name' => $container['container_name'],'details' => $container['details']);
+    event_signal('EVENT_TEST_SUITE_UPDATE', $ctx);
   }
   else
   {


### PR DESCRIPTION
Currently any custom fields that are created are not available at the time
the testsuite create/edit is calld because the events are generated before
the custom fields are persisted. Moving the logic from testsuite.class.php
to the container file that handles this fixes this problem.