### PR TITLE
Fix error on non existent test case version

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -3170,7 +3170,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $sql = " SELECT TCV.version,TCV.id " . " FROM {$this->tables['nodes_hierarchy']} NH, {$this->tables['tcversions']} TCV " . " WHERE NH.parent_id = {$tcase_id} " . " AND TCV.version = {$version_number} " . " AND TCV.id = NH.id ";
 
             $target_tcversion = $this->dbObj->fetchRowsIntoMap( $sql, 'version' );
-            if(! is_null( $target_tcversion ) && count( $target_tcversion ) != 1) {
+            if(is_null( $target_tcversion ) || count( $target_tcversion ) != 1) {
                 $status_ok = false;
                 $tcase_info = $this->tcaseMgr->get_by_id( $tcase_id );
                 $msg = sprintf( TCASE_VERSION_NUMBER_KO_STR, $version_number, $tcase_external_id, $tcase_info[0]['name'] );


### PR DESCRIPTION
With original code passing an invalid version to addTestCaseToTestPlan leads to bad response and the log entry:
	ERROR ON exec_query() - database.class.php <br />1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '1,'2020-03-21 14:48:27',1)' at line 1 - INSERT INTO testplan_tcversions(testplan_id,tcversion_id,author_id,creation_ts,node_order) VALUES(4,,1,'2020-03-21 14:48:27',1)<br />THE MESSAGE : INSERT INTO testplan_tcversions(testplan_id,tcversion_id,author_id,creation_ts,node_order) VALUES(4,,1,'2020-03-21 14:48:27',1) Query failed: errorcode[1064] errormsg:You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '1,'2020-03-21 14:48:27',1)' at line 1