### PR TITLE
Fix MySQL statement ('WHERE' sentence) in getAccessibleTestPlans (tlUser.class.php)

### DIFF
--- a/lib/functions/tlUser.class.php
+++ b/lib/functions/tlUser.class.php
@@ -945,13 +945,13 @@ class tlUser extends tlDBObject {
     
 
     // Construct where sentence
-    $where = " WHERE testproject_id = " . intval($testprojectID) . " AND ";
+    $where = " WHERE testproject_id = " . intval($testprojectID);
     if (!is_null($my['options']['active'])) {
-      $where .= " active = {$my['options']['active']} AND ";
+      $where .= " AND active = {$my['options']['active']}";
     }
   
     if (!is_null($testplanID)) {
-      $where .= " NH.id = " . intval($testplanID) . " AND ";
+      $where .= " AND NH.id = " . intval($testplanID);
     }
     
     $analyseGlobalRole = 1;


### PR DESCRIPTION
Avoid appending 'AND' if there are no further logic conditions.

If any of the checks return a null, the MySQL WHERE sentence will have an 'AND' at the end, which will make it incorrect.