### PR TITLE
Fix migration 1.9.17

### DIFF
--- a/install/sql/alter_tables/1.9.17/mssql/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/mssql/DB.1.9.17/step1/db_schema_update.sql
@@ -8,42 +8,42 @@
 --
 -- ATTENTION: do not use a different naming convention, that one already in use.
 --            TEXTIMAGE Option can be used only tables that have fields of type:
---            varchar(MAXSIZEALLOWED), nvarchar(MAXSIZEALLOWED), varbinary(MAXSIZEALLOWED), xml 
--- 
+--            varchar(MAXSIZEALLOWED), nvarchar(MAXSIZEALLOWED), varbinary(MAXSIZEALLOWED), xml
+--
 --        Find issue with custom_fields table if two fields were char(4000)
 --        changed to varchar(4000) everything goes OK
 --            http://www.mssqltips.com/sqlservertip/2242/row-sizes-exceeding-8060-bytes-in-sql-2005/
--- 
--- ATTENTION: 
--- 
+--
+-- ATTENTION:
+--
 -- @internal revisions
---                          
+--
 --  -----------------------------------------------------------------------------------
 --
---- 
-CREATE VIEW /*prefix*/latest_tcase_version_number 
-AS SELECT NH_TC.id AS testcase_id,max(TCV.version) AS version 
-FROM /*prefix*/nodes_hierarchy NH_TC 
-JOIN /*prefix*/nodes_hierarchy NH_TCV 
+---
+CREATE VIEW /*prefix*/latest_tcase_version_number
+AS SELECT NH_TC.id AS testcase_id,max(TCV.version) AS version
+FROM /*prefix*/nodes_hierarchy NH_TC
+JOIN /*prefix*/nodes_hierarchy NH_TCV
 ON NH_TCV.parent_id = NH_TC.id
-JOIN /*prefix*/tcversions TCV 
-ON NH_TCV.id = TCV.id 
+JOIN /*prefix*/tcversions TCV
+ON NH_TCV.id = TCV.id
 GROUP BY testcase_id;
 
-CREATE VIEW /*prefix*/latest_req_version 
-AS SELECT RQ.id AS req_id,max(RQV.version) AS version 
-FROM /*prefix*/nodes_hierarchy NHRQV 
-JOIN /*prefix*/requirements RQ 
-ON RQ.id = NHRQV.parent_id 
-JOIN /*prefix*/req_versions RQV 
+CREATE VIEW /*prefix*/latest_req_version
+AS SELECT RQ.id AS req_id,max(RQV.version) AS version
+FROM /*prefix*/nodes_hierarchy NHRQV
+JOIN /*prefix*/requirements RQ
+ON RQ.id = NHRQV.parent_id
+JOIN /*prefix*/req_versions RQV
 ON RQV.id = NHRQV.id
 GROUP BY RQ.id;
 
-CREATE VIEW /*prefix*/latest_rspec_revision 
+CREATE VIEW /*prefix*/latest_rspec_revision
 AS SELECT RSR.parent_id AS req_spec_id, RS.testproject_id AS testproject_id,
-MAX(RSR.revision) AS revision 
-FROM /*prefix*/req_specs_revisions RSR 
-JOIN /*prefix*/req_specs RS 
+MAX(RSR.revision) AS revision
+FROM /*prefix*/req_specs_revisions RSR
+JOIN /*prefix*/req_specs RS
 ON RS.id = RSR.parent_id
 GROUP BY RSR.parent_id,RS.testproject_id;
 
