### PR TITLE
Same logic of modification timestamps for new revision as for new ver…

### DIFF
--- a/lib/functions/requirement_mgr.class.php
+++ b/lib/functions/requirement_mgr.class.php
@@ -2973,14 +2973,8 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
       $sql = " /* $debugMsg */ " .
              " UPDATE {$this->tables['req_versions']} " .
              " SET revision = {$new_rev}, log_message=' " . $this->db->prepare_string($log_msg) . "'," .
-             " creation_ts = {$db_now} ,author_id = {$user_id}, modifier_id = NULL";
-              
-      $nullTS = $this->db->db_null_timestamp();
-      if(!is_null($nullTS))
-      {
-        $sql .= ",modification_ts = {$nullTS} ";
-      }  
-      
+             " creation_ts = {$db_now} ,author_id = {$user_id}, modifier_id = {$user_id}, modification_ts = {$db_now}";
+
       $sql .=  " WHERE id = {$parent_id} ";
       $this->db->exec_query($sql);
       return $ret;


### PR DESCRIPTION
As explained in http://mantis.testlink.org/view.php?id=8731#c29423 there are reasons to set creation and modification date both to now on creation. If in future modification (no new revision) is done, the values will start to diverge from the creation ones.
ToDo: Check for side effects