### PR TITLE
Use existant right 'req_tcase_link_management'

### DIFF
--- a/gui/templates/mainPageLeft.tpl
+++ b/gui/templates/mainPageLeft.tpl
@@ -44,7 +44,7 @@
 {/if}
 
 {if $gui->testprojectID && $gui->opt_requirements == TRUE && 
-    ($gui->grants.reqs_view == "yes" || $gui->grants.reqs_edit == "yes" || $gui->grants.monitor_req == "yes")}
+    ($gui->grants.reqs_view == "yes" || $gui->grants.reqs_edit == "yes" || $gui->grants.monitor_req == "yes" || $gui->grants.req_tcase_link_management == "yes")}
     {$display_left_block_3=true}
 {/if}
 
@@ -116,18 +116,18 @@
   {$reqOverView="lib/requirements/reqOverview.php"}
   {$reqMonOverView="lib/requirements/reqMonitorOverview.php?tproject_id="}
   <div class="list-group" style="{$divStyle}">
-        {if $gui->grants.reqs_view == "yes"}
+       {if $gui->grants.reqs_view == "yes" || $gui->grants.reqs_edit == "yes" }
           <a href="{$gui->launcher}?feature=reqSpecMgmt" class="list-group-item" style="{$aStyle}">{$labels.href_req_spec}</a>
           <a href="{$reqOverView}" class="list-group-item" style="{$aStyle}">{$labels.href_req_overview}</a>
+          <a href="{$gui->launcher}?feature=printReqSpec" class="list-group-item" style="{$aStyle}">{$labels.href_print_req}</a>
           <a href="{$gui->launcher}?feature=searchReq" class="list-group-item" style="{$aStyle}">{$labels.href_search_req}</a>
           <a href="{$gui->launcher}?feature=searchReqSpec" class="list-group-item" style="{$aStyle}">{$labels.href_search_req_spec}</a>
        {/if}
+       {if $gui->grants.req_tcase_link_management == "yes"}
+          <a href="lib/general/frmWorkArea.php?feature=assignReqs" class="list-group-item" style="{$aStyle}">{$labels.href_req_assign}</a>
+       {/if}
        {if $gui->grants.monitor_req == "yes"}
-        <a href="{$reqMonOverView}{$gui->testprojectID}" class="list-group-item" style="{$aStyle}">{$labels.href_req_monitor_overview}</a>
-      {/if}
-      {if $gui->grants.reqs_edit == "yes"}
-        <a href="lib/general/frmWorkArea.php?feature=assignReqs" class="list-group-item" style="{$aStyle}">{$labels.href_req_assign}</a>
-        <a href="{$gui->launcher}?feature=printReqSpec" class="list-group-item" style="{$aStyle}">{$labels.href_print_req}</a>
+          <a href="{$reqMonOverView}{$gui->testprojectID}" class="list-group-item" style="{$aStyle}">{$labels.href_req_monitor_overview}</a>
       {/if}
   </div>
 {/if}

--- a/gui/templates/requirements/reqViewVersionsViewer.tpl
+++ b/gui/templates/requirements/reqViewVersionsViewer.tpl
@@ -190,9 +190,11 @@ viewer for requirement
 
       {section name=row loop=$args_req_coverage}
         <span>
+		{if $args_grants->req_tcase_link_management == "yes"}
         <input type="image"  class="clickable" src="{$tlImages.disconnect_small}" 
                title="{$labels.removeLinkToTestCase}" onClick="tcaseIdentity.value={$args_req_coverage[row].id}">
-        &nbsp;&nbsp;       
+        &nbsp;&nbsp; 
+		{/if}
         <img class="clickable" src="{$tlImages.history_small}"
              onclick="javascript:openExecHistoryWindow({$args_req_coverage[row].id});"
              title="{$labels.execution_history}" />
@@ -204,7 +206,7 @@ viewer for requirement
       {/section}
       </form>
     {/if}
-    {if is_null($args_frozen_version) || !$args_frozen_version}
+    {if (is_null($args_frozen_version) || !$args_frozen_version ) && $args_grants->req_tcase_link_management == "yes"}
     <form style="display: inline;" id="reqAddTestCase_{$req_version_id}" name="reqAddTestCase_{$req_version_id}" 
           action="{$basehref}lib/requirements/reqEdit.php" method="post">
       <input type="hidden" id="atRID" name="requirement_id" value="{$args_req.id}" />

--- a/gui/templates/testcases/tcEdit_New_viewer.tpl
+++ b/gui/templates/testcases/tcEdit_New_viewer.tpl
@@ -85,7 +85,7 @@ Purpose: smarty template - create new testcase
   {include file="opt_transfer.inc.tpl" option_transfer=$gui->opt_cfg}
   </div>
   
