### PR TITLE
Defines and Image Path

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -160,6 +160,12 @@ $tlCfg->force_https = false;
 $tlCfg->sessionInactivityTimeout = 9900;
 
 /**
+ * @var string Set the session path.
+ * Default webserver config is used
+ */
+//$tlCfg->session_path = "D:\\xampp\\htdocs\\testlink\\php_sessions";
+
+/**
  * Set the session timeout value (in minutes).
  * This will prevent sessions timing out after very short periods of time
  * Warning: your server could block this settings

--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -27,7 +27,7 @@
 /** 
  * IXR is the class used for the XML-RPC server 
  */
-define ("TL_APICALL",'XML-RPC');
+define ('TL_APICALL','XML-RPC');
 
 require_once("../../../../config.inc.php");
 require_once("common.php");

--- a/lib/functions/common.php
+++ b/lib/functions/common.php
@@ -271,6 +271,12 @@ function doSessionStart($setPaths=false)
   session_set_cookie_params(99999);
   if(!isset($_SESSION))
   {
+    if (config_get('session_path') !== NULL) {
+        if (!file_exists(config_get('session_path'))) {
+            mkdir(config_get('session_path'));
+        }
+        session_save_path(config_get('session_path'));
+    }
     session_start();
   }
   

--- a/lib/functions/common.php
+++ b/lib/functions/common.php
@@ -54,7 +54,7 @@ spl_autoload_register('tlAutoload');
 
 /** CSRF security functions. */
 /** TL_APICALL => TICKET 0007190 */
-if( !defined(TL_APICALL) )
+if( !defined('TL_APICALL') )
 {
   require_once("csrf.php");
 }  

--- a/lib/functions/common2.php
+++ b/lib/functions/common2.php
@@ -48,7 +48,7 @@ spl_autoload_register('tlAutoload');
 
 /** CSRF security functions. */
 /** TL_APICALL => TICKET 0007190 */
-if( !defined(TL_APICALL) )
+if( !defined('TL_APICALL') )
 {
   require_once("csrf.php");
 }  

--- a/lib/functions/testsuite.class.php
+++ b/lib/functions/testsuite.class.php
@@ -198,7 +198,7 @@ class testsuite extends tlObjectWithAttachments
       {
         $ret['id'] = $tsuite_id;
 
-        if (defined(TL_APICALL))
+        if (defined('TL_APICALL'))
         {
             $ctx = array('id' => $tsuite_id,'name' => $name,'details' => $details);     
             event_signal('EVENT_TEST_SUITE_CREATE', $ctx);
@@ -261,7 +261,7 @@ class testsuite extends tlObjectWithAttachments
       } 
       else
       {
-        if (defined(TL_APICALL))
+        if (defined('TL_APICALL'))
         {
           // @TODO this need some refactoring due to conditional update added on 20160806
           $ctx = array('id' => $id,'name' => $name,'details' => $details);

--- a/lib/functions/tlsmarty.inc.php
+++ b/lib/functions/tlsmarty.inc.php
@@ -333,8 +333,7 @@ class TLSmarty extends Smarty
    */
   static function getImageSet()
   {
-    $burl = isset($_SESSION['basehref']) ? $_SESSION['basehref'] : TL_BASE_HREF;
-    $imgLoc = $burl . TL_THEME_IMG_DIR;
+    $imgLoc = TL_THEME_IMG_DIR;
 
     $dummy = array('active' => $imgLoc . 'flag_green.png',
                    'activity' => $imgLoc . 'information.png',


### PR DESCRIPTION
- for define() and defined() you have to use single quotes
- Image path for Requirements based Report in Reports reverted