### PR TITLE
Change authentication method with OAuth

### DIFF
--- a/lib/functions/doAuthorize.php
+++ b/lib/functions/doAuthorize.php
@@ -58,11 +58,7 @@ function doAuthorize(&$db,$login,$pwd,$options=null) {
     $user = new tlUser();
     $user->login = $login;
     $searchBy = tlUser::USER_O_SEARCH_BYLOGIN;
-    if( $isOauth ) {
-      $user->emailAddress = $login;
-      $searchBy = tlUser::USER_O_SEARCH_BYEMAIL;
-    }
-    $loginExists = ( $user->readFromDB( $db, $searchBy ) >= tl::OK ); 
+    $loginExists = ( $user->readFromDB( $db, $searchBy ) >= tl::OK );
   }
 
   if( $loginExists ) {
@@ -146,11 +142,6 @@ function doAuthorize(&$db,$login,$pwd,$options=null) {
     $user = new tlUser();
     $user->login = $login;
     $searchBy = tlUser::USER_O_SEARCH_BYLOGIN;
-    if( $isOauth ) {
-      $user->emailAddress = $login;
-      $user->login = null;
-      $searchBy = tlUser::USER_O_SEARCH_BYEMAIL;
-    }
     $user->readFromDB($db,$searchBy);
 
     // Need to do set COOKIE following Mantis model


### PR DESCRIPTION
## What I did

When using OAuth, I changed OAuth login specification like testlink users are linked by login column data instead of email column.

## Motivation

Currently, when using OAuth, users are associated using the data in the email column of the users table.
This has several disadvantages.

1. End users can freely change their email address.
  - End users can impersonate another user at their will.
2. The email address has no unique guarantee.
  - User must be authenticated with a unique value.