-  {if $gui->opt_requirements==TRUE && $gui->grants->requirement_mgmt=='yes' && isset($gui->tc.testcase_id)}
+  {if $gui->opt_requirements==TRUE && $gui->grants->req_tcase_link_management=='yes' && isset($gui->tc.testcase_id)}
     <br />
     <div>
     <a href="javascript:openReqWindow({$gui->tc.testcase_id})">{$labels.assign_requirements}</a>    

--- a/gui/templates/testcases/tcView_viewer.tpl
+++ b/gui/templates/testcases/tcView_viewer.tpl
@@ -383,13 +383,13 @@ function launchInsertStep(step_id)
    {include file="testcases/keywords.inc.tpl" args_edit_enabled=$edit_enabled} 
   </div>
   
-  {if $gui->requirementsEnabled == TRUE && ($gui->view_req_rights == "yes" || $gui->requirement_mgmt) }
+  {if $gui->requirementsEnabled == TRUE && ($gui->view_req_rights == "yes" || $gui->req_tcase_link_management) }
   <div {$addInfoDivStyle}>
     <table cellpadding="0" cellspacing="0" style="font-size:100%;">
              <tr>
                <td colspan="{$tableColspan}" style="vertical-align:text-top;"><span><a title="{$tcView_viewer_labels.requirement_spec}" href="{$hrefReqSpecMgmt}"
                target="mainframe" class="bold">{$tcView_viewer_labels.Requirements}</a>
-              {if $gui->requirement_mgmt}
+              {if $gui->req_tcase_link_management}
                 <img class="clickable" src="{$tlImages.item_link}"
                      onclick="javascript:openReqWindow({$args_testcase.testcase_id},'a');"
                      title="{$tcView_viewer_labels.link_unlink_requirements}" />

--- a/install/sql/alter_tables/1.9.17/mssql/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/mssql/DB.1.9.17/step1/db_schema_update.sql
@@ -49,6 +49,7 @@ GROUP BY RSR.parent_id,RS.testproject_id;
 
 -- since 1.9.17
 INSERT INTO /*prefix*/rights (id,description) VALUES (49,'exec_ro_access');
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 
 ALTER TABLE /*prefix*/users ADD COLUMN creation_ts timestamp NOT NULL DEFAULT now();

--- a/install/sql/alter_tables/1.9.17/mysql/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/mysql/DB.1.9.17/step1/db_schema_update.sql
@@ -29,6 +29,7 @@ GROUP BY RSR.parent_id,RS.testproject_id;
 -- since 1.9.17
 INSERT INTO /*prefix*/rights (id,description) VALUES (49,'exec_ro_access');
 INSERT INTO /*prefix*/rights (id,description) VALUES (50,'monitor_requirement');
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 
 ALTER TABLE /*prefix*/users ADD COLUMN creation_ts timestamp NOT NULL DEFAULT now();

--- a/install/sql/alter_tables/1.9.17/postgres/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/postgres/DB.1.9.17/step1/db_schema_update.sql
@@ -32,6 +32,7 @@ GROUP BY RSR.parent_id,RS.testproject_id;
 
 -- since 1.9.17
 INSERT INTO /*prefix*/rights (id,description) VALUES (49,'exec_ro_access');
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 
 ALTER TABLE /*prefix*/users ADD COLUMN creation_ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/install/sql/mssql/testlink_create_default_data.sql
+++ b/install/sql/mssql/testlink_create_default_data.sql
@@ -128,6 +128,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,24);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,31);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,32);
@@ -164,6 +165,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,8);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,9);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,10);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,11);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,50);
 
 --  Rights for tester role
@@ -183,6 +185,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,9);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,11);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,50);
 
 --  Rights for leader role
@@ -203,6 +206,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,24);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,50);
 
 --  admin account 

--- a/install/sql/mysql/testlink_create_default_data.sql
+++ b/install/sql/mysql/testlink_create_default_data.sql
@@ -122,6 +122,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,24);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,31);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,32);
@@ -157,6 +158,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,8 );
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,9 );
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,10);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,11);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,50);
 
 # Rights for tester role
@@ -176,6 +178,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,9 );
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,11);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,50);
 
 # Rights for leader role
@@ -196,6 +199,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,24);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,47);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,50);
 

--- a/install/sql/postgres/testlink_create_default_data.sql
+++ b/install/sql/postgres/testlink_create_default_data.sql
@@ -162,6 +162,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,8 );
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,9 );
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,10);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,11);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,50);
 
 --  Rights for tester role
@@ -181,6 +182,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,9 );
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,11);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,50);
 
 --  Rights for leader role
@@ -201,6 +203,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,24);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,27);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,50);
 
 

