### PR TITLE
fix: #0009039: Use the (XMLRPC) API to get requirements coverage matrix

### DIFF
--- a/lib/api/xmlrpc/v1/sample_clients/php/clientGetReqCoverage.php
+++ b/lib/api/xmlrpc/v1/sample_clients/php/clientGetReqCoverage.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * TestLink Open Source Project - http://testlink.sourceforge.net/
+ * This script is distributed under the GNU General Public License 2 or later.
+ *
+ * @filesource clientGetReqCoverage.php
+ *
+ * @author: aurelien.tisne@c-s.fr
+ *
+ */
+require_once 'util.php';
+require_once 'sample.inc.php';
+
+$method = lcfirst(str_replace('client','',basename(__FILE__,".php")));
+$devKey = 'to be changed';
+
+// Get all Test Cases linked with a Requirement
+
+$args=array();
+$args["devKey"]=isset($_REQUEST['apiKey']) ? $_REQUEST['apiKey'] : $devKey;
+$args["testprojectid"] = 10;
+$args["requirementversionid"] = 123;
+
+$debug=true;
+$client = new IXR_Client($server_url);
+$client->debug=$debug;
+$answer = runTest($client,$method,$args);

--- a/lib/api/xmlrpc/v1/sample_clients/php/clientGetRequirement.php
+++ b/lib/api/xmlrpc/v1/sample_clients/php/clientGetRequirement.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * TestLink Open Source Project - http://testlink.sourceforge.net/
+ * This script is distributed under the GNU General Public License 2 or later.
+ *
+ * @filesource clientGetRequirement.php
+ *
+ * @author: aurelien.tisne@c-s.fr
+ *
+ */
+require_once 'util.php';
+require_once 'sample.inc.php';
+
+$method = lcfirst(str_replace('client','',basename(__FILE__,".php")));
+$devKey = 'to be changed';
+$devKey = isset($_REQUEST['apiKey']) ? $_REQUEST['apiKey'] : $devKey;
+
+// Get a requirement from reqID
+// with no version -> latest is returned
+
+$args=array();
+$args["devKey"]= $devKey;
+$args["testprojectid"] = 10;
+$args["requirementid"] = 26;
+
+$client = new IXR_Client($server_url);
+$client->debug=true;
+$answer = runTest($client, $method, $args);
+
+// Get a requirement from reqID
+// with a version number
+
+$args=array();
+$args["devKey"]= $devKey;
+$args["testprojectid"] = 10;
+$args["requirementid"] = 26;
+$args["version"] = 2;
+
+$client = new IXR_Client($server_url);
+$client->debug=true;
+$answer = runTest($client, $method, $args);
+
+// Get a requirement from reqID
+// with a version ID
+
+$args=array();
+$args["devKey"]= $devKey;
+$args["testprojectid"] = 10;
+$args["requirementid"] = 26;
+$args["requirementversionid"] = 123;
+
+$client = new IXR_Client($server_url);
+$client->debug=true;
+$answer = runTest($client, $method, $args);
+
+// Get a requirement from reqDocID
+
+$args=array();
+$args["devKey"]= $devKey;
+$args["testprojectid"] = 10;
+$args["requirementdocid"] = "R1";
+
+$client = new IXR_Client($server_url);
+$client->debug=true;
+$answer = runTest($client, $method, $args);

--- a/lib/api/xmlrpc/v1/sample_clients/php/clientGetRequirements.php
+++ b/lib/api/xmlrpc/v1/sample_clients/php/clientGetRequirements.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * TestLink Open Source Project - http://testlink.sourceforge.net/
+ * This script is distributed under the GNU General Public License 2 or later.
+ *
+ * @filesource clientGetRequirements.php
+ *
+ * @author: aurelien.tisne@c-s.fr
+ *
+ */
+require_once 'util.php';
+require_once 'sample.inc.php';
+
+$method = lcfirst(str_replace('client','',basename(__FILE__,".php")));
+$devKey = 'to be changed';
+
+// Get all requirements linked with a TestPlan
+
+$args=array();
+$args["devKey"]=isset($_REQUEST['apiKey']) ? $_REQUEST['apiKey'] : $devKey;
+$args["testprojectid"] = 10;
+$args["testplanid"] = 11;
+
+$debug=true;
+$client = new IXR_Client($server_url);
+$client->debug=$debug;
+$answer = runTest($client,$method,$args);


### PR DESCRIPTION
Due to 1.9.18 changes concerning links between requirements and test cases, we update and add methods to be able to retrieve a requirements coverage matrix.

1- getRequirements - retrieve all requirements
2- getRequirement - for a requirement, get a version (the last one by default)
3- getReqCoverage - for a requirement version, get the test cases linked with it