### PR TITLE
TICKET 0008842: "Create Key Word" in a TestCase Open a white page with "true" message

### DIFF
--- a/gui/javascript/testlink_library.js
+++ b/gui/javascript/testlink_library.js
@@ -105,7 +105,6 @@ function open_popup(page) {
                 "toolbar=no,status=no,menubar=no,scrollbars=yes,directories=no,location=no," +
                 "width=600,height=500";
   window.open(page, "_blank",windowCfg);
-  return true;
 }
 
 // test specification related functions


### PR DESCRIPTION

Remove the return of the function to avoid a blank page displaying 'true' with Firefox.