### PR TITLE
fix: Keyword assignment not available, for user with specific role in test project

### DIFF
--- a/lib/keywords/keywordsAssign.php
+++ b/lib/keywords/keywordsAssign.php
@@ -226,14 +226,14 @@ function initializeGui(&$argsObj) {
   $guiObj->keyword_assignment_subtitle = null;
 
   $guiObj->canAddRemoveKWFromExecuted = 
-    $argsObj->user->hasRight($db,
+    $argsObj->user->hasRightOnProj($db,
     'testproject_add_remove_keywords_executed_tcversions') ||
-    $argsObj->user->hasRight($db,'testproject_edit_executed_testcases');
+    $argsObj->user->hasRightOnProj($db,'testproject_edit_executed_testcases');
 
   return $guiObj;
 }
 
 
 function checkRights(&$db,&$user) {
-  return $user->hasRight($db,'keyword_assignment');
+  return $user->hasRightOnProj($db,'keyword_assignment');
 }


### PR DESCRIPTION
Steps to reproduce:
As a project leader,
1. Click on the menu 'Assign Keywords' on the desktop
2. Click on a test suite
-> We go back on the desktop

Error message:
 [>>][5f6b68e8ba376820682569][DEFAULT][/lib/keywords/keywordsAssign.php][20/Sep/23 15:25:28]
	[20/Sep/23 15:25:28][AUDIT][u2qi8itork3l96sq193ci98ut9][GUI - Projet ID : 92]
		User 'atisne' has insufficient rights for 'any' action on 'keywordsAssign.php'! Exit forced!