### PR TITLE
Rework Testcase frozen comportment

### DIFF
--- a/gui/templates/testcases/inc_tcbody.tpl
+++ b/gui/templates/testcases/inc_tcbody.tpl
@@ -5,17 +5,12 @@ viewer for test case in test specification
 
 *}
 <table class="simple">
-  {if $inc_tcbody_show_title == "yes"}
-	<tr>
-	  <th colspan="{$inc_tcbody_tableColspan}" style="text-align:left;">
-	  {$inc_tcbody_testcase.tc_external_id}{$smarty.const.TITLE_SEP}{$inc_tcbody_testcase.name|escape}
-	  </th>
-	</tr>
-  {/if}
-
 	  <tr>
-	  	<th class="bold" colspan="{$inc_tcbody_tableColspan}" style="text-align:left;">{$inc_tcbody_labels.version}
-	  	{$inc_tcbody_testcase.version|escape}
+	  	<th class="bold" colspan="{$inc_tcbody_tableColspan}" style="text-align:left;">
+		{$args_testcase.tc_external_id}{$smarty.const.TITLE_SEP}{$args_testcase.name|escape}
+		{$smarty.const.TITLE_SEP_TYPE2}{$inc_tcbody_labels.version}{$inc_tcbody_testcase.version|escape}
+
+		
 		<img class="clickable" src="{$tlImages.ghost_item}"
              title="{$inc_tcbody_labels.show_ghost_string}"
              onclick="showHideByClass('tr','ghostTC');">

--- a/gui/templates/testcases/keywords.inc.tpl
+++ b/gui/templates/testcases/keywords.inc.tpl
@@ -66,7 +66,7 @@ var pF_remove_keyword = remove_keyword;
       <td style="vertical-align:top;">
           {foreach item=keyword_item from=$args_keywords_map}
                 {$keyword_item.keyword|escape}
-            {if $edit_enabled && $gui->assign_keywords}
+            {if $edit_enabled && $gui->assign_keywords && $args_frozen_version=="no"}
             <a href="javascript:keyword_remove_confirmation({$gui->tcase_id}, {$keyword_item.keyword_id},
                                                              '{$keyword_item.keyword|escape:'javascript'}', 
                                                               remove_kw_msgbox_title, remove_kw_msgbox_msg, 

--- a/gui/templates/testcases/relations.inc.tpl
+++ b/gui/templates/testcases/relations.inc.tpl
@@ -9,7 +9,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
           s='relation_id, relation_type, relation_status, relation_project,
              relation_set_by, relation_delete, relations, new_relation, by, title_created,
              in, btn_add, img_title_delete_relation,no_records_found,other_versions,version,
-             title_test_case,match_count,warning,
+             title_test_case,match_count,warning,can_not_edit_frozen_tc,
              commit_title,current_direct_link,current_testcase,test_case,relation_set_on,
              specific_direct_link,req_does_not_exist,actions,tcase_relation_hint,tcase_relation_help'}
 
@@ -73,6 +73,8 @@ var pF_delete_relation = delete_relation;
             </td>
           </tr>
         {/if}
+		
+		{if $args_frozen_version=="no"}
     
         <tr style="height:40px; vertical-align: middle;"><td style="height:40px; vertical-align: middle;" colspan="7">
         
@@ -91,6 +93,7 @@ var pF_delete_relation = delete_relation;
           
           </td>
         </tr>
+		{/if}
       {/if}
 
     {if $gui->relations.num_relations > 0}
@@ -111,13 +114,19 @@ var pF_delete_relation = delete_relation;
             {$rx.related_tcase.name|escape}</a></td>
           <td><nobr><span title="{$rel_labels.title_created} {$rx.creation_ts} {$rel_labels.by} {$rx.author|escape}">
              {$rx.author|escape}</span></nobr></td>
-
+		  {if $args_frozen_version=="no"}
           <td align="center">
             <a href="javascript:relation_delete_confirmation({$gui->relations.item.testcase_id}, {$rx.id}, 
                                                               delete_rel_msgbox_title, delete_rel_msgbox_msg, 
                                                               pF_delete_relation);">
            <img src="{$tlImages.delete}" title="{$rel_labels.img_title_delete_relation}"  style="border:none" /></a>
           </td>
+		  {else}
+		  <td align="center">
+			<img style="border:none;" 	alt="{$rel_labels.can_not_edit_frozen_tc}"
+			   title="{$rel_labels.can_not_edit_frozen_tc}"	src="{$tlImages.delete_disabled}" />
+		  </td>
+		  {/if}
         </tr>
       {/foreach}
     {/if}

--- a/gui/templates/testcases/relations.inc.tpl
+++ b/gui/templates/testcases/relations.inc.tpl
@@ -9,7 +9,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
           s='relation_id, relation_type, relation_status, relation_project,
              relation_set_by, relation_delete, relations, new_relation, by, title_created,
              in, btn_add, img_title_delete_relation,no_records_found,other_versions,version,
-             title_test_case,match_count,warning,can_not_edit_frozen_tc,
+             title_test_case,match_count,warning,can_not_edit_frozen_tc,can_not_delete_relation_frozen_tc,
              commit_title,current_direct_link,current_testcase,test_case,relation_set_on,
              specific_direct_link,req_does_not_exist,actions,tcase_relation_hint,tcase_relation_help'}
 
@@ -114,7 +114,7 @@ var pF_delete_relation = delete_relation;
             {$rx.related_tcase.name|escape}</a></td>
           <td><nobr><span title="{$rel_labels.title_created} {$rx.creation_ts} {$rel_labels.by} {$rx.author|escape}">
              {$rx.author|escape}</span></nobr></td>
-		  {if $args_frozen_version=="no"}
+		  {if $args_frozen_version=="no" && $rx.related_tcase.is_open=="1"}
           <td align="center">
             <a href="javascript:relation_delete_confirmation({$gui->relations.item.testcase_id}, {$rx.id}, 
                                                               delete_rel_msgbox_title, delete_rel_msgbox_msg, 
@@ -123,8 +123,8 @@ var pF_delete_relation = delete_relation;
           </td>
 		  {else}
 		  <td align="center">
-			<img style="border:none;" 	alt="{$rel_labels.can_not_edit_frozen_tc}"
-			   title="{$rel_labels.can_not_edit_frozen_tc}"	src="{$tlImages.delete_disabled}" />
+			<img style="border:none;" 	alt="{$rel_labels.can_not_delete_relation_frozen_tc}"
+			   title="{$rel_labels.can_not_delete_relation_frozen_tc}"	src="{$tlImages.delete_disabled}" />
 		  </td>
 		  {/if}
         </tr>

--- a/gui/templates/testcases/steps_horizontal.inc.tpl
+++ b/gui/templates/testcases/steps_horizontal.inc.tpl
@@ -18,7 +18,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
 
   <tr>
     <th width="40px"><nobr>
-    {if $edit_enabled && $steps != '' && !is_null($steps)}
+    {if $edit_enabled && $steps != '' && !is_null($steps) && $args_frozen_version=="no"}
       <img class="clickable" src="{$tlImages.reorder}" align="left"
            title="{$inc_steps_labels.show_hide_reorder}"
            onclick="showHideByClass('span','order_info');">
