### PR TITLE
TICKET 0009079: Add the ability to use the execution note template wh…

### DIFF
--- a/lib/execute/bugAdd.php
+++ b/lib/execute/bugAdd.php
@@ -239,6 +239,7 @@ function initEnv(&$dbHandler)
   $args->bug_id = trim($args->bug_id);
   switch ($args->user_action) {
     case 'create':
+    case 'link':
       if( $args->bug_id == '' && $args->exec_id > 0) {
         $map = get_execution($dbHandler,$args->exec_id);
         $args->bug_notes = $map[0]['notes'];    
@@ -247,7 +248,6 @@ function initEnv(&$dbHandler)
     
     case 'doCreate':
     case 'add_note':
-    case 'link':
     default:
     break;
   }


### PR DESCRIPTION
…en linking with an existing issue

We can define a template for an execution note ($tlCfg->execution_template->notes) to automatically populate some contextual information.
This template is used when creating a new external issue from a Testlink bug (using the 'Create issue' icon).
But it is not used when we want to link a Testlink bug to an existing external issue (using the 'Link existent issue' icon).

We now also use this template in the case of linking.