### PR TITLE
configCheck should verify the current DB version

### DIFF
--- a/lib/functions/configCheck.php
+++ b/lib/functions/configCheck.php
@@ -423,7 +423,7 @@ function checkForRepositoryDir($the_dir)
 function checkSchemaVersion(&$db)
 {
   $result = array('status' => tl::ERROR, 'msg' => null, 'kill_session' => true);
-  $latest_version = TL_LATEST_DB_VERSION; 
+  $latest_version = "DB ". TL_VERSION_NUMBER; 
   $db_version_table = DB_TABLE_PREFIX . 'db_version';
   
   $sql = "SELECT * FROM {$db_version_table} ORDER BY upgrade_ts DESC";
@@ -465,6 +465,7 @@ function checkSchemaVersion(&$db)
     case 'DB 1.9.12':
     case 'DB 1.9.13':
     case 'DB 1.9.14':
+    case 'DB 1.9.15':
       $result['msg'] = $manualop_msg;
     break;
 


### PR DESCRIPTION
After latest changes in const.inc.php (https://github.com/TestLinkOpenSourceTRMS/testlink-code/commit/3f7b8eccb224e8cdd10376fcb1e33535a6c4abc0) the configCheck.php should also verify the current version. If not you cant login anymore cause of "Unknown Schema version DB 1.9.16, please upgrade your Testlink Database to DB 1.9.15"