### PR TITLE
BUG FIX for jirarestInterface.class.php

### DIFF
--- a/lib/issuetrackerintegration/jirarestInterface.class.php
+++ b/lib/issuetrackerintegration/jirarestInterface.class.php
@@ -758,7 +758,7 @@ class jirarestInterface extends issueTrackerInterface
     foreach ($cfSet as $cf)
     {
       $cf = (array)$cf;    
-      $cfJIRAID = $cf['customfield']; 
+      $cfJIRAID = $cf['customfieldId']; 
       $valueSet = (array)$cf['values'];        
       $loop2do = count($valueSet);
 


### PR DESCRIPTION
In function getCustomFieldsAttribute($name,$objCFSet)

Line   761:   $cfJIRAID = $cf['customfield']; 
It should be 'customfieldId', otherwise the customfields are not gonna work using the Cfgtemplate .
I was getting the error "addIssue:Failure:JIRA Message: _empty_ => Field '' cannot be set. It is not on the appropriate screen, or unknown." because of this not retrieving correctly the customfields.
This little change, resolved the bug.