### PR TITLE
import customized theme's frame.css

### DIFF
--- a/gui/templates/dashio/main.tpl
+++ b/gui/templates/dashio/main.tpl
@@ -20,8 +20,8 @@
   <link href="gui/templates/dashio/css/style.css" rel="stylesheet">
   <link href="gui/templates/dashio/css/style-responsive.css" rel="stylesheet">
   <script src="gui/templates/dashio/lib/chart-master/Chart.js"></script>
-<link rel="stylesheet" type="text/css" href="{$basehref}gui/themes/default/css/frame.css">
-  
+<link rel="stylesheet" type="text/css" href="{$basehref}{$tlCfg->theme_dir}css/frame.css">
+
 </head>
 
 <body>

--- a/gui/templates/tl-classic/frmInner.tpl
+++ b/gui/templates/tl-classic/frmInner.tpl
@@ -15,7 +15,7 @@
     	<base href="{$basehref}" />
     	<title>TestLink Inner Frame</title>
     	<style media="all" type="text/css">@import "{$css}";</style>
-    	<link rel="stylesheet" type="text/css" href="{$basehref}gui/themes/default/css/frame.css">
+    	<link rel="stylesheet" type="text/css" href="{$basehref}{$tlCfg->theme_dir}css/frame.css">
     	<script type="text/javascript" src="{$basehref}third_party/jquery/{$smarty.const.TL_JQUERY}" language="javascript"></script>
     	<script type="text/javascript" src="{$basehref}third_party/chosen/chosen.jquery.js"></script>
     	{include file="bootstrap.inc.tpl"}

--- a/gui/templates/tl-classic/main.tpl
+++ b/gui/templates/tl-classic/main.tpl
@@ -15,7 +15,7 @@
 	<link rel="icon" href="{$basehref}{$smarty.const.TL_THEME_IMG_DIR}favicon.ico" type="image/x-icon" />
 
   <!-- for the iframes -->
-  <link rel="stylesheet" type="text/css" href="{$basehref}gui/themes/default/css/frame.css">
+  <link rel="stylesheet" type="text/css" href="{$basehref}{$smarty.const.TL_THEME_CSS_DIR}frame.css">
 
 
 </head>


### PR DESCRIPTION
3 files changed. 
change "...gui/themes/default/css/frame.css" to "...{$tlCfg->theme_dir}css/frame.css"

1. gui/templates/dashio/main.tpl 
```php
# <link rel="stylesheet" type="text/css" href="{$basehref}gui/themes/default/css/frame.css">
<link rel="stylesheet" type="text/css" href="{$basehref}{$tlCfg->theme_dir}css/frame.css">
```
_gui/themes/default/ -> {$tlCfg->theme_dir}_

2.  gui/templates/tl-classic/frmInner.tpl 
```php
# <link rel="stylesheet" type="text/css" href="{$basehref}gui/themes/default/css/frame.css">
<link rel="stylesheet" type="text/css" href="{$basehref}{$tlCfg->theme_dir}css/frame.css">
```
_gui/themes/default/ -> {$tlCfg->theme_dir}_

3.  gui/templates/tl-classic/main.tpl
```php
# <link rel="stylesheet" type="text/css" href="{$basehref}gui/themes/default/css/frame.css">
<link rel="stylesheet" type="text/css" href="{$basehref}{$smarty.const.TL_THEME_CSS_DIR}frame.css">
```
_gui/themes/default/css/ -> {$smarty.const.TL_THEME_CSS_DIR}_