### PR TITLE
Use existant right 'mgt_unfreeze_req'

### DIFF
--- a/gui/javascript/checkboxes.js
+++ b/gui/javascript/checkboxes.js
@@ -251,6 +251,7 @@ function cs_all_checkbox_in_div(div_id, cb_id_prefix,memory_id)
 		var elemType = inputs[idx].type;		
 		
 		if(inputs[idx].type == "checkbox" && 
+		   inputs[idx].disabled == false && 
 		  (inputs[idx].id.indexOf(cb_id_prefix)==0) )
 		{
       inputs[idx].checked = (memory.value == "1") ? false : true;

--- a/gui/templates/requirements/reqTcAssign.tpl
+++ b/gui/templates/requirements/reqTcAssign.tpl
@@ -111,8 +111,9 @@ function refreshAndClose(tcase_id,callback)
     	</tr>
     	{section name=row loop=$gui->arrAssignedReq}
     	<tr>
-    		<td><input type="checkbox" id="assigned_req{$gui->arrAssignedReq[row].id}" value="{$gui->arrAssignedReq[row].id}"
-    		                           name="req_id[{$gui->arrAssignedReq[row].id}]" /></td>
+    		<td><input type="checkbox"  {if $gui->arrAssignedReq[row].is_open == 0} disabled="disabled" {/if}
+						id="assigned_req{$gui->arrAssignedReq[row].id}" value="{$gui->arrAssignedReq[row].id}"
+    		            name="req_id[{$gui->arrAssignedReq[row].id}]" /></td>
     		<td><span class="bold">{$gui->arrAssignedReq[row].req_doc_id|escape}</span></td>
     		<td><span class="bold"><a href="lib/requirements/reqView.php?requirement_id={$gui->arrAssignedReq[row].id}">
     			{$gui->arrAssignedReq[row].title|escape}</a></span></td>
@@ -164,7 +165,7 @@ function refreshAndClose(tcase_id,callback)
       	</tr>
       	{section name=row2 loop=$gui->arrUnassignedReq}
       	<tr>
-      		<td><input type="checkbox"
+      		<td><input type="checkbox" {if $gui->arrUnassignedReq[row2].is_open == 0} disabled="disabled" {/if}
       		           id="free_req{$gui->arrUnassignedReq[row2].id}" value="{$gui->arrUnassignedReq[row2].id}"
       		           name="req_id[{$gui->arrUnassignedReq[row2].id}]" /></td>
 

--- a/gui/templates/requirements/reqViewVersions.tpl
+++ b/gui/templates/requirements/reqViewVersions.tpl
@@ -26,7 +26,7 @@ Purpose: view requirement with version management
              relation_destination_doc_id, in, btn_add, img_title_delete_relation, current_req,
              no_records_found,other_versions,version,title_test_case,match_count,warning,
              revision_log_title,please_add_revision_log,commit_title,current_direct_link,
-             specific_direct_link,req_does_not_exist,actions'}
+             specific_direct_link,req_does_not_exist,actions,img_title_relation_frozen'}
 
 
 {include file="inc_head.tpl" openHead='yes' jsValidate="yes"} 
@@ -302,7 +302,7 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
     {$loadOnCancelURL=""}
   {/if} 
 
-  {if $gui->req_cfg->relations->enable && !$frozen_version} {* show this part only if relation feature is enabled *}
+  {if $gui->req_cfg->relations->enable} {* show this part only if relation feature is enabled *}
   
     {* form to enter a new relation *}
     <form method="post" action="{$basehref}lib/requirements/reqEdit.php" 
@@ -319,7 +319,7 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
         </td></tr>
       {/if}
     
-      {if $gui->req_relations.rw}
+      {if $gui->req_relations.rw && !$frozen_version}
       <tr style="height:40px; vertical-align: middle;"><td style="height:40px; vertical-align: middle;" colspan="7">
       
         <span class="bold">{$labels.new_relation}:</span> {$labels.current_req}
@@ -392,13 +392,18 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
 
           <td align="center">
           {if $gui->req_relations.rw}
+			{if !$frozen_version && $relation.related_req.is_open}
                 <a href="javascript:relation_delete_confirmation({$gui->req_relations.req.id}, {$relation.id}, 
                                                                  delete_rel_msgbox_title, delete_rel_msgbox_msg, 
                                                                  pF_delete_req_relation);">
                   <img src="{$smarty.const.TL_THEME_IMG_DIR}/trash.png" 
                        title="{$labels.img_title_delete_relation}"  style="border:none" /></a>
