### PR TITLE
[DOC] wrong param name for XMLRPC methods

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -1259,7 +1259,7 @@ class TestlinkXMLRPCServer extends IXR_Server
    *
    * @param struct $args
    * @param string $args["devKey"]
-   * @param int $args["tplanid"]
+   * @param int $args["testplanid"]
    * @return mixed 
    *         
    * @access public
@@ -4863,7 +4863,7 @@ public function getTestCase($args)
    *
    * @param struct $args
    * @param string $args["devKey"]
-   * @param int $args["tplanid"] test plan id
+   * @param int $args["testplanid"] test plan id
    *
    * @return map where every element has:
    *


### PR DESCRIPTION
# Description

Just bad documentation for method in XMLRPC named ``'tl.getLatestBuildForTestPlan'`` , doc it's saying **tplanid** but if you take postman, configure to launch this request, will fail, but if you use **testplanid** then will works.

## Testcases

* [ ] at file : 
https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/47bd8e94e88dfbf88d166732a3d656f76e540d76/lib/api/xmlrpc/v1/xmlrpc.class.php#L1262

  * **[FAILED]** Test for param name : `tplanid`
  * **[PASSED]** Test for param name : `testplanid`

* [ ] found the same wrong word at : https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/47bd8e94e88dfbf88d166732a3d656f76e540d76/lib/api/xmlrpc/v1/xmlrpc.class.php#L4866

  * **[FAILED]** Test for param name : `tplanid`
  * **[PASSED]** Test for param name : `testplanid`

##  Report

``` curl
curl -X POST \
  http://qalab.tk:86/lib/api/xmlrpc/v1/xmlrpc.php/ \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/xml' \
  -H 'Postman-Token: 163e9593-2ecc-429e-b584-a2ca4e0e9c83' \
  -d '<?xml version="1.0"?>
    <methodCall>
        <methodName>tl.getLatestBuildForTestPlan</methodName>
        <params>
            <param>
                <value>
                    <struct>
                        <member>
                            <name>devKey</name>
                            <value>
                                <string>1bfd2ef4ceda22b482b12f2b25457495</string>
                            </value>
                        </member>
                        <member>
                            <name>testplanid</name>
                            <value>
                                <string>2</string>
                            </value>
                        </member>
                    </struct>
                </value>
            </param>
        </params>
    </methodCall>
<?xml version='\''1.0'\''>'
```

### Notes

Found while development for new library to communicate with testlink in Python language , existing are not usable

https://github.com/netzulo/qatestlink/issues/7