### PR TITLE
Issue 0007910 : Added missing navbar height to ltx.php 

### DIFF
--- a/ltx.php
+++ b/ltx.php
@@ -432,6 +432,8 @@ function launch_outer_exec(&$tplMgr,$argsObj)
 {
   $gui = new stdClass();
   $gui->titleframe = 'lib/general/navBar.php?caller=linkto';
+  $gui->navbar_height = config_get('navbar_height');
+  
   if( $argsObj->tproject_id > 0)
   {
     $gui->titleframe .= '&testproject=' . $argsObj->tproject_id;
@@ -450,7 +452,8 @@ function launch_outer_xta2m(&$tplMgr,$argsObj)
 {
   $gui = new stdClass();
   $gui->titleframe = 'lib/general/navBar.php?caller=linkto';
-
+  $gui->navbar_height = config_get('navbar_height');
+  
   if( $argsObj->tproject_id > 0)
   {
     $gui->titleframe .= '&testproject=' . $argsObj->tproject_id;


### PR DESCRIPTION
The `navbar_height` was not set while using direct links to the test execution from the BTS. 

In the logfiles I found this warning:

```
[>>][58ef6dd8990e0838291606][DEFAULT][/ltx.php][17/Apr/13 12:23:52]
        [17/Apr/13 12:23:52][WARNING][0buin7lnktbf1gcn5v79kbav21][GUI]
                E_NOTICE
Undefined property: stdClass::$navbar_height - in /var/www/html/gui/templates_c/f9f12cd08e1a9a251ed796764f358c118fbb8cea.file.main.tpl.php - Line 51
```

![testlink_ltx_analyze_01](https://cloud.githubusercontent.com/assets/5457328/25004275/d4e215d6-2053-11e7-8597-3320f7606480.png)

The picture above shows the direct link to a test execution opened from a BTS. The page seems empty in Firefox. The proposed patch adds the `navbar_height` to the `$gui`. After applying the patch the page is rendered as:

![testlink_ltx_analyze_02](https://cloud.githubusercontent.com/assets/5457328/25004320/21ed974c-2054-11e7-9e02-1fd136bd6bb1.png)

The direct links to the test execution are also not rendered correctly within Chromium:

Before patching `ltx.php`:

![testlink_1_9_17_chromium_01](https://cloud.githubusercontent.com/assets/5457328/25004559/4003433e-2055-11e7-91e8-eb77ffecf8d3.png)

After applying the patch:

![testlink_1_9_17_chromium_02](https://cloud.githubusercontent.com/assets/5457328/25004566/4a3f5e78-2055-11e7-80d8-0178b8333c31.png)
