### PR TITLE
Fixed image location for Reports and Metrics

### DIFF
--- a/lib/functions/tlsmarty.inc.php
+++ b/lib/functions/tlsmarty.inc.php
@@ -333,8 +333,7 @@ class TLSmarty extends Smarty
    */
   static function getImageSet()
   {
-    $burl = isset($_SESSION['basehref']) ? $_SESSION['basehref'] : TL_BASE_HREF;
-    $imgLoc = $burl . TL_THEME_IMG_DIR;
+    $imgLoc = TL_THEME_IMG_DIR;
 
     $dummy = array('active' => $imgLoc . 'flag_green.png',
                    'activity' => $imgLoc . 'information.png',


### PR DESCRIPTION
The images i.e "Requirements based Report" are broken. The Path to the
PNG Files is build wrong here. TL_THEME_IMG_DIR  dont need basehref,
path gets dublicated.