### PR TITLE
Fix cookie issues with default user selections for project IDs

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -2004,7 +2004,7 @@ $tlCfg->enableTableExportButton = DISABLED;
  * Taken from Mantis to implement better login security, and solve
  * TICKET 4342
  */
-$tlCfg->auth_cookie = "TESTLINK_USER_AUTH_COOKIE";
+$tlCfg->auth_cookie = $tlCfg->cookie->prefix . "TL_USER_AUTH_COOKIE";
 
 /** 
 Used when creating a Test Suite using copy

--- a/lib/functions/common.php
+++ b/lib/functions/common.php
@@ -209,7 +209,7 @@ function setSessionTestPlan($tplan_info) {
     $ckObj = new stdClass();
 
     $ckCfg = config_get('cookie');
-    $ckObj->name = $ckCfg->prefix . 'TL_lastTestPlanForUserID_' . 1;
+    $ckObj->name = $ckCfg->prefix . 'TL_lastTestPlanForUserID_' . $_SESSION['userID'];
     $ckObj->value = $tplan_info['id'];
 
     tlSetCookie($ckObj);

--- a/lib/functions/users.inc.php
+++ b/lib/functions/users.inc.php
@@ -72,7 +72,8 @@ function setUserSession(&$db,$user, $id, $roleID, $email, $locale = null, $activ
       $_SESSION['testprojectID'] = $tpID;
   }
   // Validation is done in navBar.php
-  $tplan_cookie = 'TL_lastTestPlanForUserID_' . $id;
+  $ckCfg = config_get('cookie');
+  $tplan_cookie = $ckCfg->prefix . 'TL_lastTestPlanForUserID_' . $id;
   if (isset($_COOKIE[$tplan_cookie]))
   {
     $_SESSION['testplanID'] = $_COOKIE[$tplan_cookie];


### PR DESCRIPTION
Fix for Issue http://mantis.testlink.org/view.php?id=8697

Fixed issue with cookie not using the right user id (common.php)
Fixed issue with missing prefix (user.inc.php)
Fixed constancy issue with auth cookie not using prefix (config.inc.php)