### PR TITLE
Bug in postgresql db files

### DIFF
--- a/install/sql/postgres/testlink_create_default_data.sql
+++ b/install/sql/postgres/testlink_create_default_data.sql
@@ -91,7 +91,7 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (45,'testplan_set_urgent_te
 INSERT INTO /*prefix*/rights (id,description) VALUES (46,'testplan_show_testcases_newest_versions');
 INSERT INTO /*prefix*/rights (id,description) VALUES (47,'testcase_freeze');
 
-# since 1.9.15
+-- since 1.9.15
 INSERT INTO /*prefix*/rights (id,description) VALUES (48,'mgt_plugins');
 
 

--- a/install/sql/postgres/testlink_create_tables.sql
+++ b/install/sql/postgres/testlink_create_tables.sql
@@ -839,10 +839,10 @@ CREATE OR REPLACE VIEW /*prefix*/tcases_active AS
 );
 
 CREATE TABLE /*prefix*/plugins (
-   plugin_id BIGSERIAL NOT NULL,
+   id BIGSERIAL NOT NULL,
    basename  VARCHAR(100) NOT NULL,
    enabled INT2 NOT NULL DEFAULT '0',
-   PRIMARY KEY (`plugin_id`)
+   PRIMARY KEY (plugin_id)
 );
 
 CREATE TABLE /*prefix*/plugins_configuration (
@@ -853,5 +853,5 @@ CREATE TABLE /*prefix*/plugins_configuration (
    config_value varchar(255) NOT NULL,
    author_id BIGINT NULL DEFAULT NULL REFERENCES  /*prefix*/users (id),
    creation_ts TIMESTAMP NOT NULL DEFAULT now(),
-   PRIMARY KEY (`plugin_config_id`)
+   PRIMARY KEY (plugin_config_id)
 );


### PR DESCRIPTION
Minor DB file bugs:

**testlink_create_default_data.sq**l: 
`# since 1.9.15` should be `-- since 1.9.15`

**testlink_create_tables.sql**: 
table plugins column name `'plugin_id'` should be `'id'`

**testlink_create_tables.sql**: 
table plugin `KEY (`plugin_id`)` should be `KEY (plugin_id)` 
table plugins_configuration `KEY (`plugin_config_id`)` should be `KEY (plugin_config_id)`

without this changes it fails to install
