### PR TITLE
1.9.20 fix mysql schema update

### DIFF
--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -61,6 +61,26 @@ CREATE TABLE /*prefix*/baseline_l1l2_details (
   UNIQUE KEY udx1 (context_id,top_tsuite_id,child_tsuite_id,status)
 ) DEFAULT CHARSET=utf8;
 
+CREATE TABLE /*prefix*/execution_tcsteps_wip (
+  id int(10) unsigned NOT NULL auto_increment,
+  tcstep_id int(10) unsigned NOT NULL default '0',
+  testplan_id int(10) unsigned NOT NULL default '0',
+  platform_id int(10) unsigned NOT NULL default '0',
+  build_id int(10) unsigned NOT NULL default '0',
+  tester_id int(10) unsigned default NULL,
+  creation_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  notes text,
+  status char(1) default NULL,
+  PRIMARY KEY  (id),
+  UNIQUE KEY /*prefix*/execution_tcsteps_wip_idx1(`tcstep_id`,`testplan_id`,`platform_id`,`build_id`)
+) DEFAULT CHARSET=utf8;
+
+ALTER TABLE /*prefix*/milestones MODIFY target_date date NOT NULL;
+ALTER TABLE /*prefix*/milestones MODIFY start_date date DEFAULT NULL;
+
+ALTER TABLE /*prefix*/platforms MODIFY enable_on_design tinyint(1) unsigned NOT NULL default '0';
+ALTER TABLE /*prefix*/platforms MODIFY enable_on_execution tinyint(1) unsigned NOT NULL default '1';
+
 #
 CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_testplan 
 AS SELECT tcversion_id, testplan_id, MAX(id) AS id 

--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -45,7 +45,7 @@ CREATE TABLE /*prefix*/baseline_l1l2_context (
   end_exec_ts timestamp NOT NULL,
   creation_ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
-  UNIQUE KEY udx1 (testplan_id,platform_id,creation_ts),
+  UNIQUE KEY udx1 (testplan_id,platform_id,creation_ts)
 ) DEFAULT CHARSET=utf8;
 
 

--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -18,7 +18,7 @@ ALTER TABLE /*prefix*/builds ADD COLUMN branch varchar(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN release_candidate varchar(100) NULL;
 
 --
-ALTER TABLE /*prefix*/users MODIFY password VARCHAR(255);
+ALTER TABLE /*prefix*/users MODIFY password VARCHAR(255) NOT NULL DEFAULT '';
 
 -- 
 ALTER TABLE /*prefix*/testplan_platforms ADD COLUMN active tinyint(1) NOT NULL default '1';


### PR DESCRIPTION
I compared a MySQL TestLink database schema created in 1.9.19 and migrated to 1.9.20 to a schema created in 1.9.20 and modified the install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql file accordingly, so that mysqldump of the structure will show exactly the same.

Attached is the bash script I used to create the user and databases and make the comparison.

[db_test.sh.txt](https://github.com/TestLinkOpenSourceTRMS/testlink-code/files/4116481/db_test.sh.txt)


