### PR TITLE
TICKET 0008658 - xmlrpc - getTestCaseAttachment - fix internal error

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -3638,11 +3638,11 @@ class TestlinkXMLRPCServer extends IXR_Server {
           } catch (Exception $e) {
             return $this->errors;
           }  
-
-          $map = $this->checkTestCaseVersionNumberAncestry();
-          $status_ok = $map["status_ok"];
         }
-
+        
+        $map = $this->checkTestCaseVersionNumberAncestry();
+        $status_ok = $map["status_ok"];
+        
         if($status_ok) {
             $tcvid = $this->tcVersionID;
             $docRepo = tlAttachmentRepository::create( $this->dbObj );


### PR DESCRIPTION
xmlrpc api method getTestCaseAttachment raise an internal server error caused by an invalid sql statement, when calling it with the optional parameter *version*. Calling it just with the mandatory parameter, no error occur.

reason was, that _$this->checkTestCaseVersionNumberAncestry()_ wasn't called in each cases, but it is required to define _$this->tcVersionID_ .