### PR TITLE
fix: #0009038: Make the 'Requirements based report' compliant with new link implementation between requirements and test cases

### DIFF
--- a/lib/results/resultsReqs.php
+++ b/lib/results/resultsReqs.php
@@ -302,7 +302,7 @@ if (count($rspecSet))
                               '[' . $pname . $status_l10n . ']</span>';
 
             
-            $tc_name = $prefix . $ltcase['tc_external_id'] . $title_sep . $ltcase['name'];
+            $tc_name = $prefix . $ltcase['tc_external_id'] . $title_sep . $ltcase['name'] . " v" . $ltcase['version'];
             
             $exec_history_link = "<a href=\"javascript:openExecHistoryWindow({$tc_id});\">" .
                                  "<img title=\"{$labels['execution_history']}\" " .
@@ -762,12 +762,17 @@ function buildReqSpecMap($reqSet,&$reqMgr,&$reqSpecMgr,&$tplanMgr,$reqStatusFilt
         $rspec[$req['srs_id']]['requirements'] = array();
       }
 
-      $req['linked_testcases'] = (array)$reqMgr->get_coverage($id,$coverageContext,array('accessKey' => 'tcase_id'));
+      $req['linked_testcases'] = (array)$reqMgr->getActiveForReqVersion($req['version_id']);
 
-      // Now loop to mark test cases ASSIGNED to requirements as LINKED OR NOT to Test plan under analisys.
+      // Now loop to mark test cases ASSIGNED to requirements as LINKED OR NOT to Test plan under analysis.
+      // and exclude obsolete TC
       foreach($req['linked_testcases'] as $itemID => $dummy)
       {
-        $req['linked_testcases'][$itemID]['in_testplan'] = isset($itemsInTestPlan[$itemID]);  
+        if ($dummy['is_obsolete'] == "0") {
+          $req['linked_testcases'][$itemID]['in_testplan'] = isset($itemsInTestPlan[$itemID]);
+        } else {
+          unset($req['linked_testcases'][$itemID]);
+        }
       }  
 
       $rspec[$req['srs_id']]['requirements'][$id] = $req;

--- a/lib/results/resultsReqs.php
+++ b/lib/results/resultsReqs.php
@@ -753,7 +753,6 @@ function buildReqSpecMap($reqSet,&$reqMgr,&$reqSpecMgr,&$tplanMgr,$reqStatusFilt
     if( in_array($req['status'], $reqStatusFilter, true) || 
         in_array("0", $reqStatusFilter, true) ) 
     {
-      $total++;
       
       // some sort of Caching
       if (!isset($rspec[$req['srs_id']])) 
@@ -764,22 +763,23 @@ function buildReqSpecMap($reqSet,&$reqMgr,&$reqSpecMgr,&$tplanMgr,$reqStatusFilt
 
       $req['linked_testcases'] = (array)$reqMgr->getActiveForReqVersion($req['version_id']);
 
-      // Now loop to mark test cases ASSIGNED to requirements as LINKED OR NOT to Test plan under analysis.
-      // and exclude obsolete TC
+      // Exclude obsolete TC or TC not linked to test plan under analysis
       foreach($req['linked_testcases'] as $itemID => $dummy)
       {
-        if ($dummy['is_obsolete'] == "0") {
-          $req['linked_testcases'][$itemID]['in_testplan'] = isset($itemsInTestPlan[$itemID]);
-        } else {
+        if ($dummy['is_obsolete'] == "1" || ! isset($itemsInTestPlan[$dummy['id']]) ) {
           unset($req['linked_testcases'][$itemID]);
         }
       }  
 
-      $rspec[$req['srs_id']]['requirements'][$id] = $req;
+      // if there is linked (active) test case
+      if (count($req['linked_testcases']) > 0) {
+        $total++;
+        $rspec[$req['srs_id']]['requirements'][$id] = $req;
 
-      foreach ($req['linked_testcases'] as $tc) 
-      {
-        $tc_ids[] = $tc['id'];
+        foreach ($req['linked_testcases'] as $tc) 
+        {
+          $tc_ids[] = $tc['id'];
+        }
       }
     }
   }


### PR DESCRIPTION
Due to 1.9.18 changes concerning links between requirements and test cases, we change the report to work at version level.