@@ -63,7 +63,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
   <tr id="step_row_{$step_info.step_number}">
     <td style="text-align:left;">
       <span class="order_info" style='display:none'>
-      {if $edit_enabled}
+      {if $edit_enabled && $args_frozen_version=="no"}
         <input type="text" class="step_number{$args_testcase.id}" name="step_set[{$step_info.id}]" id="step_set_{$step_info.id}"
           value="{$step_info.step_number}"
           size="{#STEP_NUMBER_SIZE#}"
@@ -73,14 +73,14 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
       </span>
       {$step_info.step_number}
     </td>
-    <td {if $edit_enabled} style="cursor:pointer;" onclick="launchEditStep({$step_info.id})" {/if}>{if $gui->stepDesignEditorType == 'none'}{$step_info.actions|nl2br}{else}{$step_info.actions}{/if}
+    <td {if $edit_enabled && $args_frozen_version=="no"} style="cursor:pointer;" onclick="launchEditStep({$step_info.id})" {/if}>{if $gui->stepDesignEditorType == 'none'}{$step_info.actions|nl2br}{else}{$step_info.actions}{/if}
     </td>
-    <td {if $edit_enabled} style="cursor:pointer;" onclick="launchEditStep({$step_info.id})" {/if}>{if $gui->stepDesignEditorType == 'none'}{$step_info.expected_results|nl2br}{else}{$step_info.expected_results}{/if}</td>
+    <td {if $edit_enabled && $args_frozen_version=="no"} style="cursor:pointer;" onclick="launchEditStep({$step_info.id})" {/if}>{if $gui->stepDesignEditorType == 'none'}{$step_info.expected_results|nl2br}{else}{$step_info.expected_results}{/if}</td>
     {if $session['testprojectOptions']->automationEnabled}
-    <td {if $edit_enabled} style="cursor:pointer;" onclick="launchEditStep({$step_info.id})" {/if}>{$gui->execution_types[$step_info.execution_type]}</td>
+    <td {if $edit_enabled && $args_frozen_version=="no"} style="cursor:pointer;" onclick="launchEditStep({$step_info.id})" {/if}>{$gui->execution_types[$step_info.execution_type]}</td>
     {/if}
 
-    {if $edit_enabled}
+    {if $edit_enabled && $args_frozen_version=="no"}
     <td class="clickable_icon">
       <img style="border:none;cursor: pointer;"
            title="{$inc_steps_labels.delete_step}"

--- a/gui/templates/testcases/steps_vertical.inc.tpl
+++ b/gui/templates/testcases/steps_vertical.inc.tpl
@@ -10,7 +10,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
 
 @internal revisions
 *}
-  {if $edit_enabled}
+  {if $edit_enabled && $args_frozen_version=="no"}
   <tr><td>
     <img class="clickable" src="{$tlImages.reorder}" align="left" title="{$inc_steps_labels.show_hide_reorder}"
     onclick="showHideByClass('span','order_info');"></td>
@@ -35,16 +35,16 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
     {else}
     <th>&nbsp;</th>
     {/if}
-    {if $edit_enabled}
+    {if $edit_enabled && $args_frozen_version=="no"}
     <th>&nbsp;</th>
     {/if}
   </tr>
   <tr>
     <td>&nbsp;</td>
-    <td colspan="2" {if $edit_enabled} style="cursor:pointer;"
+    <td colspan="2" {if $edit_enabled && $args_frozen_version=="no"} style="cursor:pointer;"
         onclick="launchEditStep({$step_info.id})"{/if}
         style="padding: 0.5em">{if $gui->stepDesignEditorType  == 'none'}{$step_info.actions|nl2br}{else}{$step_info.actions}{/if}</td>
-    {if $edit_enabled}
+    {if $edit_enabled && $args_frozen_version=="no"}
     <td class="clickable_icon">
       <img style="border:none;cursor: pointer;"
            title="{$inc_steps_labels.delete_step}"
@@ -64,7 +64,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
     <th style="background: transparent; border: none"></th>
     <th colspan="2">{$inc_steps_labels.expected_results}</th>
   </tr>
-  <tr {if $edit_enabled} style="cursor:pointer;"
+  <tr {if $edit_enabled && $args_frozen_version=="no"} style="cursor:pointer;"
       onclick="launchEditStep({$step_info.id})"{/if}>
       <td>&nbsp;</td>
     <td colspan="2" style="padding: 0.5em 0.5em 2em 0.5em">{if $gui->stepDesignEditorType  == 'none'}{$step_info.expected_results|nl2br}{else}{$step_info.expected_results}{/if}</td>

--- a/gui/templates/testcases/tcBulkOp.tpl
+++ b/gui/templates/testcases/tcBulkOp.tpl
@@ -8,7 +8,7 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
 *}
 
 {lang_get var="labels" 
-          s='status,importance,execution_type,btn_apply,btn_cancel'} 
+          s='status,importance,execution_type,force_frozen_testcases_versions,btn_apply,btn_cancel'} 
 
 {$cfg_section=$smarty.template|basename|replace:".tpl":""}
 {config_load file="input_dimensions.conf" section=$cfg_section}
@@ -53,6 +53,11 @@ TestLink Open Source Project - http://testlink.sourceforge.net/
       </select>
     </td>
   </tr>
+  <tr>
+	<td>{$labels.force_frozen_testcases_versions}</td>
+	<td><input type="checkbox" name="forceFrozenTestcasesVersions" value="1" /></td>
+  </tr>
+
 </table>
 
   	<div class="groupBtn">