-                  {/if}
-                </td>
+			{else}
+				  <img style="border:none;" 	alt="{$labels.img_title_delete_relation}"
+						title="{$labels.img_title_relation_frozen}"	src="{$tlImages.delete_disabled}" />
+			{/if}
+		  {/if}
+          </td>
         </tr>
       {/foreach}
             

--- a/gui/templates/requirements/reqViewVersions.tpl
+++ b/gui/templates/requirements/reqViewVersions.tpl
@@ -465,7 +465,7 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
                      show_hide_container_view_status_id=$memstatus_id}
               <div id="{$div_id}" class="workBack">
               {include file="$this_template_dir/reqViewVersionsViewer.tpl" 
-                       args_req_coverage=$gui->req_coverage
+                       args_hide_coverage=true
                        args_req=$my_req 
                        args_gui=$gui
                        args_grants=$gui->grants 

--- a/gui/templates/requirements/reqViewVersionsViewer.tpl
+++ b/gui/templates/requirements/reqViewVersionsViewer.tpl
@@ -191,7 +191,7 @@ viewer for requirement
 
       {section name=row loop=$args_req_coverage}
         <span>
-		{if $args_grants->req_tcase_link_management == "yes"}
+		{if $args_grants->req_tcase_link_management == "yes" && $args_frozen_version eq null}
         <input type="image"  class="clickable" src="{$tlImages.disconnect_small}" 
                title="{$labels.removeLinkToTestCase}" onClick="tcaseIdentity.value={$args_req_coverage[row].id}">
         &nbsp;&nbsp; 

--- a/gui/templates/requirements/reqViewVersionsViewer.tpl
+++ b/gui/templates/requirements/reqViewVersionsViewer.tpl
@@ -73,21 +73,20 @@ viewer for requirement
                                             '{$del_msgbox_title}', '{$warning_msg}',pF_delete_req_version);"  />
                                               
       {/if}
-
-      {if $args_frozen_version eq null}
+	  {if $args_grants->unfreeze_req}
+		{if $args_frozen_version eq null}
         <input type="button" name="freeze_req_version" value="{$labels.btn_freeze_this_version}"
                onclick="delete_confirmation({$args_req.version_id},
                         '{$labels.version}:{$args_req.version}-{$args_req.req_doc_id|escape:'javascript'|escape}:{$args_req.title|escape:'javascript'|escape}',
                                             '{$freeze_msgbox_title}', '{$freeze_warning_msg}',pF_freeze_req_version);"  />
 
-      {else}
-        {if $args_grants->unfreeze_req}
+		{else}
           <input type="button" name="unfreeze_req_version" value="{$labels.btn_unfreeze_this_version}"
                onclick="delete_confirmation({$args_req.version_id},
                         '{$labels.version}:{$args_req.version}-{$args_req.req_doc_id|escape:'javascript'|escape}:{$args_req.title|escape:'javascript'|escape}',
                                             '{$unfreeze_msgbox_title}', '{$unfreeze_warning_msg}',pF_unfreeze_req_version);"  />
-        {/if}
-      {/if}
+		{/if}
+	  {/if}
 
       {if $args_can_copy}                                         
         <input type="submit" name="copy_req" value="{$labels.btn_cp}" onclick="doAction.value='copy'"/>

--- a/gui/templates/requirements/reqViewVersionsViewer.tpl
+++ b/gui/templates/requirements/reqViewVersionsViewer.tpl
@@ -174,6 +174,7 @@ viewer for requirement
       </fieldset>
     </td>
   </tr>
