### PR TITLE
Show only results from active Builds in Test Reports

### DIFF
--- a/lib/functions/print.inc.php
+++ b/lib/functions/print.inc.php
@@ -1057,7 +1057,10 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
            " FROM {$tables['executions']} E " .
            " JOIN {$tables['builds']} B ON B.id = E.build_id " .
            " WHERE 1 = 1 ";
-
+	
+	//Bugfix to show only active builds in Test Report view
+	$sql .= "AND B.active = 1";
+	
     if(isset($context['exec_id']))
     {
       $sql .= " AND E.id=" . intval($context['exec_id']);

--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -6893,8 +6893,8 @@ class testplan extends tlObjectWithAttachments
                                     'addPriority' => false,'addImportance' => false,
                                     'ignorePlatformAndBuild' => false,
                                     'ignoreBuild' => false, 'ignorePlatform' => false,
-                                    'ua_user_alias' => '', 
-                                    'ua_force_join' => false));
+                                    'ua_user_alias' => '', 'ua_force_join' => false,
+                                    'build_is_active' => false));
 
     $my['options'] = array_merge($mop['options'],$my['options']);
       
@@ -6933,6 +6933,20 @@ class testplan extends tlObjectWithAttachments
       $platformEXEC = " ";
 
     }  
+    else if ($my['options']['ignoreBuild'] && $my['options']['build_is_active']) 
+    {
+      $sqlLEX = " SELECT EE.tcversion_id,EE.testplan_id,EE.platform_id," .
+                " MAX(EE.id) AS id " .
+                " FROM {$this->tables['executions']} EE " . 
+                " JOIN {$this->tables['builds']} B " . 
+                " ON B.id = EE.build_id " .
+                " WHERE EE.testplan_id = " . $safe['tplan_id'] . " AND B.active = 1" .
+                " GROUP BY EE.tcversion_id,EE.testplan_id,EE.platform_id, B.id";
+         
+      $platformLEX = " AND LEX.platform_id = TPTCV.platform_id "; 
+      $platformEXEC = " AND E.platform_id = TPTCV.platform_id ";
+
+    }
     else if ($my['options']['ignoreBuild']) 
     {
       $sqlLEX = " SELECT EE.tcversion_id,EE.testplan_id,EE.platform_id," .

--- a/lib/results/resultsReqs.php
+++ b/lib/results/resultsReqs.php
@@ -584,7 +584,7 @@ function init_args(&$tproject_mgr, &$tplan_mgr, &$req_cfg)
 
 
   // $dummy = $tplan_mgr->get_builds_for_html_options($id,$active=null,$open=null,$opt=null)
-  $dummy = $tplan_mgr->get_builds_for_html_options($args->tplan_id);
+  $dummy = $tplan_mgr->get_builds_for_html_options($args->tplan_id, 1); //Only active builds should be available to choose
   $args->buildSet = $dummy ? array(0 => $gui_open . lang_get('any') . $gui_close) + $dummy : null;
   $args->build = 0;
   if (isset($_REQUEST['build'])) 
@@ -811,7 +811,7 @@ function buildReqSpecMap($reqSet,&$reqMgr,&$reqSpecMgr,&$tplanMgr,$reqStatusFilt
     $allFilters = isset($filters['platform_id']) && isset($filters['build_id']);
 
     // $options = array('addExecInfo' => true,'accessKeyType' => 'tcase');
-    $options = array('addExecInfo' => true,'accessKeyType' => 'tcase+platform');
+    $options = array('addExecInfo' => true,'accessKeyType' => 'tcase+platform', 'build_is_active' => true);
 
     if($noFilter || $filterOnly['platform_id'])  
     {


### PR DESCRIPTION
Like described in user manual, only active builds should be shown in
reports. This commit was made for Test Report and Requirement based
Report view