### PR TITLE
Fix getValidKeywordSet. keywordSet needs to be an array when entering to foreach

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -3198,7 +3198,7 @@ class TestlinkXMLRPCServer extends IXR_Server
     */
   protected function getValidKeywordSet($tproject_id,$keywords,$byName,$op=null)
   {
-    $keywordSet = '';
+    $keywordSet = array();
 
     $sql = " SELECT keyword,id FROM {$this->tables['keywords']} " .
            " WHERE testproject_id = {$tproject_id} ";


### PR DESCRIPTION
I have the following tl_keywords table:

```
| id | keyword      | project
| 1  | kwTest       | 1
| 2  | @minefield   | 1
| 3  | testlink     | 1
| 4  | minefield    | 1
| 5  | prueba       | 1
| 6  | login        | 1
```

And I make an API request to add keywords to a testcase with this structure:
```
keywords: {
      "GM-5": ["minefield", "prueba", "not_exist", "kwTest"]
    }
```
Without the patch the response is:
```
{ validKeywords: { 'GM-5': ' k  mp' }, status_ok: true }
```
The returning string " k  mp" is getting the first letter of each keyword and assign it in the position related with it ID:
- k: from **kwTest** keyword, id is 1 and the position in string is 1
- m: from **minefield** keyword, id is 4 and the position in string is 4
- p: from **prueba** keyword, id is 5 and the position in string is 5
- _spaces_: unused positions (0, 2, 3)

And also the keywords are not assigned

With the patch the response is:
```
 { validKeywords: { 'GM-5: { '1': 'kwTest', '4': 'minefield', '5': 'prueba' } },
  status_ok: true }
```
And the keywords are assigned