### PR TITLE
Fix mysql and postgres migration script of 1.9.20

### DIFF
--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -3,15 +3,15 @@
 # ---------------------------------------------------------------------------------------
 # @filesource db_schema_update.sql
 #
-# SQL script - updates DB schema for MySQL - 
+# SQL script - updates DB schema for MySQL -
 # From TestLink 1.9.19 to 1.9.20
-# 
+#
 #
 -- since 1.9.20
 INSERT INTO /*prefix*/rights (id,description) VALUES (55,'testproject_add_remove_keywords_executed_tcversions');
 INSERT INTO /*prefix*/rights (id,description) VALUES (56,'delete_frozen_tcversion');
 
--- 
+--
 ALTER TABLE /*prefix*/builds ADD COLUMN commit_id varchar(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN tag varchar(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN branch varchar(64) NULL;
@@ -20,7 +20,7 @@ ALTER TABLE /*prefix*/builds ADD COLUMN release_candidate varchar(100) NULL;
 --
 ALTER TABLE /*prefix*/users MODIFY password VARCHAR(255) NOT NULL default '';
 
--- 
+--
 ALTER TABLE /*prefix*/testplan_platforms ADD COLUMN active tinyint(1) NOT NULL default '1';
 ALTER TABLE /*prefix*/platforms ADD COLUMN enable_on_design tinyint(1) unsigned NOT NULL default '0';
 ALTER TABLE /*prefix*/platforms ADD COLUMN enable_on_execution tinyint(1) unsigned NOT NULL default '1';
@@ -32,7 +32,7 @@ ALTER TABLE /*prefix*/testcase_keywords ADD INDEX /*prefix*/idx02_testcase_keywo
 ALTER TABLE /*prefix*/milestones MODIFY target_date date NOT NULL;
 ALTER TABLE /*prefix*/milestones MODIFY start_date date DEFAULT NULL;
 
--- 
+--
 CREATE TABLE /*prefix*/execution_tcsteps_wip (
    id int(10) unsigned NOT NULL auto_increment,
    tcstep_id int(10) unsigned NOT NULL default '0',
@@ -84,15 +84,15 @@ CREATE TABLE /*prefix*/baseline_l1l2_details (
 ) DEFAULT CHARSET=utf8;
 
 #
-CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_testplan 
-AS SELECT tcversion_id, testplan_id, MAX(id) AS id 
-FROM /*prefix*/executions 
+CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_testplan
+AS SELECT tcversion_id, testplan_id, MAX(id) AS id
+FROM /*prefix*/executions
 GROUP BY tcversion_id,testplan_id;
 
 #
 CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_context
 AS SELECT tcversion_id, testplan_id,build_id,platform_id,max(id) AS id
-FROM /*prefix*/executions 
+FROM /*prefix*/executions
 GROUP BY tcversion_id,testplan_id,build_id,platform_id;
 
 
@@ -100,40 +100,40 @@ CREATE OR REPLACE VIEW /*prefix*/tcversions_without_platforms
 AS SELECT
    NHTCV.parent_id AS testcase_id,
    NHTCV.id AS id
-FROM /*prefix*/nodes_hierarchy NHTCV 
+FROM /*prefix*/nodes_hierarchy NHTCV
 WHERE NHTCV.node_type_id = 4 AND
 NOT(EXISTS(SELECT 1 FROM /*prefix*/testcase_platforms TCPL
            WHERE TCPL.tcversion_id = NHTCV.id));
 
 CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_testplan_plat
 AS SELECT tcversion_id, testplan_id,platform_id,max(id) AS id
-FROM /*prefix*/executions 
+FROM /*prefix*/executions
 GROUP BY tcversion_id,testplan_id,platform_id;
 
 #
 CREATE OR REPLACE VIEW /*prefix*/tsuites_tree_depth_2
 AS SELECT TPRJ.prefix,
-NHTPRJ.name AS testproject_name,    
+NHTPRJ.name AS testproject_name,
 NHTS_L1.name AS level1_name,
 NHTS_L2.name AS level2_name,
-NHTPRJ.id AS testproject_id, 
-NHTS_L1.id AS level1_id, 
-NHTS_L2.id AS level2_id 
-FROM /*prefix*/testprojects TPRJ 
-JOIN /*prefix*/nodes_hierarchy NHTPRJ 
+NHTPRJ.id AS testproject_id,
+NHTS_L1.id AS level1_id,
+NHTS_L2.id AS level2_id
+FROM /*prefix*/testprojects TPRJ
+JOIN /*prefix*/nodes_hierarchy NHTPRJ
 ON TPRJ.id = NHTPRJ.id
-LEFT OUTER JOIN /*prefix*/nodes_hierarchy NHTS_L1 
+LEFT OUTER JOIN /*prefix*/nodes_hierarchy NHTS_L1
 ON NHTS_L1.parent_id = NHTPRJ.id
 LEFT OUTER JOIN /*prefix*/nodes_hierarchy NHTS_L2
-ON NHTS_L2.parent_id = NHTS_L1.id 
-WHERE NHTPRJ.node_type_id = 1 
+ON NHTS_L2.parent_id = NHTS_L1.id
+WHERE NHTPRJ.node_type_id = 1
 AND NHTS_L1.node_type_id = 2
 AND NHTS_L2.node_type_id = 2;
 
 ##
-CREATE OR REPLACE VIEW /*prefix*/exec_by_date_time 
+CREATE OR REPLACE VIEW /*prefix*/exec_by_date_time
 AS (
-SELECT NHTPL.name AS testplan_name, 
+SELECT NHTPL.name AS testplan_name,
 DATE_FORMAT(E.execution_ts, '%Y-%m-%d') AS yyyy_mm_dd,
 DATE_FORMAT(E.execution_ts, '%Y-%m') AS yyyy_mm,
 DATE_FORMAT(E.execution_ts, '%H') AS hh,

--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -7,10 +7,6 @@
 # From TestLink 1.9.19 to 1.9.20
 #
 #
--- since 1.9.20
-INSERT INTO /*prefix*/rights (id,description) VALUES (55,'testproject_add_remove_keywords_executed_tcversions');
-INSERT INTO /*prefix*/rights (id,description) VALUES (56,'delete_frozen_tcversion');
-
 --
 ALTER TABLE /*prefix*/builds ADD COLUMN commit_id varchar(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN tag varchar(64) NULL;

--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -22,8 +22,8 @@ ALTER TABLE /*prefix*/users MODIFY password VARCHAR(255) NOT NULL default '';
 
 -- 
 ALTER TABLE /*prefix*/testplan_platforms ADD COLUMN active tinyint(1) NOT NULL default '1';
-ALTER TABLE /*prefix*/platforms ADD COLUMN  enable_on_design tinyint(1) NOT NULL default '0';
-ALTER TABLE /*prefix*/platforms ADD COLUMN  enable_on_execution tinyint(1) NOT NULL default '1';
+ALTER TABLE /*prefix*/platforms ADD COLUMN enable_on_design tinyint(1) unsigned NOT NULL default '0';
+ALTER TABLE /*prefix*/platforms ADD COLUMN enable_on_execution tinyint(1) unsigned NOT NULL default '1';
 
 --
 ALTER TABLE /*prefix*/nodes_hierarchy ADD INDEX /*prefix*/nodes_hierarchy_node_type_id (node_type_id);

--- a/install/sql/alter_tables/1.9.20/postgres/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/postgres/DB.1.9.20/step1/db_schema_update.sql
@@ -3,16 +3,12 @@
 --
 -- SQL script - Postgres
 
--- since 1.9.20
-INSERT INTO /*prefix*/rights (id,description) VALUES (55,'testproject_add_remove_keywords_executed_tcversions');
-INSERT INTO /*prefix*/rights (id,description) VALUES (56,'delete_frozen_tcversion');
-
 ALTER TABLE /*prefix*/builds ADD COLUMN commit_id VARCHAR(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN tag VARCHAR(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN branch VARCHAR(64) NULL;
 ALTER TABLE /*prefix*/builds ADD COLUMN release_candidate VARCHAR(100) NULL;
 
--- 
+--
 ALTER TABLE /*prefix*/users ALTER COLUMN password TYPE VARCHAR(255);
 
 --
@@ -23,18 +19,18 @@ ALTER TABLE /*prefix*/platforms ADD COLUMN enable_on_execution INT2 NOT NULL DEF
 --
 -- Table structure for table "testcase_platforms"
 --
-CREATE TABLE /*prefix*/testcase_platforms( 
-  "id" BIGSERIAL NOT NULL , 
+CREATE TABLE /*prefix*/testcase_platforms(
+  "id" BIGSERIAL NOT NULL ,
   "testcase_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/nodes_hierarchy (id),
   "tcversion_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/tcversions (id),
   "platform_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/platforms (id) ON DELETE CASCADE,
   PRIMARY KEY ("id")
-); 
+);
 CREATE UNIQUE INDEX /*prefix*/idx01_testcase_platforms ON /*prefix*/testcase_platforms ("testcase_id","tcversion_id","platform_id");
 CREATE INDEX /*prefix*/idx02_testcase_platforms ON /*prefix*/testcase_platforms ("tcversion_id");
 
 CREATE TABLE /*prefix*/baseline_l1l2_context (
-  "id" BIGSERIAL NOT NULL , 
+  "id" BIGSERIAL NOT NULL ,
   "testplan_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/testplans (id),
   "platform_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/platforms (id) ON DELETE CASCADE,
   "being_exec_ts" timestamp NOT NULL,
@@ -46,7 +42,7 @@ CREATE UNIQUE INDEX /*prefix*/udx1 ON /*prefix*/baseline_l1l2_context ("testplan
 
 
 CREATE TABLE /*prefix*/baseline_l1l2_details (
-  "id" BIGSERIAL NOT NULL , 
+  "id" BIGSERIAL NOT NULL ,
   "context_id" BIGINT NOT NULL DEFAULT '0' REFERENCES  /*prefix*/baseline_l1l2_context (id),
   "top_tsuite_id" BIGINT NOT NULL DEFAULT '0'  REFERENCES  /*prefix*/testsuites (id),
   "child_tsuite_id" BIGINT NOT NULL DEFAULT '0'  REFERENCES  /*prefix*/testsuites (id),
@@ -55,26 +51,26 @@ CREATE TABLE /*prefix*/baseline_l1l2_details (
   "total_tc" INT NOT NULL DEFAULT '0',
   PRIMARY KEY ("id")
 ) ;
-CREATE UNIQUE INDEX /*prefix*/udx1 
+CREATE UNIQUE INDEX /*prefix*/udx1
 ON /*prefix*/baseline_l1l2_details ("context_id","top_tsuite_id","child_tsuite_id","status");
 
 
 
--- 
 --
-CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_testplan AS 
-( 
-  SELECT tcversion_id, testplan_id, MAX(id) AS id 
-  FROM /*prefix*/executions 
+--
+CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_testplan AS
+(
+  SELECT tcversion_id, testplan_id, MAX(id) AS id
+  FROM /*prefix*/executions
   GROUP BY tcversion_id,testplan_id
-);  
+);
 --
 
 --
-CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_context AS 
+CREATE OR REPLACE VIEW /*prefix*/latest_exec_by_context AS
 (
   SELECT tcversion_id, testplan_id,build_id,platform_id,max(id) AS id
-  FROM /*prefix*/executions 
+  FROM /*prefix*/executions
   GROUP BY tcversion_id,testplan_id,build_id,platform_id
 );
 
@@ -85,39 +81,39 @@ CREATE INDEX /*prefix*/idx02_testcase_keywords ON /*prefix*/testcase_keywords ("
 
 --
 --
-CREATE OR REPLACE VIEW /*prefix*/tcversions_without_platforms AS 
-( 
+CREATE OR REPLACE VIEW /*prefix*/tcversions_without_platforms AS
+(
   SELECT NHTCV.parent_id AS testcase_id, NHTCV.id AS id
-  FROM /*prefix*/nodes_hierarchy NHTCV 
-  WHERE NHTCV.node_type_id = 4 
+  FROM /*prefix*/nodes_hierarchy NHTCV
+  WHERE NHTCV.node_type_id = 4
   AND NOT(EXISTS(SELECT 1 FROM /*prefix*/testcase_platforms TCPL
                  WHERE TCPL.tcversion_id = NHTCV.id ) )
 );
 
-CREATE OR REPLACE VIEW /*prefix*/tsuites_tree_depth_2 AS 
+CREATE OR REPLACE VIEW /*prefix*/tsuites_tree_depth_2 AS
 (
   SELECT TPRJ.prefix,
-  NHTPRJ.name AS testproject_name,    
+  NHTPRJ.name AS testproject_name,
   NHTS_L1.name AS level1_name,
   NHTS_L2.name AS level2_name,
-  NHTPRJ.id AS testproject_id, 
-  NHTS_L1.id AS level1_id, 
-  NHTS_L2.id AS level2_id 
-  FROM /*prefix*/testprojects TPRJ 
-  JOIN /*prefix*/nodes_hierarchy NHTPRJ 
+  NHTPRJ.id AS testproject_id,
+  NHTS_L1.id AS level1_id,
+  NHTS_L2.id AS level2_id
+  FROM /*prefix*/testprojects TPRJ
+  JOIN /*prefix*/nodes_hierarchy NHTPRJ
   ON TPRJ.id = NHTPRJ.id
-  LEFT OUTER JOIN /*prefix*/nodes_hierarchy NHTS_L1 
+  LEFT OUTER JOIN /*prefix*/nodes_hierarchy NHTS_L1
   ON NHTS_L1.parent_id = NHTPRJ.id
   LEFT OUTER JOIN /*prefix*/nodes_hierarchy NHTS_L2
-  ON NHTS_L2.parent_id = NHTS_L1.id 
-  WHERE NHTPRJ.node_type_id = 1 
+  ON NHTS_L2.parent_id = NHTS_L1.id
+  WHERE NHTPRJ.node_type_id = 1
   AND NHTS_L1.node_type_id = 2
   AND NHTS_L2.node_type_id = 2
 );
 
-CREATE OR REPLACE VIEW /*prefix*/exec_by_date_time 
+CREATE OR REPLACE VIEW /*prefix*/exec_by_date_time
 AS (
-SELECT NHTPL.name AS testplan_name, 
+SELECT NHTPL.name AS testplan_name,
 TO_CHAR(E.execution_ts, 'YYYY-MM-DD') AS yyyy_mm_dd,
 TO_CHAR(E.execution_ts, 'YYYY-MM') AS yyyy_mm,
 TO_CHAR(E.execution_ts, 'HH24') AS hh,


### PR DESCRIPTION
## What happened

- The result of migration sql is not equivalent to `testlink_create_tables`
- Error occurs during migration when upgrading

## Survey results

The mysql migration script from 1.9.19 to 1.9.20 expects https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/b3004c6fa1b7cfcb61023b339f95212d706d9a11/install/sql/mysql/testlink_create_tables.sql#L334-L335.
However,`platforms.enable_on_design` and `platforms.enable_on_execution` are not migrating correctly.

Since
https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/testlink_1_9/install/sql/postgres/testlink_create_default_data.sql
or
https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/testlink_1_9/install/sql/mysql/testlink_create_default_data.sql
is executed by https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/testlink_1_9/install/installNewDB.php.
When executed in the migration script, it will be 

```
Error executing 'postInstallation': MySQL command failed to run. Error:
  ERROR 1062 (23000) at line 11: Duplicate entry '55' for key 'PRIMARY'
```

## Impacted area

This affects all users who are using `1.9.19` and below and upgrading to `1.9.20`.
Users using from `1.9.20` are not affected.

## What did I do

- Change the settings for `platforms.enable_on_design` and `platforms.enable_on_execution` columns in `db_schema_update.sql`.
- Remove inserting data into the `rights` table in `db_schema_update.sql`

---

Covered https://github.com/TestLinkOpenSourceTRMS/testlink-code/pull/251