### PR TITLE
Fix ResultsBugs template

### DIFF
--- a/gui/templates/tl-classic/results/resultsBugs.tpl
+++ b/gui/templates/tl-classic/results/resultsBugs.tpl
@@ -10,7 +10,7 @@ Purpose: smarty template - show Test Results and Metrics
 
 {include file="inc_head.tpl"}
 {foreach from=$gui->tableSet key=idx item=matrix name="initializer"}
-  {$tableID="$matrix->tableID"}
+  {$tableID=$matrix->tableID}
   {if $smarty.foreach.initializer.first}
     {$matrix->renderCommonGlobals()}
     {if $matrix instanceof tlExtTable}


### PR DESCRIPTION
Return tableID as $matrix value, not as string.
Otherwise the Smarty template engine converts the $matrix object to a string.

PHP Fatal error: Object of class tlExtTable could not converted to string.