--- a/gui/templates/testcases/tcDelete.tpl
+++ b/gui/templates/testcases/tcDelete.tpl
@@ -9,7 +9,7 @@ delete test case in test specification
 *}
 {lang_get var="labels"
           s='btn_yes_iw2del,btn_no,th_version,th_linked_to_tplan,title_delete_testcases,
-             th_executed,question_del_tc,platform'}
+             th_executed,question_del_tc,platform,question_del_tc_version,btn_yes_iw2del_version'}
 {include file="inc_head.tpl"}
 
 <body>
@@ -47,16 +47,23 @@ delete test case in test specification
 	  		{/foreach}
 	      </table>
       	{$gui->delete_message}
-    {/if}
+      {/if}
     
     {if $gui->delete_enabled}
-	  <p>{$labels.question_del_tc}</p>
-	  <form method="post" 
-	        action="{$basehref}lib/testcases/tcEdit.php?testcase_id={$gui->testcase_id}&tcversion_id={$gui->tcversion_id}">
-	  	<input type="submit" id="do_delete" name="do_delete" value="{$labels.btn_yes_iw2del}" />
-	  	<input type="button" name="cancel_delete"
-	  	                     onclick="javascript:{$gui->cancelActionJS};" value="{$labels.btn_no}" />
-	  </form>
+	  {if $gui->tcversion_id neq 0}
+		{$local_question=$labels.question_del_tc_version}
+		{$local_button=$labels.btn_yes_iw2del_version}
+	  {else}
+	    {$local_question=$labels.question_del_tc}
+		{$local_button=$labels.btn_yes_iw2del}
+	  {/if}
+	  <p>{$local_question}</p>
+		  <form method="post" 
+				action="{$basehref}lib/testcases/tcEdit.php?testcase_id={$gui->testcase_id}&tcversion_id={$gui->tcversion_id}">
+			<input type="submit" id="do_delete" name="do_delete" value="{$local_button}" />
+			<input type="button" name="cancel_delete"
+								 onclick="javascript:{$gui->cancelActionJS};" value="{$labels.btn_no}" />
+		  </form>	  
     {/if}
  
   

--- a/gui/templates/testcases/tcView.tpl
+++ b/gui/templates/testcases/tcView.tpl
@@ -70,9 +70,9 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
   {/if}
   {* is it frozen? *}
   {if $gui->tc_current_version[idx][0].is_open}
-    {$frozen_version=false}
+    {$frozen_version="no"}
   {else}
-    {$frozen_version=true}
+    {$frozen_version="yes"}
   {/if}
   
     {$tlImages.toggle_direct_link} &nbsp;

--- a/gui/templates/testcases/tcView.tpl
+++ b/gui/templates/testcases/tcView.tpl
@@ -147,6 +147,12 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
           {$title=$labels.version}
           {$title="$title $version_num"}
 
+		  {if $my_testcase.is_open == "0"}
+			{$tcv_frozen_version="yes"}
+		  {else}
+			{$tcv_frozen_version="no"}
+		  {/if}
+		  
           {$sep="_"}
           {$div_id="v_$vid"}
           {$div_id="$div_id$sep$version_num"}
@@ -178,8 +184,8 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
                        args_can_do=$gui->can_do
                        args_can_move_copy="no" 
                        args_can_delete_testcase='no'
-					   args_frozen_version=$frozen_version
-
+					   args_frozen_version=$tcv_frozen_version
+					   
                        args_can_delete_version="yes"
                        args_read_only="yes"
 

--- a/gui/templates/testcases/tcView.tpl
+++ b/gui/templates/testcases/tcView.tpl
@@ -68,7 +68,13 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
   {else}
     {$my_delete_version="no"}
   {/if}
-    <h2 style="{$my_style}">
+  {* is it frozen? *}
+  {if $gui->tc_current_version[idx][0].is_open}
+    {$frozen_version=false}
+  {else}
+    {$frozen_version=true}
+  {/if}
+  
     {$tlImages.toggle_direct_link} &nbsp;
     {if $gui->display_testcase_path}
       {foreach from=$gui->path_info[$tcID] item=path_part}
@@ -79,9 +85,6 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
     <img class="clickable" src="{$tlImages.cog}" onclick="javascript:toogleShowHide('tcView_viewer_tcase_control_panel','inline');"
          title="{$labels.actions}" />
 
-    {if $gui->show_title == 'no'}
-      {$gui->tc_current_version[idx][0].tc_external_id|escape}:{$gui->tc_current_version[idx][0].name|escape}</h2>
-    {/if}
     <div class="direct_link" style='display:none'><a href="{$gui->direct_link}" target="_blank">{$gui->direct_link}</a></div>
     {include file="testcases/tcView_viewer.tpl" 
              args_testcase=$gui->tc_current_version[idx][0]
@@ -92,6 +95,7 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
              args_can_do=$gui->can_do
              args_can_move_copy="yes"
              args_can_delete_testcase="yes" 
+             args_frozen_version=$frozen_version
              args_can_delete_version=$my_delete_version
 
              args_show_version="yes" 
@@ -174,6 +178,8 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
                        args_can_do=$gui->can_do
                        args_can_move_copy="no" 
                        args_can_delete_testcase='no'
+					   args_frozen_version=$frozen_version
+
                        args_can_delete_version="yes"
                        args_read_only="yes"
 

--- a/gui/templates/testcases/tcView.tpl
+++ b/gui/templates/testcases/tcView.tpl
@@ -183,6 +183,7 @@ var {$gui->dialogName} = new std_dialog('&refreshTree');
                        args_can_delete_version="yes"
                        args_read_only="yes"
 
+                       args_hide_relations="yes" 
                        args_show_version="no" 
                        args_show_title="no"
                        args_users=$gui->users

--- a/gui/templates/testcases/tcView_viewer.tpl
+++ b/gui/templates/testcases/tcView_viewer.tpl
@@ -198,7 +198,7 @@ viewer for test case in test specification
 
 		
 	{* Edit TC *}
-	{if $edit_enabled && $args_frozen_version eq null}
+	{if $edit_enabled && $args_frozen_version=="no"}
 		 <input type="submit" name="edit_tc" 
 				onclick="doAction.value='edit';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_edit}" />
 	{/if}
@@ -210,7 +210,7 @@ viewer for test case in test specification
 	{/if}
 
 	{* activate/desactivate TC version *}
-	{if $args_can_do->edit == "yes" && $args_can_do->deactivate=='yes' && $args_frozen_version eq null}
+	{if $args_can_do->edit == "yes" && $args_can_do->deactivate=='yes' && $args_frozen_version=="no"}
 		  {if $args_testcase.active eq 0}
 			  {$act_deact_btn="activate_this_tcversion"}
 			  {$act_deact_value="activate_this_tcversion"}
@@ -227,7 +227,7 @@ viewer for test case in test specification
 	{* freeze/unfreeze TC version *}
 	{if $args_can_do->edit == "yes" && 
 		$args_can_do->freeze=='yes'}
-		  {if $args_frozen_version neq null}
+		  {if $args_frozen_version=="yes"}
 			  {$freeze_btn="unfreeze"}
 			  {$freeze_value="unfreeze_this_tcversion"}
 			  {$version_title_class="unfreeze_version"}
@@ -242,7 +242,7 @@ viewer for test case in test specification
 	{/if}
 
 	{* delete TC version *}
-	{if $args_frozen_version eq null && $args_can_do->delete_version == "yes" && $args_can_delete_version == "yes"}
+	{if $args_frozen_version=="no" && $args_can_do->delete_version == "yes" && $args_can_delete_version == "yes"}
 	   <input type="submit" name="delete_tc_version" value="{$tcView_viewer_labels.btn_del_this_version}" />
 	{/if}
 
@@ -291,7 +291,7 @@ viewer for test case in test specification
   {/if}
   
   {* warning message when tc version is frozen *}
-{if $args_frozen_version neq null}
+{if $args_frozen_version=="yes"}
   <div class="messages" align="center">{$tcView_viewer_labels.can_not_edit_frozen_tc}</div>
 {/if}
   
@@ -357,12 +357,13 @@ function launchInsertStep(step_id)
   {include file="testcases/inc_steps.tpl"
            layout=$gui->steps_results_layout
            edit_enabled=$edit_enabled
+		   args_frozen_version=$args_frozen_version
            ghost_control=true
            steps=$args_testcase.steps}
   {/if}
 </table>
 
-{if $edit_enabled && $args_testcase.is_open}
+{if $edit_enabled && $args_frozen_version=="no"}
 <div {$addInfoDivStyle}>
   <input type="submit" name="create_step" 
           onclick="doAction.value='createStep';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_create_step}" />
@@ -402,7 +403,7 @@ function launchInsertStep(step_id)
              <tr>
                <td colspan="{$tableColspan}" style="vertical-align:text-top;"><span><a title="{$tcView_viewer_labels.requirement_spec}" href="{$hrefReqSpecMgmt}"
                target="mainframe" class="bold">{$tcView_viewer_labels.Requirements}</a>
-              {if $gui->req_tcase_link_management}
+              {if $gui->req_tcase_link_management && $args_frozen_version=="no"}
                 <img class="clickable" src="{$tlImages.item_link}"
                      onclick="javascript:openReqWindow({$args_testcase.testcase_id},'a');"
                      title="{$tcView_viewer_labels.link_unlink_requirements}" />

--- a/gui/templates/testcases/tcView_viewer.tpl
+++ b/gui/templates/testcases/tcView_viewer.tpl
@@ -90,7 +90,7 @@ viewer for test case in test specification
 {$edit_enabled=0}
 {$delete_enabled=0}
 {$has_been_executed=0}
-
+{$show_relations=1}
 {if $args_can_do->edit == "yes"}
 
   {$has_been_executed=0}
@@ -129,7 +129,10 @@ viewer for test case in test specification
   {$edit_enabled=0} 
   {$delete_enabled=0} 
 {/if}
-	
+{if $args_hide_relations == "yes"}
+	{$show_relations=0}
+{/if}
+
 <div style="display:{$tlCfg->gui->op_area_display->test_case};" 
     id="tcView_viewer_tcase_control_panel">
   <fieldset class="groupBtn">
@@ -454,11 +457,13 @@ function launchInsertStep(step_id)
         </tr>
       {/if}
     </table>
-  </div><br>
+  </div>
   {/if}
   
-
-{include file="testcases/relations.inc.tpl" args_edit_enabled=$edit_enabled} 
+{if $show_relations}
+  <br />
+  {include file="testcases/relations.inc.tpl" args_edit_enabled=$edit_enabled} 
+{/if}
 
 {if $args_linked_versions != null && $tlCfg->spec_cfg->show_tplan_usage}
   {* Test Case version Test Plan Assignment *}

--- a/gui/templates/testcases/tcView_viewer.tpl
+++ b/gui/templates/testcases/tcView_viewer.tpl
@@ -146,7 +146,7 @@ viewer for test case in test specification
 		<input type="hidden" name="show_mode" value="{$gui->show_mode}" />
 
 		{* New TC sibling *}
-		{if $args_read_only}
+		{if $args_read_only != "yes" }
 			<input type="hidden" name="containerID" value="{$args_testcase.testsuite_id}" />
 			<input type="submit" name="new_tc" title="{$tcView_viewer_labels.hint_new_sibling}"
 				   onclick="doAction.value='create';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_new_sibling}" />
@@ -207,7 +207,7 @@ viewer for test case in test specification
 	{/if}
 
 	{* new TC version *}
-	{if $args_can_do->create_new_version == "yes"}
+	{if $args_can_do->create_new_version == "yes" && $args_read_only != "yes"}
 	  <input type="submit" name="do_create_new_version" title="{$tcView_viewer_labels.hint_new_version}" 
 			 value="{$tcView_viewer_labels.btn_new_version}" />
 	{/if}
@@ -228,7 +228,7 @@ viewer for test case in test specification
 	{/if}
 
 	{* freeze/unfreeze TC version *}
-	{if $args_can_do->edit == "yes" && 
+	{if $args_read_only != "yes" && 
 		$args_can_do->freeze=='yes'}
 		  {if $args_frozen_version=="yes"}
 			  {$freeze_btn="unfreeze"}

--- a/gui/templates/testcases/tcView_viewer.tpl
+++ b/gui/templates/testcases/tcView_viewer.tpl
@@ -18,7 +18,8 @@ viewer for test case in test specification
              show_ghost_string,display_author_updater,onchange_save,
              estimated_execution_duration,status,btn_save,estimated_execution_duration_short,
              requirement,btn_show_exec_history,btn_resequence_steps,link_unlink_requirements,
-             code_mgmt,code_link_tl_to_cts"}
+             code_mgmt,code_link_tl_to_cts,can_not_edit_frozen_tc,testcase_operations,
+			 testcase_version_operations"}
 
 {lang_get s='warning_delete_step' var="warning_msg"}
 {lang_get s='delete' var="del_msgbox_title"}
@@ -91,9 +92,6 @@ viewer for test case in test specification
 {$has_been_executed=0}
 
 {if $args_can_do->edit == "yes"}
-  {* Seems logical you can disable some you have executed before *}
-  {$active_status_op_enabled=1}
-  {$freeze_op_enabled=1}
 
   {$has_been_executed=0}
   {lang_get s='can_not_edit_tc' var="warning_edit_msg"}
@@ -131,150 +129,159 @@ viewer for test case in test specification
   {$edit_enabled=0} 
   {$delete_enabled=0} 
 {/if}
-
+	
 <div style="display:{$tlCfg->gui->op_area_display->test_case};" 
-     class="groupBtn" id="tcView_viewer_tcase_control_panel">
+    id="tcView_viewer_tcase_control_panel">
+  <fieldset class="groupBtn">
+	 <b>{$tcView_viewer_labels.testcase_operations}</b>
+
     <form style="display: inline;" id="topControls" name="topControls" method="post" action="{$basehref}lib/testcases/tcEdit.php">
-    <input type="hidden" name="testcase_id" value="{$args_testcase.testcase_id}" />
-    <input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
-    <input type="hidden" name="has_been_executed" value="{$has_been_executed}" />
-    <input type="hidden" name="doAction" value="" />
-    <input type="hidden" name="show_mode" value="{$gui->show_mode}" />
+		<input type="hidden" name="testcase_id" value="{$args_testcase.testcase_id}" />
+		<input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
+		<input type="hidden" name="has_been_executed" value="{$has_been_executed}" />
+		<input type="hidden" name="doAction" value="" />
+		<input type="hidden" name="show_mode" value="{$gui->show_mode}" />
 
-    {if $edit_enabled && $args_testcase.is_open}
-         <input type="submit" name="edit_tc" 
-                onclick="doAction.value='edit';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_edit}" />
-    {/if}
-  
-    {* Double condition because for test case versions WE DO NOT DISPLAY this  button, using $args_can_delete_testcase='no'
-      *}
-    {if $delete_enabled && $args_can_do->delete_testcase == "yes" &&  $args_can_delete_testcase == "yes"}
-      <input type="submit" name="delete_tc" value="{$tcView_viewer_labels.btn_delete}" />
-    {/if}
-  
-    {* Double condition because for test case versions WE DO NOT DISPLAY this  button, using $args_can_move_copy='no'
-    *}
-    {if $args_can_do->copy == "yes" && $args_can_move_copy == "yes"}
-         <input type="submit" name="move_copy_tc"   value="{$tcView_viewer_labels.btn_mv_cp}" />
-    {/if}
+		{* New TC sibling *}
+		{if $args_read_only}
+			<input type="hidden" name="containerID" value="{$args_testcase.testsuite_id}" />
+			<input type="submit" name="new_tc" title="{$tcView_viewer_labels.hint_new_sibling}"
+				   onclick="doAction.value='create';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_new_sibling}" />
+		{/if}
 
-    {if $edit_enabled}
-        <input type="hidden" name="containerID" value="{$args_testcase.testsuite_id}" />
-        <input type="submit" name="new_tc" title="{$tcView_viewer_labels.hint_new_sibling}"
-               onclick="doAction.value='create';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_new_sibling}" />
-    {/if}
-
+		{* Move Copy *}
+		{if $args_can_do->copy == "yes" && $args_can_move_copy == "yes"}
+			 <input type="submit" name="move_copy_tc"   value="{$tcView_viewer_labels.btn_mv_cp}" />
+		{/if}
+	  
+		{* Delete TC *}
+		{if $delete_enabled && $args_can_do->delete_testcase == "yes" &&  $args_can_delete_testcase == "yes"}
+		  <input type="submit" name="delete_tc" value="{$tcView_viewer_labels.btn_delete}" />
+		{/if}
     </form>
+  
+	{* bulk action *}
+	{if $edit_enabled}
+	  <form style="display: inline;" id="tcbulkact" name="tcbulkact" 
+			method="post" action="{$bulkOpAction}" >
+		<input type="hidden" name="tcase_id" id="tcase_id" value="{$args_testcase.testcase_id}" />
+		<input type="submit" name="bulk_op" value="{$tcView_viewer_labels.btn_bulk}" />
+	  </form>
+	{/if}
+	
+	{* compare versions *}
+	<span>
+	  {if $args_testcase.version > 1}
+		<form style="display: inline;" id="version_compare" name="version_compare" method="post" action="{$basehref}lib/testcases/tcCompareVersions.php">
+		  <input type="hidden" name="testcase_id" value="{$args_testcase.testcase_id}" />
+		  <input type="submit" name="compare_versions" value="{$tcView_viewer_labels.btn_compare_versions}" />
+		</form>
+	  {/if}
+	</span>
+    {* execution history *}
+	<span>
+      <input type="button" onclick="javascript:openExecHistoryWindow({$args_testcase.testcase_id},1);"
+           value="{$tcView_viewer_labels.btn_show_exec_history}" />
+    </span>
+  </fieldset>
+  {* End of TC Section *}
 
-  <span>
-  <form style="display: inline;" id="tcexport" name="tcexport" method="post" action="{$exportTestCaseAction}" >
-    <input type="hidden" name="testcase_id" value="{$args_testcase.testcase_id}" />
-    <input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
-    <input type="submit" name="export_tc" value="{$tcView_viewer_labels.btn_export}" />
+  <fieldset class="groupBtn">
+  	 <b>{$tcView_viewer_labels.testcase_version_operations}</b>
+
+  <form style="display: inline;" id="versionControls" name="versionControls" method="post" action="{$basehref}lib/testcases/tcEdit.php">
+	<input type="hidden" name="testcase_id" id="versionControls_testcase_id" value="{$args_testcase.testcase_id}" />
+	<input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
+	<input type="hidden" name="has_been_executed" value="{$has_been_executed}" />
+	<input type="hidden" name="doAction" value="" />
+	<input type="hidden" name="show_mode" value="{$gui->show_mode}" />
+
+		
+	{* Edit TC *}
+	{if $edit_enabled && $args_frozen_version eq null}
+		 <input type="submit" name="edit_tc" 
+				onclick="doAction.value='edit';{$gui->submitCode}" value="{$tcView_viewer_labels.btn_edit}" />
+	{/if}
+
+	{* new TC version *}
+	{if $args_can_do->create_new_version == "yes"}
+	  <input type="submit" name="do_create_new_version" title="{$tcView_viewer_labels.hint_new_version}" 
+			 value="{$tcView_viewer_labels.btn_new_version}" />
+	{/if}
+
+	{* activate/desactivate TC version *}
+	{if $args_can_do->edit == "yes" && $args_can_do->deactivate=='yes' && $args_frozen_version eq null}
+		  {if $args_testcase.active eq 0}
+			  {$act_deact_btn="activate_this_tcversion"}
+			  {$act_deact_value="activate_this_tcversion"}
+			  {$version_title_class="inactivate_version"}
+		  {else}
+			  {$act_deact_btn="deactivate_this_tcversion"}
+			  {$act_deact_value="deactivate_this_tcversion"}
+			  {$version_title_class="activate_version"}
+		  {/if}
+		  <input type="submit" name="{$act_deact_btn}"
+							 value="{lang_get s=$act_deact_value}" />
+	{/if}
+
+	{* freeze/unfreeze TC version *}
+	{if $args_can_do->edit == "yes" && 
+		$args_can_do->freeze=='yes'}
+		  {if $args_frozen_version neq null}
+			  {$freeze_btn="unfreeze"}
+			  {$freeze_value="unfreeze_this_tcversion"}
+			  {$version_title_class="unfreeze_version"}
+		  {else}
+			  {$freeze_btn="freeze"}
+			  {$freeze_value="freeze_this_tcversion"}
+			  {$version_title_class="freeze_version"}
+		  {/if}
+
+		 <input type="submit" name="{$freeze_btn}" 
+				onclick="doAction.value='{$freeze_btn}';{$gui->submitCode}" value="{lang_get s=$freeze_value}" />
+	{/if}
+
+	{* delete TC version *}
+	{if $args_frozen_version eq null && $args_can_do->delete_version == "yes" && $args_can_delete_version == "yes"}
+	   <input type="submit" name="delete_tc_version" value="{$tcView_viewer_labels.btn_del_this_version}" />
+	{/if}
+
   </form>
-  </span>
+  {* add TC version to testplan *}
+  {if $args_can_do->add2tplan == "yes" && $args_has_testplans}
+	<span>
+	  <form style="display: inline;" id="addToTestPlans" name="addToTestPlans" method="post" action="">
+		<input type="hidden" name="testcase_id" id="versionControls_testcase_id" value="{$args_testcase.testcase_id}" />
+		<input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
+		<input type="button" id="addTc2Tplan_{$args_testcase.id}"  name="addTc2Tplan_{$args_testcase.id}" 
+		   value="{$tcView_viewer_labels.btn_add_to_testplans}" onclick="location='{$hrefAddTc2Tplan}'" />
+	  </form>
+	</span>
+  {/if}
+  {* Export TC version *}
+	<span>
+	  <form style="display: inline;" id="tcexport" name="tcexport" method="post" action="{$exportTestCaseAction}" >
+		<input type="hidden" name="testcase_id" value="{$args_testcase.testcase_id}" />
+		<input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
+		<input type="submit" name="export_tc" value="{$tcView_viewer_labels.btn_export}" />
+	  </form>
+	</span>
+{/if} {* user can edit *}
 
-  <span>
+{* Print TC version *}
+<span>
   <form style="display: inline;" id="tcprint" name="tcprint" method="post" action="" >
     <input type="button" name="tcPrinterFriendly" value="{$tcView_viewer_labels.btn_print_view}" 
            onclick="javascript:openPrintPreview('tc',{$args_testcase.testcase_id},{$args_testcase.id},null,
                                                 '{$printTestCaseAction}');"/>
   </form>
-  </span>
+</span>
 
-    <form style="display: inline;" id="versionControls" name="versionControls" method="post" action="{$basehref}lib/testcases/tcEdit.php">
-    <input type="hidden" name="testcase_id" id="versionControls_testcase_id" value="{$args_testcase.testcase_id}" />
-    <input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
-    <input type="hidden" name="has_been_executed" value="{$has_been_executed}" />
-    <input type="hidden" name="doAction" value="" />
-    <input type="hidden" name="show_mode" value="{$gui->show_mode}" />
+</fieldset>
+{* End of TC version Section *}
 
 
-    {if $args_can_do->create_new_version == "yes"}
-      <input type="submit" name="do_create_new_version" title="{$tcView_viewer_labels.hint_new_version}" 
-             value="{$tcView_viewer_labels.btn_new_version}" />
-    {/if}
-
-    {if $delete_enabled && $args_can_do->delete_version == "yes" && $args_can_delete_version == "yes"}
-       <input type="submit" name="delete_tc_version" value="{$tcView_viewer_labels.btn_del_this_version}" />
-    {/if}
-
-
-  
-    {* --------------------------------------------------------------------------------------- *}
-    {if $active_status_op_enabled eq 1 && $args_can_do->deactivate=='yes'}
-          {if $args_testcase.active eq 0}
-              {$act_deact_btn="activate_this_tcversion"}
-              {$act_deact_value="activate_this_tcversion"}
-              {$version_title_class="inactivate_version"}
-          {else}
-              {$act_deact_btn="deactivate_this_tcversion"}
-              {$act_deact_value="deactivate_this_tcversion"}
-              {$version_title_class="activate_version"}
-          {/if}
-          <input type="submit" name="{$act_deact_btn}"
-                             value="{lang_get s=$act_deact_value}" />
-    {/if}
-
-    {if $freeze_op_enabled==1 && 
-        $args_can_do->freeze=='yes'}
-          {if $args_testcase.is_open eq 0}
-              {$freeze_btn="unfreeze"}
-              {$freeze_value="unfreeze_this_tcversion"}
-              {$version_title_class="unfreeze_version"}
-          {else}
-              {$freeze_btn="freeze"}
-              {$freeze_value="freeze_this_tcversion"}
-              {$version_title_class="freeze_version"}
-          {/if}
-
-         <input type="submit" name="{$freeze_btn}" 
-                onclick="doAction.value='{$freeze_btn}';{$gui->submitCode}" value="{lang_get s=$freeze_value}" />
-
-    {/if}
-
-
-  </form>
-{/if} {* user can edit *}
-
-{if $args_can_do->add2tplan == "yes" && $args_has_testplans}
-  <span>
-  <form style="display: inline;" id="addToTestPlans" name="addToTestPlans" method="post" action="">
-    <input type="hidden" name="testcase_id" id="versionControls_testcase_id" value="{$args_testcase.testcase_id}" />
-    <input type="hidden" name="tcversion_id" value="{$args_testcase.id}" />
-    <input type="button" id="addTc2Tplan_{$args_testcase.id}"  name="addTc2Tplan_{$args_testcase.id}" 
-           value="{$tcView_viewer_labels.btn_add_to_testplans}" onclick="location='{$hrefAddTc2Tplan}'" />
-  </form>         
-  </span>
-
-  {/if}
-
-  <span>
-  {* compare versions *}
-  {if $args_testcase.version > 1}
-    <form style="display: inline;" id="version_compare" name="version_compare" method="post" action="{$basehref}lib/testcases/tcCompareVersions.php">
-      <input type="hidden" name="testcase_id" value="{$args_testcase.testcase_id}" />
-      <input type="submit" name="compare_versions" value="{$tcView_viewer_labels.btn_compare_versions}" />
-    </form>
-  {/if}
-  </span>
-  <span>
-    <input type="button" onclick="javascript:openExecHistoryWindow({$args_testcase.testcase_id},1);"
-           value="{$tcView_viewer_labels.btn_show_exec_history}" />
-  
-
-    {if $edit_enabled && $args_testcase.is_open}
-      <form style="display: inline;" id="tcbulkact" name="tcbulkact" 
-            method="post" action="{$bulkOpAction}" >
-        <input type="hidden" name="tcase_id" id="tcase_id" value="{$args_testcase.testcase_id}" />
-        <input type="submit" name="bulk_op" value="{$tcView_viewer_labels.btn_bulk}" />
-      </form>
-    {/if}
-
-  </span>
-  <br/><br/>
-
-  </div> {* class="groupBtn" *}
+</div>
 
 
 
@@ -282,6 +289,11 @@ viewer for test case in test specification
   {if $args_testcase.active eq 0}
     <div class="messages" align="center">{$tcView_viewer_labels.tcversion_is_inactive_msg}</div>
   {/if}
+  
+  {* warning message when tc version is frozen *}
+{if $args_frozen_version neq null}
+  <div class="messages" align="center">{$tcView_viewer_labels.can_not_edit_frozen_tc}</div>
+{/if}
   
    {if $warning_edit_msg != ""}
        <div class="messages" align="center">

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -7282,8 +7282,8 @@ class testcase extends tlObjectWithAttachments
    *
    * @author Andreas Simon
    *
-   * @param integer $source_id ID of source requirement
-   * @param integer $destination_id ID of destination requirement
+   * @param integer $source_id ID of source testcase
+   * @param integer $destination_id ID of destination testcase
    * @param integer $type_id relation type ID to set
    * @param integer $author_id user's ID
    */
@@ -7294,13 +7294,21 @@ class testcase extends tlObjectWithAttachments
     // check if exists before trying to add
     if( !$this->relationExits($source_id, $destination_id, $type_id) )
     {
+		// check if related testcase is open
+		$dummy = $this->get_by_id($destination_id,self::LATEST_VERSION);
+		if(($dummy[0]['is_open']) =="1"){
 
-      $time = is_null($ts) ? $this->db->db_now() : $ts;
-      $sql = " $debugMsg INSERT INTO {$this->tables['testcase_relations']} "  .
-             " (source_id, destination_id, relation_type, author_id, creation_ts) " .
-             " values ($source_id, $destination_id, $type_id, $author_id, $time)";
-      $this->db->exec_query($sql);
-      $ret = array('status_ok' => true, 'msg' => 'relation_added');
+		  $time = is_null($ts) ? $this->db->db_now() : $ts;
+		  $sql = " $debugMsg INSERT INTO {$this->tables['testcase_relations']} "  .
+				 " (source_id, destination_id, relation_type, author_id, creation_ts) " .
+				 " values ($source_id, $destination_id, $type_id, $author_id, $time)";
+		  $this->db->exec_query($sql);
+		  $ret = array('status_ok' => true, 'msg' => 'relation_added');
+		}
+		else
+		{
+		  $ret = array('status_ok' => false, 'msg' => 'related_tcase_not_open');
+		}
     }
     else
     {

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -7583,14 +7583,22 @@ class testcase extends tlObjectWithAttachments
   /**
    *
    */
-  function setIntAttrForAllVersions($id,$attr,$value)
+  function setIntAttrForAllVersions($id,$attr,$value,$forceFrozenVersions=false)
   {
     $debugMsg = 'Class:' . __CLASS__ . ' - Method: ' . __FUNCTION__;
 //    $children =
 
+
     $sql = " UPDATE {$this->tables['tcversions']} " .
-           " SET {$attr} = " . $this->db->prepare_int($value) .
-           " WHERE id IN (" .
+           " SET {$attr} = " . $this->db->prepare_int($value) ;
+		   
+	if($forceFrozenVersions==false){
+	  $sql .= " WHERE is_open=1 AND ";
+	}
+	else{
+	  $sql .= " WHERE ";
+	}
+	$sql .= " id IN (" .
            "  SELECT NHTCV.id FROM {$this->tables['nodes_hierarchy']} NHTCV " .
            "  WHERE NHTCV.parent_id = " . intval($id) . ")";
     $this->db->exec_query($sql);

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -2175,7 +2175,7 @@ class testcase extends tlObjectWithAttachments
 
        [options]:
                 [output]: default 'full'
-          domain 'full','essential','full_without_steps'
+          domain 'full','essential','full_without_steps','full_without_users'
 
     returns: array
 
@@ -7170,7 +7170,7 @@ class testcase extends tlObjectWithAttachments
             }
             $relSet['relations'][$key]['type_localized'] = $relSet['relations'][$key][$type_localized];
             $otherItem = $this->get_by_id($rel[$other_key],self::LATEST_VERSION,null,
-                                          array('output' => 'essential','getPrefix' => true));
+                                          array('output' => 'full_without_users','getPrefix' => true));
 
 
             // only add it, if either interproject linking is on or if it is in the same project

--- a/lib/testcases/tcBulkOp.php
+++ b/lib/testcases/tcBulkOp.php
@@ -77,7 +77,10 @@ function init_args(&$tcaseMgr)
   $args->domainTCExecType = $tcaseMgr->get_execution_types();
 
   $dummy = config_get('importance');
-  $args->domainTCImportance = $dummy['code_label'];
+  foreach ($dummy['code_label'] as $code => $label) 
+  {
+	$args->domainTCImportance[$code] =  lang_get($label);
+  }
   $args->forceFrozenVersions = isset($_REQUEST['forceFrozenTestcasesVersions']) ? intval($_REQUEST['forceFrozenTestcasesVersions']) : 0;
 
   return $args;

--- a/lib/testcases/tcBulkOp.php
+++ b/lib/testcases/tcBulkOp.php
@@ -26,8 +26,8 @@ if($args->doAction == 'apply')
   {
     if($val > 0)
     {
-      $tcaseMgr->setIntAttrForAllVersions($args->tcase_id,$key,$val);
-    }  
+      $tcaseMgr->setIntAttrForAllVersions($args->tcase_id,$key,$val,$args->forceFrozenVersions);
+    }
   }  
 }  
 
