### PR TITLE
Update lnl.php - added possibility of shareable link for "testreport_onbuild"

### DIFF
--- a/lnl.php
+++ b/lnl.php
@@ -62,6 +62,14 @@ switch($args->light)
                  "&requirement=y&keyword=y&notes=y&headerNumbering=y&format=" . FORMAT_HTML;
         $what2launch = "lib/results/printDocument.php?apikey=$args->apikey{$param}";         
       break;
+      
+      case 'testreport_onbuild':
+        $param = "&type={$args->type}&level=testproject" .
+                 "&tproject_id={$args->tproject_id}&tplan_id={$args->tplan_id}&build_id={$args->build_id}" .
+                 "&header=y&summary=y&toc=y&body=y&passfail=y&cfields=y&metrics=y&author=y" .
+                 "&requirement=y&keyword=y&notes=y&headerNumbering=y&format=" . FORMAT_HTML;
+        $what2launch = "lib/results/printDocument.php?apikey=$args->apikey{$param}";         
+      break;
 
       case 'test_plan':
         $param = "&type={$args->type}&level=testproject" .


### PR DESCRIPTION
Added possibility to have a shareable link to 'testreport_onbuild'. I needed this for a PoC at my current client and thought I'd share.
