### PR TITLE
Fix for admin having no (execute) rights on private projects/tplans

### DIFF
--- a/lib/functions/tlUser.class.php
+++ b/lib/functions/tlUser.class.php
@@ -794,6 +794,11 @@ class tlUser extends tlDBObject
     global $g_propRights_global;
     global $g_propRights_product;
 
+    if ( ($this->globalRoleID == TL_ROLES_ADMIN) && ($roleQuestion != 'exec_ro_access') )
+    {
+      return true;
+    }
+
     if (!is_null($tplanID))
     {
       $testPlanID = $tplanID;
@@ -838,6 +843,7 @@ class tlUser extends tlDBObject
       $globalRights[] = $right->name;
     }
     $allRights = $globalRights;
+    
     $userTestProjectRoles = $this->tprojectRoles;
     $userTestPlanRoles = $this->tplanRoles;
     


### PR DESCRIPTION
We've experienced issue with global admins having no testplan execution right on some private projects / testplans (he could go to execution, but at the bottom of the Testcase description there was no area with execution notes and with buttons for marking test as blocked/successfull/failed).

For some reason the global admins are not always assigned an admin role on all of the projects/testplans. For the public projects and public testplans it is not an issue. But if project of testplan is private, than the $user->hasRight() returns false (I'm not sure about it => has debugged with vim and by trial and error, but that was my conclusion).
In the execSetResults controller it lead to an effect, that the user was identified as having no execution right.

It would be possibly better to ignore public-Attributes for global admins, but I've taken the simpler way (I'm not an php-Developer, so I've searched for the simplest way).

I had to add exception for exec_ro_access, because otherwise the wrong description (wrong menu item) was shown on the home for admins - "Show the exections RO" or something like this - instead of "Execute tests" (I've used the german language and haven't noticed the text exactly).