### PR TITLE
fix: jira needs accountdId instead of user name while issue creation

### DIFF
--- a/lib/issuetrackerintegration/jirarestInterface.class.php
+++ b/lib/issuetrackerintegration/jirarestInterface.class.php
@@ -401,9 +401,13 @@ class jirarestInterface extends issueTrackerInterface
           }  
         }
 
-
-        if (property_exists($opt, 'reporter')) {
-          $issue['fields']['reporter'] = array('name' => (string)$opt->reporter);
+	if (property_exists($opt, 'reporter')) {
+          $accountid = $this->APIClient->getAccountId($opt->reporter_email);
+          if($accountid) {
+            $issue['fields']['reporter'] = array('accountId' => (string)$accountid);
+          } else {
+            $issue['fields']['reporter'] = array('name' => (string)$opt->reporter);
+          }
         }
 
         if (property_exists($opt, 'issueType')) {

--- a/third_party/fayp-jira-rest/Jira.php
+++ b/third_party/fayp-jira-rest/Jira.php
@@ -523,5 +523,39 @@ class Jira
         return $items;
     }
 
-
+    /**
+     * getAccountId
+     *
+     * @return mixed
+     */
+    public function getAccountId($email)
+    {
+        $cmd = $this->host . 'groupuserpicker?query=' . $email;
+        $this->request->openConnect($cmd, 'GET');
+        $this->request->execute();
+        if ($result = json_decode($this->request->getResponseBody())) {
+            if (!isset($result->users)) {
+                //error_log('cannot find user');
+                return false;
+            }
+            $infos = $result->users->users;
+            $cnt = $result->users->total;
+            if ($infos) {
+                foreach ($infos as $info) {
+                    if ($info->accountId) {
+                        return $info->accountId;
+                    }
+                }
+            }
+            return false;
+        }
+        else
+        {
+            // ATTENTION \Exception in order to use PHP object.
+            $msg = "Error Processing Request - " . __METHOD__ . ' ' .
+                   implode('/', $items->errorMessages);
+            throw new \Exception($msg, 999);
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
According to below issues and announcement, the field in reporter to create issue should be filled in Account ID

[sudden-reporter-is-required-error](https://community.developer.atlassian.com/t/sudden-reporter-is-required-error/35547/3)
[How are usernames changing in Jira Cloud?](https://support.atlassian.com/jira-software-cloud/docs/how-are-usernames-changing-in-jira-cloud/?_ga=2.187037162.319881130.1615277068-1793427790.1613698078)

![Screenshot from 2021-03-11 14-51-02](https://user-images.githubusercontent.com/8871658/110742227-509c3400-8279-11eb-9c0f-442a9a1ab91f.png)



