### PR TITLE
Ticket-8852: xmlrpc test execution attachment upload returning error

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -5088,7 +5088,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $uploadOp = $docRepo->insertAttachment( $fkId, $fkTable, $title, $fInfo );
             
 
-            if($uploaOp->statusOK == false) {
+            if($uploadOp->statusOK == false) {
               $msg = $msg_prefix . ATTACH_DB_WRITE_ERROR_STR;
               $this->errors[] = new IXR_ERROR( ATTACH_DB_WRITE_ERROR, $msg );
               $statusOK = false;


### PR DESCRIPTION
Typo causes xmlrpc test execution attachment upload to return error.