### PR TITLE
Fix postgresql db creation script

### DIFF
--- a/install/sql/postgres/testlink_create_tables.sql
+++ b/install/sql/postgres/testlink_create_tables.sql
@@ -873,17 +873,6 @@ CREATE TABLE /*prefix*/testproject_codetracker (
 
 
 --
---
---
-CREATE TABLE /*prefix*/testproject_codetracker (
-  testproject_id int(10) unsigned NOT NULL,
-  codetracker_id int(10) unsigned NOT NULL,
-  PRIMARY KEY (testproject_id)
-);
-
-
-
---
 -- VIEWS
 --
 CREATE OR REPLACE VIEW /*prefix*/tcases_active AS 


### PR DESCRIPTION
Duplicate table testproject_codetracker with incorrect syntax for postgresql.