### PR TITLE
[Mantis #8565] Add api_key in testplan POST action

### DIFF
--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -189,6 +189,8 @@ class testplan extends tlObjectWithAttachments
     $active_status = intval($item->active) > 0 ? 1 : 0;
     $public_status = intval($item->is_public) > 0 ? 1 : 0;
 
+    $api_key = md5(rand()) . md5(rand());
+
     $id = $this->tree_manager->new_node($item->testProjectID,$this->node_types_descr_id['testplan'],$name);
     $sql = "/* $debugMsg */ " . 
            " INSERT INTO {$this->tables['testplans']} (id,notes,api_key,testproject_id,active,is_public) " .


### PR DESCRIPTION
I simply copied the API key generation performed by the create function slightly further up.

Mantis issue: http://mantis.testlink.org/view.php?id=8565