### PR TITLE
Fix no step results in printview

### DIFF
--- a/lib/functions/print.inc.php
+++ b/lib/functions/print.inc.php
@@ -893,7 +893,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
 
 
   static $st;
-  
+  static $statusL10N;
   static $labels;
   static $tcase_prefix;
   static $userMap = array();


### PR DESCRIPTION
In generated "Test report on build" report did not show execution step status.
This pull request fix this. 