### PR TITLE
Fixed tables creation error

### DIFF
--- a/install/sql/mysql/testlink_create_tables.sql
+++ b/install/sql/mysql/testlink_create_tables.sql
@@ -802,8 +802,8 @@ CREATE TABLE /*prefix*/baseline_l1l2_context (
   id int(10) unsigned NOT NULL AUTO_INCREMENT,
   testplan_id int(10) unsigned NOT NULL DEFAULT '0',
   platform_id int(10) unsigned NOT NULL DEFAULT '0',
-  being_exec_ts timestamp NOT NULL,
-  end_exec_ts timestamp NOT NULL,
+  being_exec_ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  end_exec_ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   creation_ts timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   UNIQUE KEY udx1 (testplan_id,platform_id,creation_ts)


### PR DESCRIPTION
Hi,
The mysql tables script was failing due to error
ERROR 1067 (42000) at line 801: Invalid default value for 'end_exec_ts'
This change fix the issue
Thanks