### PR TITLE
fix TICKET 0008851: Create and Link an existing keywork fails with a DB error

### DIFF
--- a/lib/functions/testproject.class.php
+++ b/lib/functions/testproject.class.php
@@ -1140,15 +1140,20 @@ function setPublicStatus($id,$status)
    **/
   public function addKeyword($testprojectID,$keyword,$notes) {
     $kw = new tlKeyword();
-    $kw->initialize(null,$testprojectID,$keyword,$notes);
-    $op = array('status' => tlKeyword::E_DBERROR, 'id' => -1, 
-                'msg' => 'ko DB Error');
-    $op['status'] = $kw->writeToDB($this->db);
-    if ($op['status'] >= tl::OK) {
-      $op['id'] = $kw->dbID;
-      logAuditEvent(TLS("audit_keyword_created",$keyword),"CREATE",$op['id'],"keywords");
+
+    if ( $kw->getByName($this->db, $keyword, $testprojectID) ) {
+        $op = array('status' => tl::OK, 'id' => $kw->dbID);
     } else {
-      $op['msg'] = tlKeyword::getError($op['status']);
+        $kw->initialize(null,$testprojectID,$keyword,$notes);
+        $op = array('status' => tlKeyword::E_DBERROR, 'id' => -1,
+                    'msg' => 'ko DB Error');
+        $op['status'] = $kw->writeToDB($this->db);
+        if ($op['status'] >= tl::OK) {
+            $op['id'] = $kw->dbID;
+            logAuditEvent(TLS("audit_keyword_created",$keyword),"CREATE",$op['id'],"keywords");
+        } else {
+            $op['msg'] = tlKeyword::getError($op['status']);
+        }
     }
 
     return $op;

--- a/lib/functions/tlKeyword.class.php
+++ b/lib/functions/tlKeyword.class.php
@@ -280,6 +280,36 @@ class tlKeyword extends tlDBObject implements iSerialization,iSerializationToXML
   }
 
   /**
+   * create a keyword by a given name
+   *
+   * @param resource $db [ref] the database connection
+   * @param string $name the name of the keyword
+   * @param integer $tprojectID the testprojectID
+   * @param integer $kwID an additional keyword id which is excluded in the search
+   * @return tlKeyword the created keyword on success, or null else
+   */
+  public function getByName(&$db, $name, $tprojectID, $kwID = null) {
+    $result = null;
+    $tables = tlObjectWithDB::getDBTables("keywords");
+
+    $name = $db->prepare_string(strtoupper($name));
+    $query = " SELECT id, notes FROM {$tables['keywords']}
+               WHERE UPPER(keyword) ='{$name}'
+               AND testproject_id = " . $tprojectID ;
+
+    if ($kwID) {
+      $query .= " AND id <> " .$kwID;
+    }
+
+    $kw = $db->fetchFirstRow($query);
+    if ($kw) {
+        $this->initialize($kw['id'], $tprojectID, $name, $kw['notes']);
+        $result = $this;
+    }
+    return $result;
+  }
+
+  /**
    * currently not implemented
    * 
    * @param resource $db 


### PR DESCRIPTION
If we ask to add an existing keyword, return its ID rather than return -1.