### PR TITLE
TICKET 0008199: Possibility to get execution history by external id

### DIFF
--- a/lib/execute/execHistory.php
+++ b/lib/execute/execHistory.php
@@ -23,6 +23,10 @@ $args = init_args();
 $gui = new stdClass();
 $gui->exec_cfg = config_get('exec_cfg');
 
+if ($args->tcase_id == 0){
+ $row = $tcase_mgr->get_by_external($args->external_id,-1);
+ $args->tcase_id = key($row);
+}
 
 $node['basic'] = $tcase_mgr->tree_manager->get_node_hierarchy_info($args->tcase_id); 
 $node['specific'] = $tcase_mgr->getExternalID($args->tcase_id); 
@@ -101,11 +105,13 @@ function init_args()
   $_REQUEST = strings_stripSlashes($_REQUEST);
 
   $iParams = array("tcase_id" => array(tlInputParameter::INT_N),
+                    "external_id" => array(tlInputParameter::INT_N),
                    'onlyActiveTestPlans' => array(tlInputParameter::INT_N));
   $pParams = R_PARAMS($iParams);
 
   $args = new stdClass();
   $args->tcase_id = intval($pParams["tcase_id"]);
+  $args->external_id = intval($pParams["external_id"]);
 
   $args->onlyActiveTestPlans = null;
   if(intval($pParams["onlyActiveTestPlans"]) > 0  ||  

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -5470,7 +5470,8 @@ class testcase extends tlObjectWithAttachments
     }
 
     $sql .= $add_filters;
-    $sql .= " AND NH_TCASE_PARENT.id = {$parent_id}" ;
+    if ($parent_id != -1)
+      $sql .= " AND NH_TCASE_PARENT.id = {$parent_id}" ;
     $recordset = $this->db->fetchRowsIntoMap($sql,'id');
     return $recordset;
   }


### PR DESCRIPTION
Sometimes it is needed to get execution history by external id (for example from external tools, like Jenkins, Allure, ReportPortal)