### PR TITLE
Correct php warning

### DIFF
--- a/lib/execute/execHistory.php
+++ b/lib/execute/execHistory.php
@@ -167,7 +167,7 @@ function getCustomFields(&$tcaseMgr,&$execSet)
       $exec_id = $execSet[$tcvid][$idx]['execution_id'];
       $tplan_id = $execSet[$tcvid][$idx]['testplan_id'];
       $dummy = $tcaseMgr->html_table_of_custom_field_values($tcvid,'execution',null,$exec_id,$tplan_id);
-      $cf[$exec_id] = (count($dummy) > 0) ? $dummy : '';
+      $cf[$exec_id] = (($dummy instanceof Countable) && (count($dummy) > 0)) ? $dummy : '';
     } 
   }
   return $cf;


### PR DESCRIPTION
Function html_table_of_custom_field_values may return null.