### PR TITLE
Fix mysql migration script of 1.9.20

### DIFF
--- a/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.20/mysql/DB.1.9.20/step1/db_schema_update.sql
@@ -22,8 +22,8 @@ ALTER TABLE /*prefix*/users MODIFY password VARCHAR(255) NOT NULL default '';
 
 -- 
 ALTER TABLE /*prefix*/testplan_platforms ADD COLUMN active tinyint(1) NOT NULL default '1';
-ALTER TABLE /*prefix*/platforms ADD COLUMN  enable_on_design tinyint(1) NOT NULL default '0';
-ALTER TABLE /*prefix*/platforms ADD COLUMN  enable_on_execution tinyint(1) NOT NULL default '1';
+ALTER TABLE /*prefix*/platforms ADD COLUMN  enable_on_design unsigned tinyint(1) NOT NULL default '0';
+ALTER TABLE /*prefix*/platforms ADD COLUMN  enable_on_execution unsigned tinyint(1) NOT NULL default '1';
 
 --
 ALTER TABLE /*prefix*/nodes_hierarchy ADD INDEX /*prefix*/nodes_hierarchy_node_type_id (node_type_id);


### PR DESCRIPTION
This PR is a rework of https://github.com/TestLinkOpenSourceTRMS/testlink-code/pull/272.

## What happened

*  The final schema for `testlink_create_tables` and `alter_tables` will be different.

## Intent of the change

### Add unsigned

According to [testlink_create_tables.sql](https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/testlink_1_9_20_fixed/install/sql/mysql/testlink_create_tables.sql#L170), the `enable_on_design` and `enable_on_execution` columns of the platforms table seem to expect unsigned.

However, the SQL for the migration alter_table does not have unsigned, so when migrating from 1.9.20 or lower versions, there is a difference compared to the initial preparation of 1.9.20.

Assuming that `testlink_create_tables.sql` is the correct structure, this changes will be necessary.