### PR TITLE
Fix php warning

### DIFF
--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -2145,7 +2145,7 @@ class testplan extends tlObjectWithAttachments
         
       $recordset = (array)$this->db->get_recordset($sql);
       $myarray = array();
-      if (count($recordset) > 0) {        
+      if (!is_null($recordset) && count($recordset) > 0) {        
         $myarray = array($recordset[0]);
         $myarray = array_merge($myarray, $this->get_parenttestsuites($recordset[0]['parent_id'])); 
       }


### PR DESCRIPTION
Correct warning when get_recordset returns null