### PR TITLE
fix substr call in formatTcPrefix to start the cut at the correct position

### DIFF
--- a/lib/functions/testproject.class.php
+++ b/lib/functions/testproject.class.php
@@ -1070,7 +1070,7 @@ function count_testcases($id)
     // limit tcasePrefix len.
     if(tlStringLen($fstr) > self::TESTCASE_PREFIX_MAXLEN)
     {
-      $fstr = substr($fstr,self::TESTCASE_PREFIX_MAXLEN);
+      $fstr = substr($fstr, 0, self::TESTCASE_PREFIX_MAXLEN);
     }
     return $fstr;
   }


### PR DESCRIPTION
If you define a prefix that is longer than 16chars over the api the substr of the prefix is started at char 16.
Example: prefix "very very long prefix" result in "refix"