+  {if !isset($args_hide_coverage)}
   <td>
     <fieldset class="x-fieldset x-form-label-left"><legend class="legend_container">{$labels.coverage}</legend>
     {if $gui->user_feedback != ''}
@@ -226,7 +227,8 @@ viewer for requirement
         
     </fieldset>
     </td>
-   </tr>
+	{/if}
+
   <tr>
       <td>&nbsp;</td>
   </tr>

--- a/gui/templates/requirements/reqViewVersionsViewer.tpl
+++ b/gui/templates/requirements/reqViewVersionsViewer.tpl
@@ -55,23 +55,23 @@ viewer for requirement
         
       {if $args_frozen_version eq null}
         <input type="submit" name="edit_req" value="{$labels.btn_edit}" onclick="doAction.value='edit'"/>
-      {/if}
         
-      {* If more than one version is displayed show "Delete" and "Delete this Version" button*}
-      {if $args_can_delete_req && !$gui->version_option}
-        <input type="button" name="delete_req" value="{$labels.btn_delete}"
+		{* If more than one version is displayed show "Delete" button (only if last version is not frozen) *}
+		{if $args_can_delete_req && !$gui->version_option}
+          <input type="button" name="delete_req" value="{$labels.btn_delete}"
                onclick="delete_confirmation({$args_req.id},
                                             '{$args_req.req_doc_id|escape:'javascript'|escape}:{$args_req.title|escape:'javascript'|escape}',
                                             '{$del_msgbox_title}', '{$warning_msg}',pF_delete_req);"  />
-      {/if}
+		{/if}
         
-      {* If a single version is displayed do only show "Delete this Version" button *}
-      {if $args_can_delete_version || $gui->version_option}
-        <input type="button" name="delete_req_version" value="{$labels.btn_del_this_version}"
+		{* If a single version is displayed do only show "Delete this Version" button *}
+		{if ($args_can_delete_version || $gui->version_option)}
+          <input type="button" name="delete_req_version" value="{$labels.btn_del_this_version}"
                onclick="delete_confirmation({$args_req.version_id},
                         '{$labels.version}:{$args_req.version}-{$args_req.req_doc_id|escape:'javascript'|escape}:{$args_req.title|escape:'javascript'|escape}',
                                             '{$del_msgbox_title}', '{$warning_msg}',pF_delete_req_version);"  />
                                               
+		{/if}
       {/if}
 	  {if $args_grants->unfreeze_req}
 		{if $args_frozen_version eq null}
@@ -91,8 +91,10 @@ viewer for requirement
       {if $args_can_copy}                                         
         <input type="submit" name="copy_req" value="{$labels.btn_cp}" onclick="doAction.value='copy'"/>
       {/if}
-      <input type="button" name="new_revision" id="new_revision" value="{$labels.btn_new_revision}" 
+	  {if $args_frozen_version eq null}
+        <input type="button" name="new_revision" id="new_revision" value="{$labels.btn_new_revision}" 
              onclick="doAction.value='doCreateRevision';javascript:ask4log('reqViewF','log_message','{$req_version_id}');"/>
+	  {/if}
       <input type="button" name="new_version" id="new_version" value="{$labels.btn_new_version}" 
                onclick="doAction.value='doCreateVersion';javascript:ask4log('reqViewF','log_message','{$req_version_id}');"/>
     </form>

--- a/install/sql/alter_tables/1.9.17/mssql/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/mssql/DB.1.9.17/step1/db_schema_update.sql
@@ -98,6 +98,7 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (52,'codetracker_view');
 
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,51);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,52);

--- a/install/sql/alter_tables/1.9.17/mysql/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/mysql/DB.1.9.17/step1/db_schema_update.sql
@@ -62,6 +62,7 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (52,'codetracker_view');
 
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,51);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,52);

--- a/install/sql/alter_tables/1.9.17/postgres/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/postgres/DB.1.9.17/step1/db_schema_update.sql
@@ -66,6 +66,7 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (52,'codetracker_view');
 
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,51);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,52);

--- a/install/sql/mssql/testlink_create_default_data.sql
+++ b/install/sql/mssql/testlink_create_default_data.sql
@@ -169,6 +169,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,10);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,11);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,50);
 
 --  Rights for tester role
