### PR TITLE
TICKET 0008700: Missing translation for 'tluser_account_expired'

### DIFF
--- a/locale/en_GB/strings.txt
+++ b/locale/en_GB/strings.txt
@@ -2391,7 +2391,7 @@ $TLS_error_ldap_update_failed = "Updating LDAP failed";
 $TLS_error_ldap_user_not_found = "LDAP user not found";
 $TLS_error_ldap_start_tls_failed = "LDAP start TLS failed";
 $TLS_unknown_authentication_method = "Do not know how to handle %s authentication method";
-
+$TLS_tluser_account_expired = "The user account has expired";
 
 // ----- lib/functions/product.inc.php -----
 $TLS_info_product_delete_fails = "An error occurred while deleting the Test Project";


### PR DESCRIPTION
English (GB) translations does not propose a value to the key 'tluser_account_expired'.