### PR TITLE
Remove code path as a primary key in script links.

### DIFF
--- a/install/sql/mysql/testlink_create_tables.sql
+++ b/install/sql/mysql/testlink_create_tables.sql
@@ -212,7 +212,7 @@ CREATE TABLE /*prefix*/testcase_script_links (
   `code_path` varchar(255) NOT NULL,
   `branch_name` varchar(64) default NULL,
   `commit_id` varchar(40) default NULL,
-  PRIMARY KEY  (`tcversion_id`,`project_key`,`repository_name`,`code_path`)
+  PRIMARY KEY  (`tcversion_id`,`project_key`,`repository_name`)
 ) DEFAULT CHARSET=utf8;
 
 


### PR DESCRIPTION
Although unique,  the paths are, however, very large which will kill database performance and isn't needed as a key.
Also causes errors in many databases.

20:59:25	CREATE TABLE /*prefix*/testcase_script_links (   `tcversion_id` int(10) unsigned NOT NULL default '0',   `project_key` varchar(64) NOT NULL,   `repository_name` varchar(64) NOT NULL,   `code_path` varchar(255) NOT NULL,   `branch_name` varchar(64) default NULL,   `commit_id` varchar(40) default NULL,   PRIMARY KEY  (`tcversion_id`,`project_key`,`repository_name`,`code_path`) ) DEFAULT CHARSET=utf8	Error Code: 1071. Specified key was too long; max key length is 1000 bytes	0.000 sec

This error means that we have a primary key, used as a hash, more than 1000 bytes long.  