### PR TITLE
Add SQL scripts for mgt_plugins right in new installs.

### DIFF
--- a/install/sql/mssql/testlink_create_default_data.sql
+++ b/install/sql/mssql/testlink_create_default_data.sql
@@ -91,6 +91,7 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (44,'testplan_update_linked
 INSERT INTO /*prefix*/rights (id,description) VALUES (45,'testplan_set_urgent_testcases');
 INSERT INTO /*prefix*/rights (id,description) VALUES (46,'testplan_show_testcases_newest_versions');
 INSERT INTO /*prefix*/rights (id,description) VALUES (47,'testcase_freeze');
+INSERT INTO /*prefix*/rights (id,description) VALUES (48,'mgt_plugins');
 
 
 
@@ -143,6 +144,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,44);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,45);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,46);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,47);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,48);
 
 
 

--- a/install/sql/mysql/testlink_create_default_data.sql
+++ b/install/sql/mysql/testlink_create_default_data.sql
@@ -87,6 +87,8 @@ INSERT INTO /*prefix*/rights  (id,description) VALUES (45,'testplan_set_urgent_t
 INSERT INTO /*prefix*/rights  (id,description) VALUES (46,'testplan_show_testcases_newest_versions');
 INSERT INTO /*prefix*/rights  (id,description) VALUES (47,'testcase_freeze');
 
+# since 1.9.15
+INSERT INTO /*prefix*/rights  (id,description) VALUES (48,'mgt_plugins');
 
 # Rights for Administrator role
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,1 );
@@ -134,6 +136,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,44);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,45);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,46);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,47);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,48);
 
 
 # Rights for guest role

--- a/install/sql/postgres/testlink_create_default_data.sql
+++ b/install/sql/postgres/testlink_create_default_data.sql
@@ -91,6 +91,8 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (45,'testplan_set_urgent_te
 INSERT INTO /*prefix*/rights (id,description) VALUES (46,'testplan_show_testcases_newest_versions');
 INSERT INTO /*prefix*/rights (id,description) VALUES (47,'testcase_freeze');
 
+# since 1.9.15
+INSERT INTO /*prefix*/rights (id,description) VALUES (48,'mgt_plugins');
 
 
 --  Rights for Administrator (admin role)
@@ -139,6 +141,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,44);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,45);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,46);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,47);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,48);
 
 
 --  Rights for guest role


### PR DESCRIPTION
When a new install happens, add the mgt_plugins right into the system as well
as assign it to the Admin role.

This was already added for migrations but not setup for new installs.