@@ -47,8 +47,6 @@ $smarty->display($templateCfg->template_dir . $templateCfg->default_template);
 function init_args(&$tcaseMgr)
 {
   $_REQUEST = strings_stripSlashes($_REQUEST);
-  
-  new dBug($_REQUEST);
 
   $args = new stdClass();
   $args->doAction = isset($_REQUEST['doAction']) ? $_REQUEST['doAction'] : null;
@@ -80,6 +78,7 @@ function init_args(&$tcaseMgr)
 
   $dummy = config_get('importance');
   $args->domainTCImportance = $dummy['code_label'];
+  $args->forceFrozenVersions = isset($_REQUEST['forceFrozenTestcasesVersions']) ? intval($_REQUEST['forceFrozenTestcasesVersions']) : 0;
 
   return $args;
 }

--- a/lib/testcases/tcEdit.php
+++ b/lib/testcases/tcEdit.php
@@ -178,7 +178,7 @@ if($args->delete_tc_version)
 
   $tcinfo = $tcase_mgr->get_by_id($args->tcase_id,$args->tcversion_id);
 
-  $gui->title = lang_get('title_del_tc') . 
+  $gui->main_descr = lang_get('title_del_tc') . 
                 TITLE_SEP_TYPE3 . lang_get('version') . " " . $tcinfo[0]['version'];
   $gui->testcase_name = $tcinfo[0]['name'];
   $gui->testcase_id = $args->tcase_id;