@@ -54,7 +54,7 @@ CREATE TABLE /*prefix*/testcase_script_links (
   code_path varchar(255)  NOT NULL,
   branch_name varchar(64)  NULL,
   commit_id varchar(40)  NULL,
- CONSTRAINT /*prefix*/PK_testcase_script_links PRIMARY KEY CLUSTERED 
+ CONSTRAINT /*prefix*/PK_testcase_script_links PRIMARY KEY CLUSTERED
 (
   tcversion_id ASC,
   project_key ASC,
@@ -69,14 +69,14 @@ CREATE TABLE /*prefix*/codetrackers
   name VARCHAR(100) NOT NULL,
   type int NOT NULL CONSTRAINT /*prefix*/DF_codetrackers_type DEFAULT ((0)),
   cfg nvarchar(max)  NULL,
-  CONSTRAINT /*prefix*/PK_codetrackers PRIMARY KEY  CLUSTERED 
+  CONSTRAINT /*prefix*/PK_codetrackers PRIMARY KEY  CLUSTERED
   (
     id
   )  ON [PRIMARY],
-    CONSTRAINT /*prefix*/UIX_codetrackers UNIQUE NONCLUSTERED 
-   ( 
+    CONSTRAINT /*prefix*/UIX_codetrackers UNIQUE NONCLUSTERED
+   (
   name ASC
-   ) ON [PRIMARY]  
+   ) ON [PRIMARY]
 ) ON [PRIMARY];
 
 
@@ -84,10 +84,10 @@ CREATE TABLE /*prefix*/testproject_codetracker
 (
   testproject_id int NOT NULL,
   codetracker_id int NOT NULL,
-    CONSTRAINT /*prefix*/UIX_testproject_codetracker UNIQUE NONCLUSTERED 
-   ( 
+    CONSTRAINT /*prefix*/UIX_testproject_codetracker UNIQUE NONCLUSTERED
+   (
   testproject_id ASC
-   ) ON [PRIMARY]    
+   ) ON [PRIMARY]
 )ON [PRIMARY];
 
 -- since 1.9.17
@@ -100,7 +100,6 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (54,'exec_assign_testcases'
 
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,29);
-INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,51);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,52);

--- a/install/sql/alter_tables/1.9.17/mysql/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/mysql/DB.1.9.17/step1/db_schema_update.sql
@@ -1,28 +1,28 @@
 /* mysql */
-CREATE VIEW /*prefix*/latest_tcase_version_number 
-AS SELECT NH_TC.id AS testcase_id,max(TCV.version) AS version 
-FROM /*prefix*/nodes_hierarchy NH_TC 
-JOIN /*prefix*/nodes_hierarchy NH_TCV 
+CREATE VIEW /*prefix*/latest_tcase_version_number
+AS SELECT NH_TC.id AS testcase_id,max(TCV.version) AS version
+FROM /*prefix*/nodes_hierarchy NH_TC
+JOIN /*prefix*/nodes_hierarchy NH_TCV
 ON NH_TCV.parent_id = NH_TC.id
-JOIN /*prefix*/tcversions TCV 
-ON NH_TCV.id = TCV.id 
+JOIN /*prefix*/tcversions TCV
+ON NH_TCV.id = TCV.id
 GROUP BY testcase_id;
 
 
-CREATE VIEW /*prefix*/latest_req_version 
-AS SELECT RQ.id AS req_id,max(RQV.version) AS version 
-FROM /*prefix*/nodes_hierarchy NHRQV 
-JOIN /*prefix*/requirements RQ 
-ON RQ.id = NHRQV.parent_id 
-JOIN /*prefix*/req_versions RQV 
+CREATE VIEW /*prefix*/latest_req_version
+AS SELECT RQ.id AS req_id,max(RQV.version) AS version
+FROM /*prefix*/nodes_hierarchy NHRQV
+JOIN /*prefix*/requirements RQ
+ON RQ.id = NHRQV.parent_id
+JOIN /*prefix*/req_versions RQV
 ON RQV.id = NHRQV.id
 GROUP BY RQ.id;
 
-CREATE VIEW /*prefix*/latest_rspec_revision 
+CREATE VIEW /*prefix*/latest_rspec_revision
 AS SELECT RSR.parent_id AS req_spec_id, RS.testproject_id AS testproject_id,
-MAX(RSR.revision) AS revision 
-FROM /*prefix*/req_specs_revisions RSR 
-JOIN /*prefix*/req_specs RS 
+MAX(RSR.revision) AS revision
+FROM /*prefix*/req_specs_revisions RSR
+JOIN /*prefix*/req_specs RS
 ON RS.id = RSR.parent_id
 GROUP BY RSR.parent_id,RS.testproject_id;
 
@@ -64,7 +64,6 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (54,'exec_assign_testcases'
 
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,29);
-INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,51);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,52);

