### PR TITLE
Adding code trackers table creation to postgres install script

### DIFF
--- a/install/sql/postgres/testlink_create_tables.sql
+++ b/install/sql/postgres/testlink_create_tables.sql
@@ -774,6 +774,24 @@ CREATE TABLE /*prefix*/testproject_issuetracker
 );
 
 
+CREATE TABLE /*prefix*/codetrackers
+(
+  "id" BIGSERIAL NOT NULL ,
+  "name" VARCHAR(100) NOT NULL,
+  "type" INTEGER NOT NULL DEFAULT '0',
+  "cfg" TEXT,
+  PRIMARY KEY  ("id")
+);
+CREATE UNIQUE INDEX /*prefix*/codetrackers_uidx1 ON /*prefix*/codetrackers ("name");
+
+
+CREATE TABLE /*prefix*/testproject_codetracker
+(
+  "testproject_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/testprojects (id) ON DELETE CASCADE,
+  "codetracker_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/codetrackers (id) ON DELETE CASCADE,
+  PRIMARY KEY ("testproject_id")
+);
+
 
 CREATE TABLE /*prefix*/reqmgrsystems
 (


### PR DESCRIPTION
I wasn't able to install TestLink correctly on a Postgres DB with the latest version, the problem was that the code trackers table was missing, so I added it to the install script and it's back in ship-shape.