### PR TITLE
restore <a> default TestLink style and except CSS style for bootstrap buttons

### DIFF
--- a/gui/themes/default/css/testlink.css
+++ b/gui/themes/default/css/testlink.css
@@ -82,22 +82,18 @@ form
 }
 
 /* ***** Links ***** */
-/* A Visited link is still blue */
+/* A Visited link is still blue, except if class is btn-primary from bootstrap */
 
-/*
-a:visited, a:active {
+a:not(.btn-primary){
 	color: 			#059;
 	text-decoration: none;
 }
-*/
 
 /* A link being hovered over is red*/
-/*
 a:hover   {
 	color: 			#900;
 	text-decoration: none;
 }
-*/
 
 /* ***** Menu bar specific ******************************************* */
 div.menu_title {


### PR DESCRIPTION
legacy management pages (projects, Issues tracker, keyword, platforms, testplans, builds, milestones) and metrics and reports items are without css style since the desactivation from commit e42fc31feff60df2988e66dbf940f6dab63baddf