### PR TITLE
avoid unauthorized access to getIssueTrackerSystem

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -8109,7 +8109,15 @@ class TestlinkXMLRPCServer extends IXR_Server {
 
         $extCall = is_null( $call );
         if($extCall) {
-            $this->authenticate();
+            $status_ok = $this->authenticate();
+            if(! $status_ok) {
+                return $this->errors;
+            }
+            if(! $this->userHasRight( "issuetracker_view", self::CHECK_PUBLIC_PRIVATE_ATTR )) {
+                $msg = sprintf( INSUFFICIENT_RIGHTS_STR );
+                $this->errors[] = new IXR_Error( INSUFFICIENT_RIGHTS, $msg_prefix . $msg );
+                return $this->errors;
+            }
         }
 
         $ret = null;


### PR DESCRIPTION
I think the function getIssueTrackerSystem exposed by the xmlrpc has two issues, which I hope to improve with this request:
1. the return value of authenticate() is not checked, therefore even with wrong dev key the issue tracker data is sent out, leaking e.g. credentials for the issue tracker to anyone
2. a check if the user has the permission to view issue tracker info was missing