### PR TITLE
Added Plugin Enable/Disable UI.

### DIFF
--- a/cfg/const.inc.php
+++ b/cfg/const.inc.php
@@ -871,6 +871,11 @@ $tlCfg->guiTopMenu[7] = array('label' => 'title_events',
                               'url' => 'lib/events/eventviewer.php',
                               'right' => array('events_mgt', 'mgt_view_events'),'condition'=>'',
                               'shortcut'=>'v','target'=>'mainframe'); 
+$tlCfg->guiTopMenu[8] = array('label' => 'title_plugins',
+                              'imgKey' => 'plugins',
+                              'url' => 'lib/plugins/pluginView.php',
+                              'right' => array('mgt_plugins'),'condition'=>'',
+                              'shortcut'=>'p','target'=>'mainframe');
 
 
 define( 'PARTIAL_URL_TL_FILE_FORMATS_DOCUMENT',  'docs/tl-file-formats.pdf');

--- a/gui/templates/plugins/pluginView.tpl
+++ b/gui/templates/plugins/pluginView.tpl
@@ -1,0 +1,113 @@
+{*
+TestLink Open Source Project - http://testlink.sourceforge.net/
+@filesource pluginView.tpl
+Purpose: smarty template - Manage plugins
+
+@internal revisions
+@since 1.9.15
+
+*}
+{lang_get var="labels"
+          s="btn_create,title_plugin_mgmt,th_plugin,th_plugin_description,th_plugin_version,
+             installed_plugins,available_plugins,actions"}
+
+{include file="inc_head.tpl" openHead="yes" jsValidate="yes" enableTableSorting="yes"}
+{include file="bootstrap.inc.tpl"}
+{include file="inc_ext_js.tpl"}
+
+{lang_get s='confirm_install_header' var="install_header"}
+{lang_get s='confirm_install_text' var="install_text"}
+{lang_get s='confirm_uninstall_header' var="uninstall_header"}
+{lang_get s='confirm_uninstall_text' var="uninstall_text"}
+
+</head>
+
+<body {$body_onload}>
+
+{include file="inc_update.tpl"}
+
+{* Form to submit the values back to the caller *}
+<form name="pluginForm" action="lib/plugins/pluginView.php" method="POST">
+  <input type="hidden" name="pluginId" />
+  <input type="hidden" name="pluginName" />
+  <input type="hidden" name="operation" />
+</form>
+
+{if $gui->installed_plugins|@count ne 0}
+  <h1 class="title">{$labels.installed_plugins}</h1>
+  <div class="workBack">
+    <table class="common sortable" width="100%">
+      <tr>
+        <th width="30%">{$tlImages.sort_hint}{$labels.th_plugin}</th>
+        <th width="40%" class="{$noSortableColumnClass}">{$labels.th_plugin_description}</th>
+        <th width="20%" class="icon_cell">{$labels.th_plugin_version}</th>
+        <th class="icon_cell">{$labels.actions}</th>
+      </tr>
+      {foreach from=$gui->installed_plugins item=plugin}
+      <tr>
+        <td>{$plugin.name}</td>
+        <td>{$plugin.description}</td>
+        <td>{$plugin.version}</td>
+        <td align="center">[<a href="#" onClick="return uninstallPlugin({$plugin.id})">Uninstall</a>]</td>
+      </tr>
+    {/foreach}
+  </table>
+</div>
+{/if}
+
+{if $gui->available_plugins|@count ne 0}
+  <br>
+  <h1 class="title">{$labels.available_plugins}</h1>
+  <div class="workBack">
+    <table class="common sortable" width="100%">
+      <tr>
+        <th width="30%">{$tlImages.sort_hint}{$labels.th_plugin}</th>
+        <th width="40%" class="{$noSortableColumnClass}">{$labels.th_plugin_description}</th>
+        <th width="20%" class="icon_cell">{$labels.th_plugin_version}</th>
+        <th class="icon_cell">{$labels.actions}</th>
+      </tr>
+      {foreach from=$gui->available_plugins item=plugin}
+      <tr>
+        <td>{$plugin.name}</td>
+        <td>{$plugin.description}</td>
+        <td>{$plugin.version}</td>
+        <td align="center">[<a href="#" onClick="return installPlugin('{$plugin.name}')">Install</a>]</td>
+      </tr>
+      {/foreach}
+    </table>
+  </div>
+{/if}
+
+<script type="text/javascript">
+  function uninstallPlugin(id)
+  {
+    Ext.Msg.confirm("{$uninstall_header}", "{$uninstall_text}",
+            function(btn, text)
+            {
+              if( btn == 'yes' )
+              {
+                document.forms['pluginForm'].elements['pluginId'].value = id;
+                document.forms['pluginForm'].elements['operation'].value = 'uninstall';
+                document.forms['pluginForm'].submit();
+              }
+            }
+    );
+    return false;
+  }
+  function installPlugin(name)
+  {
+    Ext.Msg.confirm("{$install_header}", "{$install_text}",
+            function(btn, text)
+            {
+              if (btn == 'yes')
+              {
+                document.forms['pluginForm'].elements['pluginName'].value = name;
+                document.forms['pluginForm'].elements['operation'].value = 'install';
+                document.forms['pluginForm'].submit();
+              }
+            }
+    );
+    return false;
+  }
+</script>
+</body>

--- a/install/sql/alter_tables/1.9.15/mssql/DB.1.9.15/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.15/mssql/DB.1.9.15/step1/db_schema_update.sql
@@ -23,10 +23,12 @@
 --- 
 SET IDENTITY_INSERT /*prefix*/rights ON
 INSERT INTO /*prefix*/rights (id,description) VALUES (47,'testcase_freeze');
+INSERT INTO /*prefix*/rights (id,description) VALUES (48,'mgt_plugins');
 SET IDENTITY_INSERT /*prefix*/rights OFF
 
 --  Rights for Administrator role
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,47);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,48);
 
 ALTER TABLE /*prefix*/cfield_testprojects ADD monitorable INT NOT NULL default '0';
 
