### PR TITLE
restapi should not use SESSION

### DIFF
--- a/lib/functions/tlIssueTracker.class.php
+++ b/lib/functions/tlIssueTracker.class.php
@@ -642,7 +642,7 @@ class tlIssueTracker extends tlObject
   {
     $issueT = $this->getLinkedTo($tprojectID);
     $name = $issueT['issuetracker_name'];
-    $goodForSession = ($issueT['api'] != 'db');
+    $goodForSession = ($issueT['api'] != 'db' && $issueT['api'] != 'rest');
 
     if($goodForSession && isset($_SESSION['its'][$name]))
     {


### PR DESCRIPTION
restapi should not use SESSION
Because it does not consider the session when using the curl

At redminerestInterface.class.php@addIssue
curl is not working properly, so null in addIssueFromXMLString
Because it is using the SESSION
Similar problems have occurred in other places

