### PR TITLE
Update execSetResults.php - put obsolete line "Kint::dump" in comment

### DIFF
--- a/lib/execute/execSetResults.php
+++ b/lib/execute/execSetResults.php
@@ -415,7 +415,7 @@ else
   $smarty->assign('cfg',$cfg);
   $smarty->assign('users',tlUser::getByIDs($db,$userSet,'id'));
 
-  Kint::dump($gui);
+  //Kint::dump($gui);
   $smarty->display($templateCfg->template_dir . $templateCfg->default_template);
 } 
 


### PR DESCRIPTION
Obsolete dump-line put in comments.
If line is active, then in test execution, displaying a testcase, shows unnecessary info:
"$gui stdClass(75)"
"→ Called from <ROOT>/testlink/lib/execute/execSetResults.php:418"