@@ -42,4 +44,30 @@ CREATE TABLE /*prefix*/req_monitor (
   (
     req_id,user_id,testproject_id
   )  ON [PRIMARY]
+) ON [PRIMARY];
+
+CREATE TABLE /*prefix*/plugins (
+  plugin_id int NOT NULL IDENTITY(1,1) CONSTRAINT /*prefix*/DF_plugins_plugin_id DEFAULT ((0)),
+  basename VARCHAR(100) NOT NULL,
+  enabled tinyint NOT NULL CONSTRAINT /*prefix*/DF_plugins_enabled DEFAULT ((0)),
+  author_id int NOT NULL,
+  creation_ts datetime NOT NULL CONSTRAINT /*prefix*/DF_plugins_creation_ts DEFAULT (getdate()),
+ CONSTRAINT /*prefix*/PK_plugins PRIMARY KEY CLUSTERED
+ (
+  plugin_id ASC
+ ) ON [PRIMARY]
+) ON [PRIMARY];
+
+CREATE TABLE /*prefix*/plugins_configuration (
+  plugin_config_id int IDENTITY(1,1) NOT NULL CONSTRAINT /*prefix*/DF_plugins_configuration_plugin_config_id DEFAULT ((0)),
+  testproject_id int NOT NULL CONSTRAINT /*prefix*/DF_plugins_configuration__testproject_id DEFAULT ((0)),
+  config_key VARCHAR(255) NOT NULL,
+  config_type int NOT NULL,
+  config_value VARCHAR(255) NOT NULL,
+  author_id int NOT NULL,
+  creation_ts datetime NOT NULL CONSTRAINT /*prefix*/DF_plugins_configuration__creation_ts DEFAULT (getdate()),
+ CONSTRAINT /*prefix*/PK_plugins_configuration PRIMARY KEY CLUSTERED
+ (
+  plugin_config_id ASC
+ ) ON [PRIMARY]
 ) ON [PRIMARY];

--- a/install/sql/alter_tables/1.9.15/mysql/DB.1.9.15/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.15/mysql/DB.1.9.15/step1/db_schema_update.sql
@@ -1,8 +1,10 @@
 /* mysql */
 INSERT INTO /*prefix*/rights  (id,description) VALUES (47,'testcase_freeze');
+INSERT INTO /*prefix*/rights  (id,description) VALUES (48,'mgt_plugins');
 
 # Rights for Administrator role
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,47);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,48);
 
 ALTER TABLE /*prefix*/cfield_testprojects ADD COLUMN monitorable tinyint(1) NOT NULL default '0';
 

--- a/install/sql/alter_tables/1.9.15/postgres/DB.1.9.15/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.15/postgres/DB.1.9.15/step1/db_schema_update.sql
@@ -5,9 +5,11 @@
 -- 
 --
 INSERT INTO /*prefix*/rights (id,description) VALUES (47,'testcase_freeze');