--- a/lib/functions/roles.inc.php
+++ b/lib/functions/roles.inc.php
@@ -122,7 +122,8 @@ function init_global_rights_maps()
   $g_rights_req = array("mgt_view_req" => $l18n['desc_mgt_view_req'],
                         "monitor_requirement" => $l18n['desc_monitor_requirement'],
                         "mgt_modify_req" => $l18n['desc_mgt_modify_req'],
-                        "mgt_unfreeze_req" => $l18n['desc_mgt_unfreeze_req']);
+                        "mgt_unfreeze_req" => $l18n['desc_mgt_unfreeze_req'],
+                        "req_tcase_link_management" => $l18n['desc_req_tcase_link_management']);
   
   $g_rights_product = array("mgt_modify_product" => $l18n['desc_mgt_modify_product'],
                             "project_inventory_management" => $l18n['desc_project_inventory_management'],

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -6631,6 +6631,7 @@ class testcase extends tlObjectWithAttachments
     $goo->tcase_cfg->can_edit_executed = $grantsObj->testproject_edit_executed_testcases == 'yes' ? 1 : 0;
     $goo->tcase_cfg->can_delete_executed = $grantsObj->testproject_delete_executed_testcases == 'yes' ? 1 : 0;
     $goo->view_req_rights = property_exists($grantsObj, 'mgt_view_req') ? $grantsObj->mgt_view_req : 0;
+	$goo->req_tcase_link_management = property_exists($grantsObj, 'req_tcase_link_management') ? $grantsObj->req_tcase_link_management : 0;
 
     $goo->parentTestSuiteName = '';
     $goo->tprojectName = '';

--- a/lib/general/mainPage.php
+++ b/lib/general/mainPage.php
@@ -210,6 +210,7 @@ function getGrants($dbHandler,$user,$forceToNo=false)
   $right2check = array('project_edit' => 'mgt_modify_product',
                        'reqs_view' => "mgt_view_req", 
                        'monitor_req' => "monitor_requirement", 
+                       'req_tcase_link_management' => "req_tcase_link_management",
                        'reqs_edit' => "mgt_modify_req",
                        'keywords_view' => "mgt_view_key",
                        'keywords_edit' => "mgt_modify_key",

--- a/lib/requirements/reqTcAssign.php
+++ b/lib/requirements/reqTcAssign.php
@@ -86,7 +86,6 @@ switch($args->edit)
 
 $smarty = new TLSmarty();
 $smarty->assign('gui', $gui);
-$smarty->assign('modify_req_rights', has_rights($db,"mgt_modify_req")); 
 $smarty->display($templateCfg->template_dir . $templateCfg->default_template);
 
 
@@ -379,5 +378,5 @@ function getTargetTestCases(&$dbHandler,&$argsObj)
 
 function checkRights(&$db,&$user)
 {
-  return ($user->hasRight($db,'mgt_view_req') && $user->hasRight($db,'mgt_modify_req'));
+  return ($user->hasRight($db,'req_tcase_link_management'));
 }

--- a/lib/requirements/reqView.php
+++ b/lib/requirements/reqView.php
@@ -108,6 +108,7 @@ function initialize_gui(&$dbHandler,$argsObj,&$tproject_mgr)
   $gui->grants = new stdClass();
   $gui->grants->req_mgmt = $argsObj->user->hasRight($dbHandler,"mgt_modify_req",$target_id);
   $gui->grants->monitor_req = $argsObj->user->hasRight($dbHandler,"monitor_requirement",$target_id);
+  $gui->grants->req_tcase_link_management = $argsObj->user->hasRight($dbHandler,"req_tcase_link_management",$target_id);
   $gui->grants->unfreeze_req = $argsObj->user->hasRight($dbHandler,"mgt_unfreeze_req",$target_id);
   
   $gui->tcasePrefix = $tproject_mgr->getTestCasePrefix($argsObj->tproject_id);

--- a/lib/testcases/archiveData.php
+++ b/lib/testcases/archiveData.php
@@ -200,7 +200,7 @@ function initializeEnv($dbHandler)
   $gui = new stdClass();
 
   $grant2check = array('mgt_modify_tc','mgt_view_req','testplan_planning','mgt_modify_product',
-                       'mgt_modify_req','testcase_freeze', 
+                       'mgt_modify_req','testcase_freeze', 'req_tcase_link_management',
                        'testproject_edit_executed_testcases','testproject_delete_executed_testcases');
   $grants = new stdClass();
   foreach($grant2check as $right)

--- a/lib/testcases/tcImport.php
+++ b/lib/testcases/tcImport.php
@@ -227,9 +227,12 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
     $userObj->readFromDB($db,tlUser::TLOBJ_O_SEARCH_BY_ID);
     $userRights['can_edit_executed'] = 
       $userObj->hasRight($db,'testproject_edit_executed_testcases',$tproject_id);
-
+	$userRights['can_link_to_req'] = 
+	  $userObj->hasRight($db,'req_tcase_link_management',$tproject_id);
+	
     $k2l = array('already_exists_updated','original_name','testcase_name_too_long','already_exists_not_updated',
-                 'start_warning','end_warning','testlink_warning','hit_with_same_external_ID');
+                 'start_warning','end_warning','testlink_warning','hit_with_same_external_ID',
+				 'req_assignment_skipped_during_import');
     foreach($k2l as $k)
     {
       $messages[$k] = lang_get($k);
@@ -507,9 +510,15 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
     {
       if( $tprojectHas['reqSpec'] )
       {
-        $msg = processRequirements($db,$req_mgr,$name,$ret['id'],$tc['requirements'],
+		if(!$userRights['can_link_to_req']){
+			$msg[]=array($name,$messages['req_assignment_skipped_during_import']);
+		}
+		else{
+			// appel
+			$msg = processRequirements($db,$req_mgr,$name,$ret['id'],$tc['requirements'],
                                    $reqSpecSet,$feedbackMsg,$userID);
-        if( !is_null($msg) )
+		}
+		if( !is_null($msg) )
         {
           $resultMap = array_merge($resultMap,$msg);
         }

--- a/lib/testcases/testcaseCommands.class.php
+++ b/lib/testcases/testcaseCommands.class.php
@@ -32,7 +32,7 @@ class testcaseCommands
     $this->execution_types = $this->tcaseMgr->get_execution_types();
     $this->grants = new stdClass();
 
-    $g2c = array('mgt_modify_tc','mgt_view_req','testplan_planning',
+    $g2c = array('mgt_modify_tc','mgt_view_req','testplan_planning','req_tcase_link_management',
                  'testproject_delete_executed_testcases','testproject_edit_executed_testcases');
     foreach($g2c as $grant)
     {

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2716,6 +2716,7 @@ $TLS_bulk_req_assign_msg = 'This operation will assign selected requirements to 
 
 $TLS_bulk_req_assign_no_test_cases = 'Operation can not be done because there are no test cases inside selected test suite';
 
+$TLS_bulk_assigment_done = '%s assignments has been done';
 $TLS_req_title_bulk_assign = 'Requirements Bulk Assignment';
 $TLS_req_title_available = 'Available Requirements';
 $TLS_no_req_spec_available = "No Requirements Specification available for this Test Project";

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2909,6 +2909,7 @@ $TLS_same_name = 'has same name';
 $TLS_duplicate_criteria = "Consider Test Case as duplicate if";
 $TLS_hit_with_same_external_ID = "Can not be imported - You are hitting an existent Test Case with SAME EXTERNAL ID:";
 $TLS_attachment_skipped_during_import = "Attachment \"%s\" has been ignored because it is already linked to the test element";
+$TLS_req_assignment_skipped_during_import = "Link to requirements has been ignored because the current user is not allowed to assign requirements to testcases";
 
 // ----- lib/testcases/tcexport.php -----
 $TLS_no_testcases_to_export = "There are no Test Cases to export";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2910,6 +2910,7 @@ $TLS_same_name = "présente le même nom";
 $TLS_duplicate_criteria = "Considérer la fiche de test comme connue si elle";
 $TLS_hit_with_same_external_ID = "Ne peut pas être importée - Une fiche de test utilise déjà l'ID EXTERNE :";
 $TLS_attachment_skipped_during_import = "La pièce jointe \"%s\" a été ignorée car elle est déjà liée à l'élément de test.";
+$TLS_req_assignment_skipped_during_import = "Les liens vers les exigences ont été ignorées car l'utilisateur n'a pas les droits pour lier les exigences aux fiches de test";
 
 // ----- lib/testcases/tcexport.php -----
 $TLS_no_testcases_to_export = "Aucune fiche de test pour l’export";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2717,6 +2717,7 @@ $TLS_bulk_req_assign_msg = "L’opération lie les exigences sélectionnées à 
 
 $TLS_bulk_req_assign_no_test_cases = "L’opération ne peut être effectuée car il n’y a aucune fiches de test dans le dossier de test";
 
+$TLS_bulk_assigment_done = '%s liens entre exigences et fiches de test ont été ajoutés';
 $TLS_req_title_bulk_assign = "Lier en masse les exigences";
 $TLS_req_title_available = "Exigences disponibles";
 $TLS_no_req_spec_available = "Aucun dossier d’exigences disponible pour le projet";


### PR DESCRIPTION
Fixes Mantis Issue 8164

The right that is used to :
- Access Req Assignment from desktop
- Add/Remove TestCases link when viewing a requirement
- Add/Remove Requirement link when viewing/editing testcase(s)