### PR TITLE
Changed OIDC federation behavior in AzureAD

### DIFF
--- a/lib/functions/oauth_api.php
+++ b/lib/functions/oauth_api.php
@@ -21,14 +21,12 @@ function oauth_link($oauthCfg)
       str_replace('http://', 'https://', $oap['redirect_uri']);
   }
 
+  $oap['prompt'] = 'none';
   // see https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code for details
   if ($oauthCfg['oauth_name'] == 'azuread') {
-    $oap['prompt'] = 'login';
     if (!is_null($oauthCfg['oauth_domain']))
       $oap['domain_hint'] = $oauthCfg['oauth_domain'];
   } else {
-
-    $oap['prompt'] = 'none';
     if ($oauthCfg['oauth_force_single']) {
       $oap['prompt'] = 'consent';
     }


### PR DESCRIPTION
When we use Azure AD OIDC prompt parameter, we reduce convenience.
Also, the same behavior as GitHub and Google providers was good.
If the prompt parameter is not specified or set `none`, the behavior becomes like them.

prompt type|feature
---|---
Not specified or `none`|If you have an Azure AD session, use it automatically. User friendly with no login screen.
`login` | End users must log in to the Provider every time, regardless of whether there is them session.