+INSERT INTO /*prefix*/rights (id,description) VALUES (48,'mgt_plugins');
 
 --  Rights for Administrator (admin role)
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,47);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,48);
 
 ALTER TABLE /*prefix*/cfield_testprojects ADD COLUMN "monitorable" INT2 NOT NULL default '0';
 
@@ -20,4 +22,22 @@ CREATE TABLE /*prefix*/req_monitor (
   user_id BIGINT NULL DEFAULT NULL REFERENCES  /*prefix*/users (id),
   testproject_id BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/testprojects (id) ON DELETE CASCADE,
   PRIMARY KEY (req_id,user_id,testproject_id)
+);
+
+CREATE TABLE /*prefix*/plugins (
+   plugin_id BIGSERIAL NOT NULL,
+   basename  VARCHAR(100) NOT NULL,
+   enabled INT2 NOT NULL DEFAULT '0',
+   PRIMARY KEY (plugin_id)
+);
+
+CREATE TABLE /*prefix*/plugins_configuration (
+   plugin_config_id BIGSERIAL NOT NULL,
+   testproject_id BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/testprojects (id) ON DELETE CASCADE,
+   config_key VARCHAR(255) NOT NULL,
+   config_type INTEGER NOT NULL,
+   config_value varchar(255) NOT NULL,
+   author_id BIGINT NULL DEFAULT NULL REFERENCES  /*prefix*/users (id),
+   creation_ts TIMESTAMP NOT NULL DEFAULT now(),
+   PRIMARY KEY (plugin_config_id)
 );

--- a/install/sql/mssql/testlink_create_tables.sql
+++ b/install/sql/mssql/testlink_create_tables.sql
@@ -1013,3 +1013,29 @@ CREATE TABLE /*prefix*/req_monitor (
     req_id,user_id,testproject_id
   )  ON [PRIMARY]
 ) ON [PRIMARY];
+
+CREATE TABLE /*prefix*/plugins (
+  plugin_id int NOT NULL IDENTITY(1,1) CONSTRAINT /*prefix*/DF_plugins_plugin_id DEFAULT ((0)),
+  basename VARCHAR(100) NOT NULL,
+  enabled tinyint NOT NULL CONSTRAINT /*prefix*/DF_plugins_enabled DEFAULT ((0)),
+  author_id int NOT NULL,
+  creation_ts datetime NOT NULL CONSTRAINT /*prefix*/DF_plugins_creation_ts DEFAULT (getdate()),
+ CONSTRAINT /*prefix*/PK_plugins PRIMARY KEY CLUSTERED
+ (
+  plugin_id ASC
+ ) ON [PRIMARY]
+) ON [PRIMARY];
+
+CREATE TABLE /*prefix*/plugins_configuration (
+  plugin_config_id int IDENTITY(1,1) NOT NULL CONSTRAINT /*prefix*/DF_plugins_configuration_plugin_config_id DEFAULT ((0)),
+  testproject_id int NOT NULL CONSTRAINT /*prefix*/DF_plugins_configuration__testproject_id DEFAULT ((0)),
+  config_key VARCHAR(255) NOT NULL,
+  config_type int NOT NULL,
+  config_value VARCHAR(255) NOT NULL,
+  author_id int NOT NULL,
+  creation_ts datetime NOT NULL CONSTRAINT /*prefix*/DF_plugins_configuration__creation_ts DEFAULT (getdate()),
+ CONSTRAINT /*prefix*/PK_plugins_configuration PRIMARY KEY CLUSTERED
+ (
+  plugin_config_id ASC
+ ) ON [PRIMARY]
+) ON [PRIMARY];

--- a/install/sql/postgres/testlink_create_tables.sql
+++ b/install/sql/postgres/testlink_create_tables.sql
@@ -836,4 +836,22 @@ CREATE OR REPLACE VIEW /*prefix*/tcases_active AS
 	FROM /*prefix*/nodes_hierarchy nhtcv
 	JOIN /*prefix*/tcversions tcv ON tcv.id = nhtcv.id
 	WHERE tcv.active = 1