@@ -190,6 +191,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,27);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,50);
 
 --  Rights for leader role
@@ -212,6 +214,8 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,27);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,30);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,47);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,50);
 
 --  admin account 

--- a/install/sql/mysql/testlink_create_default_data.sql
+++ b/install/sql/mysql/testlink_create_default_data.sql
@@ -165,6 +165,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,10);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,11);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,50);
 
 # Rights for tester role
@@ -186,6 +187,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,27);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,50);
 
 # Rights for leader role
@@ -208,6 +210,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,27);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,47);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,50);
 

--- a/install/sql/postgres/testlink_create_default_data.sql
+++ b/install/sql/postgres/testlink_create_default_data.sql
@@ -168,6 +168,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,10);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,11);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (4,50);
 
 --  Rights for tester role
@@ -189,6 +190,7 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,25);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,27);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (6,50);
 
 --  Rights for leader role
@@ -211,6 +213,8 @@ INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,26);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,27);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,29);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,30);
+INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,47);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (9,50);
 
 

--- a/lib/functions/requirement_mgr.class.php
+++ b/lib/functions/requirement_mgr.class.php
@@ -2586,6 +2586,19 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
   {
     $this->updateBoolean($reqVersionID,'is_open',$value);
   }  
+  
+  function getOpen($reqVersionID)
+  {
+	
+	$debugMsg = 'Class:' . __CLASS__ . ' - Method: ' . __FUNCTION__;
+
+    $sql = " /* $debugMsg */ SELECT is_open " .
+           " FROM {$this->tables['req_versions']} req_versions " .
+           " WHERE  req_versions.id={$reqVersionID}";
+
+    return ($this->db->get_recordset($sql));
+  }  
+
 
     /**
    * 

--- a/lib/requirements/reqCommands.class.php
+++ b/lib/requirements/reqCommands.class.php
@@ -668,6 +668,11 @@ class reqCommands
         $op['ok'] = false;
         $op['msg'] = sprintf(lang_get('rel_add_error_exists_already'),$this->reqRelationTypeDescr[$relTypeID]);
       }
+	  $dest_open = $this->reqMgr->getOpen($destination_id);
+      if (!$dest_open) {
+		$op['ok'] = false;
+        $op['msg'] = sprintf(lang_get('rel_add_error_dest_frozen'));
+	  }
     }
     
     if ($op['ok']) {

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2788,6 +2788,7 @@ $TLS_delete_rel_msgbox_title = "Delete relation";
 $TLS_delete_rel_msgbox_msg = "Really delete relation #%i?";
 $TLS_img_title_delete_relation = "Click to delete this relation.";
 $TLS_img_title_relation_frozen = "Relation can't be deleted because one of linked requirement is frozen.";
+$TLS_rel_add_error_dest_frozen = "Relation can't be added because the destination requirement is frozen.";
 
 // ----- configured requirement relation types (BUGID 1748) -----
 $TLS_req_rel_is_parent_of = "parent of";

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2787,7 +2787,7 @@ $TLS_error_deleting_rel = "Relation could not be deleted.";
 $TLS_delete_rel_msgbox_title = "Delete relation";
 $TLS_delete_rel_msgbox_msg = "Really delete relation #%i?";
 $TLS_img_title_delete_relation = "Click to delete this relation.";
-
+$TLS_img_title_relation_frozen = "Relation can't be deleted because one of linked requirement is frozen.";
 
 // ----- configured requirement relation types (BUGID 1748) -----
 $TLS_req_rel_is_parent_of = "parent of";

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2425,7 +2425,7 @@ $TLS_desc_keyword_assignment = "Keyword Assignment";
 
 
 
-$TLS_desc_mgt_unfreeze_req = "Unfreeze requirement";
+$TLS_desc_mgt_unfreeze_req = "Freeze/Unfreeze requirement";
 $TLS_desc_mgt_modify_key = "Keyword management";
 $TLS_desc_mgt_modify_product = "Test Project management";
 $TLS_desc_mgt_modify_req = "Requirement management";

--- a/locale/en_GB/texts.php
+++ b/locale/en_GB/texts.php
@@ -52,7 +52,9 @@ analyse serves as confirmation that all defined expectations are met.</p>
 	to the current test case. A designer could mark requirements which are covered by this
 	test case and then click the button 'Assign'. These new assigned test case are shown in
 	the middle block 'Assigned Requirements'.</li>
-</ol>";
+</ol>
+<h2>Warning:</h2>
+A frozen requirement cannot be modified to update coverage. According to this fact, frozen requirements are listed but associated checkboxed are disabled.";
 
 
 // --------------------------------------------------------------------------------------

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2387,7 +2387,7 @@ $TLS_desc_keyword_assignment = "Affectation de mots-clés";
 
 
 
-$TLS_desc_mgt_unfreeze_req = "Déverrouiller exigence";
+$TLS_desc_mgt_unfreeze_req = "Verrouiller/déverrouiller les exigences";
 $TLS_desc_mgt_modify_key = "Gestion des mots-clés";
 $TLS_desc_mgt_modify_product = "Gestion de projets";
 $TLS_desc_mgt_modify_req = "Gestion d’exigences";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2750,6 +2750,7 @@ $TLS_delete_rel_msgbox_title = "Supprimer la relation";
 $TLS_delete_rel_msgbox_msg = "Etes-vous sûr de vouloir supprimer la relation #%i ?";
 $TLS_img_title_delete_relation = "Cliquer pour supprimer la relation.";
 $TLS_img_title_relation_frozen = "La relation ne peut pas être supprimée car au moins une des deux exigences liées est verrouillée.";
+$TLS_rel_add_error_dest_frozen = "La relation ne peut pas être ajoutée car l'exigence de destination est verrouillée.";
 
 
 // ----- configured requirement relation types (BUGID 1748) -----

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2749,6 +2749,7 @@ $TLS_error_deleting_rel = "La relation n’a pas pu être supprimée.";
 $TLS_delete_rel_msgbox_title = "Supprimer la relation";
 $TLS_delete_rel_msgbox_msg = "Etes-vous sûr de vouloir supprimer la relation #%i ?";
 $TLS_img_title_delete_relation = "Cliquer pour supprimer la relation.";
+$TLS_img_title_relation_frozen = "La relation ne peut pas être supprimée car au moins une des deux exigences liées est verrouillée.";
 
 
 // ----- configured requirement relation types (BUGID 1748) -----

--- a/locale/fr_FR/texts.php
+++ b/locale/fr_FR/texts.php
@@ -48,7 +48,9 @@ d'une exigence et trouver lesquelles ont successivement échoué pendant les tes
 	n'ont pas de relation avec la fiche de test sélectionnée. Un concepteur peut marquer les exigences qui sont 
 	couvertes par cette fiche de test et alors cliquer sur le bouton 'Affecter'. Cette nouvelle fiche de test 
 	affectée est affichée dans 	le bloc du milieu 'Exigences affectées'.</li>
-</ol>";
+</ol>
+<h2>Attention :</h2>
+Une exigence verrouillée ne peut pas voir sa couverture modifiée. En conséquence, les exigences verrouillées sont listées mais les cases à cocher correspondantes sont désactivées.";
 
 
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Fix Mantis Issue 8172

The right that is used to :

- Access "Freeze Requirement" and "Unfreeze Requirement" buttons in view Requirement page
- Hide some buttons in View Requirement Page if the Requirement is frozen
    - "Delete" Button
    - "Delete this version" Button
    - "New Revision" Button
    - "Add link to testcase" and "Remove link to testcase" buttons in Requirement coverage section
- Hide "Add Req Relation" form in Relations Section if the current requirement is frozen
- Check if the destination requirement is frozen when adding a new requirement relation
- Disable "Delete Req Relation" in Relations Section if one of the two linked requirements is frozen

Coverage is linked to a requirement, not a requirement version. The "Coverage" Section, available and editable in "Others Versions", has been deleted according to the TestLink behaviour.