### PR TITLE
correct php warnings

### DIFF
--- a/lib/functions/object.class.php
+++ b/lib/functions/object.class.php
@@ -587,7 +587,7 @@ abstract class tlDBObject extends tlObject implements iDBSerialization
     
     if (in_array("iDBBulkReadSerialization",class_implements($className)))
       $items = self::bulkCreateObjectsFromDB($db,$ids,$className,$returnAsMap,$detailLevel);
-    else
+    elseif (isset($ids))
     {
       for($i = 0;$i < sizeof($ids);$i++)
       {


### PR DESCRIPTION
We were seeing situations where the $ids parameter was null.