-);				
+);
+
+CREATE TABLE /*prefix*/plugins (
+   plugin_id BIGSERIAL NOT NULL,
+   basename  VARCHAR(100) NOT NULL,
+   enabled INT2 NOT NULL DEFAULT '0',
+   PRIMARY KEY (`plugin_id`)
+);
+
+CREATE TABLE /*prefix*/plugins_configuration (
+   plugin_config_id BIGSERIAL NOT NULL,
+   testproject_id BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/testprojects (id) ON DELETE CASCADE,
+   config_key VARCHAR(255) NOT NULL,
+   config_type INTEGER NOT NULL,
+   config_value varchar(255) NOT NULL,
+   author_id BIGINT NULL DEFAULT NULL REFERENCES  /*prefix*/users (id),
+   creation_ts TIMESTAMP NOT NULL DEFAULT now(),
+   PRIMARY KEY (`plugin_config_id`)
+);

--- a/lib/functions/roles.inc.php
+++ b/lib/functions/roles.inc.php
@@ -75,7 +75,7 @@ function init_global_rights_maps()
                    'desc_mgt_modify_users' => null,'desc_role_management' => null,
                    'desc_user_role_assignment' => null,
                    'desc_mgt_view_events' => null, 'desc_events_mgt' => null,
-                   'desc_mgt_unfreeze_req' => null,
+                   'desc_mgt_unfreeze_req' => null,'desc_mgt_plugins' => null,
                    'right_exec_edit_notes' => null, 'right_exec_delete' => null,
                    'right_testplan_unlink_executed_testcases' => null, 
                    'right_testproject_delete_executed_testcases' => null,
@@ -156,7 +156,8 @@ function init_global_rights_maps()
   $g_rights_users = $g_rights_users_global;
               
   $g_rights_system = array ("mgt_view_events" => $l18n['desc_mgt_view_events'],
-                            "events_mgt" => $l18n['desc_events_mgt']);
+                            "events_mgt" => $l18n['desc_events_mgt'],
+                            "mgt_plugins" => $l18n['desc_mgt_plugins']);
 
 
               

--- a/lib/functions/tlPlugin.class.php
+++ b/lib/functions/tlPlugin.class.php
@@ -62,6 +62,23 @@ abstract class TestlinkPlugin extends tlObjectWithDB
   }
 
   /**
+   * This function allows for the plugins to do any specific install activities.
+   * Return false if u want to stop installation
+   */
+  public function install()
+  {
+    return true;
+  }
+
+  /**
+   * This function allows for the plugins to do any specific uninstall activities that maybe required to cleanup
+   */
+  public function uninstall()
+  {
+    
+  }
+  
+  /**
    * return an array of default configuration name/value pairs
    */
   public function config()

--- a/lib/functions/tlsmarty.inc.php
+++ b/lib/functions/tlsmarty.inc.php
@@ -411,6 +411,7 @@ class TLSmarty extends Smarty
                    'on' => $imgLoc . 'lightbulb.png',
                    'off' => $imgLoc . 'lightbulb_off.png',
                    'order_alpha' => $imgLoc . 'style.png',
+                   'plugins' => $imgLoc . 'connect.png',
                    'public' => $imgLoc . 'door_open.png',
                    'private' => $imgLoc . 'door.png',
                    'remove' => $imgLoc . 'delete.png',

