### PR TITLE
Echo attachment content sometimes dont work

### DIFF
--- a/lib/attachments/attachmentdownload.php
+++ b/lib/attachments/attachmentdownload.php
@@ -11,7 +11,7 @@
  * @since 1.9.14
  *
  */
-@ob_end_clean();
+@ob_start();
 require_once('../../config.inc.php');
 require_once('../functions/common.php');
 require_once('../functions/attachments.inc.php');


### PR DESCRIPTION
In a Windows based Webenvironment the attachment of a PNG file is displayed wrong. We have to use ob_start here.