--- a/install/sql/alter_tables/1.9.17/postgres/DB.1.9.17/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.17/postgres/DB.1.9.17/step1/db_schema_update.sql
@@ -1,36 +1,36 @@
 -- TestLink Open Source Project - http://testlink.sourceforge.net/
 -- This script is distributed under the GNU General Public License 2 or later.
 --
--- SQL script - Postgres   
--- 
+-- SQL script - Postgres
 --
-CREATE VIEW /*prefix*/latest_tcase_version_number 
-AS SELECT NH_TC.id AS testcase_id,max(TCV.version) AS version 
-FROM /*prefix*/nodes_hierarchy NH_TC 
-JOIN /*prefix*/nodes_hierarchy NH_TCV 
+--
+CREATE VIEW /*prefix*/latest_tcase_version_number
+AS SELECT NH_TC.id AS testcase_id,max(TCV.version) AS version
+FROM /*prefix*/nodes_hierarchy NH_TC
+JOIN /*prefix*/nodes_hierarchy NH_TCV
 ON NH_TCV.parent_id = NH_TC.id
-JOIN /*prefix*/tcversions TCV 
-ON NH_TCV.id = TCV.id 
+JOIN /*prefix*/tcversions TCV
+ON NH_TCV.id = TCV.id
 GROUP BY testcase_id;
 
-CREATE VIEW /*prefix*/latest_req_version 
-AS SELECT RQ.id AS req_id,max(RQV.version) AS version 
-FROM /*prefix*/nodes_hierarchy NHRQV 
-JOIN /*prefix*/requirements RQ 
-ON RQ.id = NHRQV.parent_id 
-JOIN /*prefix*/req_versions RQV 
+CREATE VIEW /*prefix*/latest_req_version
+AS SELECT RQ.id AS req_id,max(RQV.version) AS version
+FROM /*prefix*/nodes_hierarchy NHRQV
+JOIN /*prefix*/requirements RQ
+ON RQ.id = NHRQV.parent_id
+JOIN /*prefix*/req_versions RQV
 ON RQV.id = NHRQV.id
 GROUP BY RQ.id;
 
-CREATE VIEW /*prefix*/latest_rspec_revision 
+CREATE VIEW /*prefix*/latest_rspec_revision
 AS SELECT RSR.parent_id AS req_spec_id, RS.testproject_id AS testproject_id,
-MAX(RSR.revision) AS revision 
-FROM /*prefix*/req_specs_revisions RSR 
-JOIN /*prefix*/req_specs RS 
+MAX(RSR.revision) AS revision
+FROM /*prefix*/req_specs_revisions RSR
+JOIN /*prefix*/req_specs RS
 ON RS.id = RSR.parent_id
 GROUP BY RSR.parent_id,RS.testproject_id;
 
-CREATE TABLE /*prefix*/testcase_script_links(  
+CREATE TABLE /*prefix*/testcase_script_links(
   "tcversion_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/tcversions (id) ON DELETE CASCADE,
   "project_key" VARCHAR(64) NOT NULL,
   "repository_name" VARCHAR(64) NOT NULL,
@@ -38,7 +38,7 @@ CREATE TABLE /*prefix*/testcase_script_links(
   "branch_name" VARCHAR(64) NULL,
   "commit_id" VARCHAR(40) NULL,
   PRIMARY KEY ("tcversion_id","project_key","repository_name","code_path")
-); 
+);
 
 CREATE TABLE /*prefix*/codetrackers
 (
@@ -68,7 +68,6 @@ INSERT INTO /*prefix*/rights (id,description) VALUES (54,'exec_assign_testcases'
 
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,28);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,29);
-INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,30);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,50);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,51);
 INSERT INTO /*prefix*/role_rights (role_id,right_id) VALUES (8,52);


### PR DESCRIPTION
The combination of `role_id` and `right_id` of 8 and 30 in `role_rights` table already exists in `1.9.16`.
Therefore, a migration that upgrades to `1.9.17` will always fail.

## Refs

- mysql
  - https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/1.9.16/install/sql/mysql/testlink_create_default_data.sql#L121
- mssql
  - https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/1.9.16/install/sql/mssql/testlink_create_default_data.sql#L129
- postgres
  - https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/1.9.16/install/sql/postgres/testlink_create_default_data.sql#L128