--- a/lib/plugins/pluginView.php
+++ b/lib/plugins/pluginView.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * TestLink Open Source Project - http://testlink.sourceforge.net/
+ * This script is distributed under the GNU General Public License 2 or later. 
+ *
+ * Enable/Disable/Show plugins
+ *
+ * @filesource  pluginView.php
+ * @package     TestLink
+ * @copyright   2015-2016, TestLink community
+ * @link        http://www.testlink.org/
+ *
+ */
+require_once('../../config.inc.php');
+require_once('common.php');
+require_once('users.inc.php');
+require_once('exttable.class.php');
+require_once("plugin_api.php");
+testlinkInitPage($db,false,false,"checkRights");
+
+$smarty = new TLSmarty();
+
+$templateCfg = templateConfiguration();
+
+
+list($args,$gui) = initEnv($db);
+
+switch($args->operation)
+{
+    case 'install':
+        if ($args->pluginName)
+        {
+            $p_plugin = plugin_register($args->pluginName, true);
+            plugin_init($args->pluginName);
+            plugin_install($p_plugin);
+            $feedback = sprintf(lang_get('plugin_installed'), $args->pluginName);
+        }
+        break;
+	case 'uninstall':
+	    if ($args->pluginId)
+        {
+            $t_basename = plugin_uninstall($args->pluginId);
+            $feedback = sprintf(lang_get('plugin_uninstalled'), $t_basename);
+        }  
+  	    break;
+		
+	default:
+	    break;
+} 
+
+$gui->main_title = lang_get('title_plugin_mgmt');
+$gui->installed_plugins = get_all_installed_plugins();
+$gui->available_plugins = get_all_available_plugins($gui->installed_plugins);
+
+$smarty = new TLSmarty();
+$smarty->assign('gui',$gui);
+if ($feedback) {
+  $smarty->assign('user_feedback', $feedback);
+}
+$smarty->display($templateCfg->template_dir . $templateCfg->default_template);
+
+
+function initEnv(&$dbHandler)
+{
+  $_REQUEST=strings_stripSlashes($_REQUEST);
+
+  $iParams = array("operation" => array(tlInputParameter::STRING_N,0,50),
+                   "pluginId" => array(tlInputParameter::INT_N),
+                   "pluginName" => array(tlInputParameter::STRING_N,0,50));
+
+  $args = new stdClass();
+  $pParams = R_PARAMS($iParams,$args);
+
+  $args->currentUser = $_SESSION['currentUser'];
+  $args->currentUserID = $_SESSION['currentUser']->dbID;
+  $args->basehref =  $_SESSION['basehref'];
+  
+  $gui = new stdClass();
+  $gui->grants = getGrantsForUserMgmt($dbHandler,$args->currentUser);
+  $gui->feedback = '';
+  $gui->basehref = $args->basehref;
+
+  return array($args,$gui);
+}
+
+function checkRights(&$db,&$user)
+{
+	return $user->hasRight($db,'mgt_plugins');
+}

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2612,6 +2612,7 @@ $TLS_desc_mgt_view_key = "Keyword view (read only access)";
 $TLS_desc_mgt_view_req = "Requirement view (read only access)";
 $TLS_desc_mgt_view_tc = "Test Case view (read only access)";
 $TLS_desc_mgt_view_events = "Event viewer (read only access)";
+$TLS_desc_mgt_plugins = "Plugins Management";
 
 $TLS_desc_platforms_view="Platform view (read only access)";
 $TLS_desc_platforms_management="Platform Management";
@@ -3711,6 +3712,21 @@ $TLS_empty_log_message = "<i>Log Message is empty</i>";
 $TLS_diff_method = "Select a comparison mode:";
 $TLS_use_html_comp = "HTML Compare";
 $TLS_use_html_code_comp = "HTML Code Compare";
+
+// ----- pluginView.php -----
+$TLS_title_plugins = "Plugins";
+$TLS_title_plugin_mgmt = "Manage Plugins";
+$TLS_th_plugin = "Plugin Name";
+$TLS_th_plugin_description = "Description";
+$TLS_th_plugin_version = "Version";
+$TLS_installed_plugins = "Installed Plugins";
+$TLS_available_plugins = "Available Plugins";
+$TLS_plugin_uninstalled = "%s Plugin uninstalled successfully";
+$TLS_plugin_installed = "%s Plugin installed successfully";
+$TLS_confirm_install_header = "Confirm Install";
+$TLS_confirm_install_text = "Are you sure you want to install";
+$TLS_confirm_uninstall_header = "Confirm Uninstall";
+$TLS_confirm_uninstall_text = "Are you sure you want to uninstall";
 
 $TLS_diff_subtitle_tc = "Differences between version %s (v%s) and version %s (v%s) of testcase %s";
 $TLS_diff_subtitle_req = "Differences between version %s (v%s) and version %s (v%s) of requirement %s";


### PR DESCRIPTION
The Plugin enable/disable UI has 2 tables. The top table shows the list of enabled plugins that
can be uninstalled and the bottom table contains the list of new plugins that are yet to be
installed. The details that are shown in the page are the Plugin Name, Description and the Version.

Major changes:
* Added new permission (mgt_plugins) that is only added to the "admin" role for now. This "rights"
  is required for a user to see the plugin management page. This will also appear in the "System
  rights" section of the Roles page.
* Migration scripts for the following:
  + Added the mgt_plugins right
  + Added the right to the "admin" role
  + Default tables required for plugins to work
  This is done for all supported DBs.
* Additional functions added in tlPlugin.class.php so actual plugins have the opportunity to
  add custom code when a plugin is activated ("install" function) or deactived("uninstall" function)
* Added Language bindings only for en_GB

You can view the Plugin UI page at https://cl.ly/2E0f232P1327 and the Role Page that contains the new permissions at https://cl.ly/1Q2p3A463d2Q

Note: I have not added the localization strings for other languages as Im not sure how to approach it. Should I add for all the languages and set them to the "english" value. Please advise.