### PR TITLE
Mantis 7746 - Send notification mails only to active global role users

### DIFF
--- a/lib/functions/tlRole.class.php
+++ b/lib/functions/tlRole.class.php
@@ -331,7 +331,7 @@ class tlRole extends tlDBObject
   protected function getUserIDsWithGlobalRole(&$db)
   {
     $sql = "SELECT id FROM {$this->tables['users']} " .
-           " WHERE role_id = {$this->dbID}";
+           " WHERE role_id = {$this->dbID} AND active = 1";
     $idSet = $db->fetchColumnsIntoArray($sql,"id");
     
     return $idSet; 


### PR DESCRIPTION
If the config(_custom).inc.php is configured with:
`$tlCfg->notifications->userSignUp->to->roles = array(TL_ROLES_ADMIN);`
Then all global admins will receive notifications when a user signs up.
However, it also sends mails to the e-mail addresses of accounts that are now put to inactive.

For this I have a patch in GitHub, in the file "tlRole.class.php".
In the function "protected function getUserIDsWithGlobalRole(&$db)" I extended the WHERE-clause in the SQL as such:
` " WHERE role_id = {$this->dbID} AND active = 1";`

I chose to do it in this location so that the fix works not only for TL_ROLES_ADMIN users, or only for new user signups, but that it works for any functionality and any global role.
