### PR TITLE
Fix getReqSpec and adds two functions to the xmlrpc api

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -7744,6 +7744,78 @@ protected function createAttachmentTempFile()
 
   /**
    *
+   * get set of requirements
+   *
+   * @param args['recspecid'] 
+   *
+   * @return array of requirements related to this specification
+   *
+   */
+   public function getRequirements($args)
+   {
+        $msg_prefix="(" .__FUNCTION__ . ") - ";
+      $status_ok=true;
+      $this->_setArgs($args);
+
+        $checkFunctions = array('authenticate');
+        $status_ok=$this->_runChecks($checkFunctions,$msg_prefix);
+
+        if( $status_ok )
+        {
+            $result = $this->reqSpecMgr->get_requirements($this->args[self::$reqSpecIDParamName]);
+            if( is_null($result) )
+            {
+                $status_ok=false;
+                $trecspec_info = $this->reqSpecMgr->get_by_id($this->args[self::$reqSpecIDParamName]);
+                $msg=$msg_prefix . sprintf(REQSPEC_KO_STR,$trecspec_info['name']);
+                $this->errors[] = new IXR_ERROR(REQSPEC_KO,$msg); 
+            } 
+        }
+
+        return $status_ok ? $result : $this->errors;  
+   }
+   
+   
+   
+   
+    
+  /**
+   * get set of requirement specifications
+   *
+   * @param args['testprojectid']
+   * @param args['reqspecid']
+   *  
+   * @return array of requirement specifications related to this project
+   *
+   */
+   public function getRequirementSpecifications($args)
+   {
+        $msg_prefix="(" .__FUNCTION__ . ") - ";
+      $status_ok=true;
+      $this->_setArgs($args);
+
+        $checkFunctions = array('authenticate','checkTestProjectID');
+        $status_ok=$this->_runChecks($checkFunctions,$msg_prefix);
+
+        if( $status_ok )
+        {
+
+
+			if ($this->args[self::$reqSpecIDParamName] == 0)
+				$id = null;
+			else
+				$id = $this->args[self::$reqSpecIDParamName];
+        //  var_dump($this->tprojectMgr);
+            $result = $this->tprojectMgr->getReqSpec($this->args[self::$testProjectIDParamName], $id);  
+        }
+		
+        return $result;       
+   }
+ 
+  
+  
+  /**
+   *
    */
   function initMethodYellowPages()
   {
@@ -7802,6 +7874,8 @@ protected function createAttachmentTempFile()
                             'tl.getTestCaseAttachments' => 'this:getTestCaseAttachments',
                             'tl.getTestCase' => 'this:getTestCase',
                             'tl.getFullPath' => 'this:getFullPath',
+							'tl.getRequirementSpecifications' => 'this:getRequirementSpecifications',
+							'tl.getRequirements' => 'this:getRequirements',							
                             'tl.getTestSuiteByID' => 'this:getTestSuiteByID',
                             'tl.getUserByLogin' => 'this:getUserByLogin',
                             'tl.getUserByID' => 'this:getUserByID',

--- a/lib/functions/testproject.class.php
+++ b/lib/functions/testproject.class.php
@@ -1642,13 +1642,13 @@ function setPublicStatus($id,$status)
 
 
 
-  /**
+   /**
    * collect information about current list of Requirements Specification
    *
    * @param integer $testproject_id
    * @param string  $id optional id of the requirement specification
    *
-   * @return mixed 
+   * @return mixed
    *     null if no srs exits, or no srs exists for id
    *     array, where each element is a map with SRS data.
    *
@@ -1665,31 +1665,32 @@ function setPublicStatus($id,$status)
    *         modification_ts
    *
    * @author Martin Havlat
-   * @internal revisions 
-   *       
+   * @internal revisions
    **/
   public function getReqSpec($testproject_id, $id = null, $fields=null,$access_key=null)
   {
     $debugMsg = 'Class:' . __CLASS__ . ' - Method: ' . __FUNCTION__;
 
-    $fields2get="RSPEC.id,testproject_id,RSPEC.scope,RSPEC.total_req,RSPEC.type," .
-                "RSPEC.author_id,RSPEC.creation_ts,RSPEC.modifier_id," .
-                "RSPEC.modification_ts,NH.name AS title";
-    
+    $fields2get="RSPEC.id, RSPEC.testproject_id, RSPECREV.scope, RSPECREV.doc_id, RSPECREV.total_req, RSPECREV.type, RSPECREV.author_id, RSPECREV.creation_ts, RSPECREV.modifier_id, RSPECREV.modification_ts, RSPECREV.name AS title, NH.parent_id";
+
     $fields = is_null($fields) ? $fields2get : implode(',',$fields);
-    $sql = "  /* $debugMsg */ SELECT {$fields} FROM {$this->tables['req_specs']} RSPEC, " .
-           " {$this->tables['nodes_hierarchy']} NH , {$this->tables['requirements']} REQ " .
-           " WHERE testproject_id={$testproject_id} AND RSPEC.id=NH.id AND REQ.srs_id = RSPEC.id" ;
-           
+
+    $sql = "  /* $debugMsg */ SELECT {$fields} FROM {$this->tables['req_specs_revisions']} RSPECREV, " .
+        " {$this->tables['req_specs']} RSPEC, {$this->tables['nodes_hierarchy']} NH, {$this->tables['requirements']} REQ" .
+        " WHERE RSPECREV.parent_id=RSPEC.id AND RSPEC.testproject_id={$testproject_id} AND NH.id=RSPEC.id AND REQ.srs_id = RSPEC.id";
+
     if (!is_null($id))
-      {
-          $sql .= " AND RSPEC.id=" . $id;
-      }
-      $sql .= "  ORDER BY RSPEC.id,title";
-      $rs = is_null($access_key) ? $this->db->get_recordset($sql) : $this->db->fetchRowsIntoMap($sql,$access_key);
-        
+    {
+      $sql .= " AND RSPEC.id=" . $id;
+    }
+    $sql .= " GROUP BY RSPEC.id" ;
+    $sql .= " ORDER BY RSPEC.id,title";
+
+    $rs = is_null($access_key) ? $this->db->get_recordset($sql) : $this->db->fetchRowsIntoMap($sql,$access_key);
+
     return $rs;
   }
+
 
   /**
    * create a new System Requirements Specification


### PR DESCRIPTION
I made two function into the xmlrpc api to get the requirements for a project and get the requirement specifications.

In order to do that I wanted to use getReqSpec and I noticed that this function was totally outdated : the sql request was not up to date with the current database model at all. So I fixed it as well.