### PR TITLE
A missing INTO in a DB query was causing issues with the plugin

### DIFF
--- a/lib/functions/plugin_api.php
+++ b/lib/functions/plugin_api.php
@@ -187,7 +187,7 @@ function plugin_config_set($option, $value, $project = TL_ANY_PROJECT)
   else 
   {
     // Insert new config value
-    $sql = " INSERT $plugin_config_table " .
+    $sql = " INSERT INTO $plugin_config_table " .
            " (config_key, config_type, config_value, testproject_id, author_id) " .
            " VALUES (" .
            "'" . $dbHandler->prepare_string($full_option) . "', " . 


### PR DESCRIPTION
The lib/functions/plugin_api.php had a DB query formation without the INTO statement in an INSERT query.  This was causing the plugins to fail whenever the DB in use was not MySQL.  MySQL seemed to work even with the missing INTO.  I've fixed it now.  This fix need to go into 1.9.15 too.