--- a/lib/testcases/testcaseCommands.class.php
+++ b/lib/testcases/testcaseCommands.class.php
@@ -1141,8 +1141,9 @@ class testcaseCommands
       {
         $source_id = $argsObj->destination_tcase_id;
         $destination_id = $argsObj->tcase_id;
-      }      
-      $this->tcaseMgr->addRelation($source_id, $destination_id,$relTypeInfo[0], $argsObj->user_id); 
+      }
+      $ret = $this->tcaseMgr->addRelation($source_id, $destination_id,$relTypeInfo[0], $argsObj->user_id);
+	  $guiObj->user_feedback = sprintf(lang_get($ret['msg']), $argsObj->relation_destination_tcase);	  
     } 
     else
     {

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2512,6 +2512,9 @@ $TLS_create_new_version = "Created new version %s";
 $TLS_testcase_name_already_exists = "There's already a Test Case with this title (%s)";
 $TLS_created_with_title = "Created with title (%s)";
 $TLS_the_format_tc_xml_import = "";
+$TLS_relation_added = "Relation to %s has been added";
+$TLS_related_tcase_not_open = "Relation to %s cannot be added : this testcase is frozen";
+$TLS_relation_already_exists = "Relation to %s cannot be added : the relation already exists";
 
 
 // ----- lib/functions/testsuite.class.php -----

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -1236,6 +1236,10 @@ $TLS_jolly_hint = "value will be searched like in OR mode in title,summary,preco
 
 
 
+// ----- gui/templates/testcases/tcBulkOp.tpl -----
+$TLS_force_frozen_testcases_versions = "Force Frozen Testcases Versions";
+
+
 // ----- gui/templates/testcases/searchData.tpl -----
 $TLS_too_wide_search_criteria = "Too many results. Please, set a more specific " .
     "criteria for the search.";

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -744,6 +744,7 @@ $TLS_title_change_node_order = "Change children order";
 // ----- gui/templates/containerView.tpl -----
 $TLS_testsuite_operations = "Test Suite Operations";
 $TLS_testcase_operations = "Test Case Operations";
+$TLS_testcase_version_operations = "Test Case Version Operations";
 $TLS_alt_del_testsuite = "Delete this Test Suite with all children (Test Suites and Test Cases)";
 $TLS_alt_edit_testsuite = "Modify this Test Suite data and title";
 $TLS_alt_move_cp_testsuite = "Move or copy this Test Suite";
@@ -1644,7 +1645,7 @@ $TLS_testproject_alt_delete = 'Delete the Test project and all related data.';
 // Warning!!! - if JS string you must use \\n to get \n
 $TLS_popup_product_delete = 'Warning! This action deletes irrevocable all Test Project related ' .
                             'data (including test results, plans, etc.). ' .
-                            'You can also use to deactivate instead of delete.\\n' .
+                            'You can also use to desactivate instead of delete.\\n' .
                             'Recommendation: Execute a dump of database at first.\\n' .
                             'Are you sure to delete the Test Project?';
 $TLS_th_reqmgrsystem_short = 'Req. Mgmt. System';
@@ -1692,13 +1693,14 @@ $TLS_hint_new_sibling = "Create another test case under current Test Suite";
 $TLS_hint_new_version = "Create a new version";
 
 $TLS_can_not_edit_tc = "You can not edit this version because it has been executed";
-$TLS_deactivate_this_tcversion = "Deactivate this version";
+$TLS_can_not_edit_frozen_tc = "You can not edit this version because it has been frozen";
+$TLS_deactivate_this_tcversion = "Desactivate this version";
 $TLS_execution_type = 'Execution type';
 $TLS_execution_type_short_descr = 'Execution';
 $TLS_tcversion_is_inactive_msg = "This version is INACTIVE => will be not available to be included in a test plan";
 
 
-$TLS_no_right_to_delete_executed_tc = "Your role has no right to delete executed test cases or test case versions";
+$TLS_no_right_to_delete_executed_tc = "Your role has no right to delete executed test cases";
 $TLS_system_blocks_delete_executed_tc = $TLS_no_right_to_delete_executed_tc;
 $TLS_system_blocks_delete_executed_tc_when = $TLS_no_right_to_delete_executed_tc;
 $TLS_btn_bulk = "Bulk action";

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -1251,7 +1251,9 @@ $TLS_too_wide_search_criteria = "Too many results. Please, set a more specific "
 
 // ----- gui/templates/tcDelete.tpl -----
 $TLS_btn_yes_iw2del = "Yes, delete Test Case!";
-$TLS_question_del_tc = "Really delete Test Case?";
+$TLS_btn_yes_iw2del_version = "Yes, delete Test Case Version!";
+$TLS_question_del_tc = "Really delete this Test Case?";
+$TLS_question_del_tc_version = "Really delete this Test Case Version?";
 $TLS_th_executed = "Executed";
 $TLS_th_linked_to_tplan = "Linked to Test Plan";
 $TLS_th_version = "Version";

--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -1694,6 +1694,7 @@ $TLS_hint_new_version = "Create a new version";
 
 $TLS_can_not_edit_tc = "You can not edit this version because it has been executed";
 $TLS_can_not_edit_frozen_tc = "You can not edit this version because it has been frozen";
+$TLS_can_not_delete_relation_frozen_tc = "You can not delete this relation : testcase has been frozen";
 $TLS_deactivate_this_tcversion = "Desactivate this version";
 $TLS_execution_type = 'Execution type';
 $TLS_execution_type_short_descr = 'Execution';

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -1212,6 +1212,10 @@ $TLS_jolly_hint = "la valeur sera cherchée, comme en mode OR, dans le titre, le
 
 
 
+// ----- gui/templates/testcases/tcBulkOp.tpl -----
+$TLS_force_frozen_testcases_versions = "Forcer les versions verrouillées des fiches de test";
+
+
 // ----- gui/templates/testcases/searchData.tpl -----
 $TLS_too_wide_search_criteria = "Trop de résultats à afficher. Veuillez définir des " .
 		"critères de recherche plus fins.";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -2473,7 +2473,9 @@ $TLS_create_new_version = "Nouvelle version créée %s";
 $TLS_testcase_name_already_exists = "Fiche de test existe déjà avec le titre (%s)";
 $TLS_created_with_title = "Créée avec le titre (%s)";
 $TLS_the_format_tc_xml_import = "";
-
+$TLS_relation_added = "La relation vers %s a été ajoutée";
+$TLS_related_tcase_not_open = "La relation vers %s ne peut pas être ajoutée : cette fiche de test est verrouillée";
+$TLS_relation_already_exists = "La relation vers %s ne peut pas être ajoutée : cette relation existe déjà";
 
 // ----- lib/functions/testsuite.class.php -----
 $TLS_component_name_already_exists = "Il existe déjà un dossier de test portant le nom %s";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -1227,7 +1227,9 @@ $TLS_too_wide_search_criteria = "Trop de résultats à afficher. Veuillez défin
 
 // ----- gui/templates/tcDelete.tpl -----
 $TLS_btn_yes_iw2del = "OK, supprimer la fiche de test";
+$TLS_btn_yes_iw2del_version = "OK, supprimer la version de cette fiche de test";
 $TLS_question_del_tc = "Etes-vous sûr de vouloir supprimer la fiche de test ?";
+$TLS_question_del_tc_version = "Etes-vous sûr de vouloir supprimer cette version de la fiche de test ?";
 $TLS_th_executed = "Exécutée";
 $TLS_th_linked_to_tplan = "Liée à une campagne de test";
 $TLS_th_version = "Version";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -1667,6 +1667,7 @@ $TLS_hint_new_version = "Créer une nouvelle version";
 
 $TLS_can_not_edit_tc = "Vous ne pouvez pas modifier la version car elle a été exécutée.";
 $TLS_can_not_edit_frozen_tc = "Vous ne pouvez pas modifier la version car elle a été verrouillée";
+$TLS_can_not_delete_relation_frozen_tc = "Vous ne pouvez pas supprimer la relation : fiche de test verrouillée";
 $TLS_deactivate_this_tcversion = "Désactiver la version";
 $TLS_execution_type = "Type d’exécution";
 $TLS_execution_type_short_descr = "Exécution";

--- a/locale/fr_FR/strings.txt
+++ b/locale/fr_FR/strings.txt
@@ -1666,6 +1666,7 @@ $TLS_hint_new_sibling = "Créer une autre fiche de test dans le dossier de tests
 $TLS_hint_new_version = "Créer une nouvelle version";
 
 $TLS_can_not_edit_tc = "Vous ne pouvez pas modifier la version car elle a été exécutée.";
+$TLS_can_not_edit_frozen_tc = "Vous ne pouvez pas modifier la version car elle a été verrouillée";
 $TLS_deactivate_this_tcversion = "Désactiver la version";
 $TLS_execution_type = "Type d’exécution";
 $TLS_execution_type_short_descr = "Exécution";


### PR DESCRIPTION
Fix ticket 8189

	- Display a information message if the testcase is frozen
	- Hide some buttons in View TestCase Page if the TestCase is frozen
	- no keyword deletion available if frozen
	- no link to requirement from testcase if frozen
	- no steps edition if frozen
	- Hide "Add TestCase Relation" form in Relations Section if the current TestCase is frozen
	- Disable "Delete TestCase Relation" in Relations Section if one of the two linked TestCase is frozen
	- Disable "Delete TestCase Relation" in Relations Section if the dest TestCase is frozen
	- Verify destination frozen status when adding new relation between testcases
	- Check if the destination TestCase is frozen when adding a new TestCase relation
	- Coverage is linked to a TestCase, not a TestCase version. The "Coverage" Section, available and editable in "Others Versions", has been deleted according to this TestLink behaviour.
	- Remove few buttons in testcase "others versions"
	- Don't apply testcase bulk action if testcase version is frozen
	- delete testcase version => confirmation message is wrong
	- use importance translated values in testcase bulk action