### PR TITLE
When MySQL strict mode is enabled, dates such as 0000-00-00 are not a…

### DIFF
--- a/install/sql/mysql/testlink_create_tables.sql
+++ b/install/sql/mysql/testlink_create_tables.sql
@@ -39,7 +39,7 @@
 # @internal revisions
 #
 # ---------------------------------------------------------------------------------------
-
+SET SQL_MODE='ALLOW_INVALID_DATES';
 
 CREATE TABLE /*prefix*/assignment_types (
   `id` int(10) unsigned NOT NULL auto_increment,


### PR DESCRIPTION
…llowed hence the definition TIMESTAMP NOT NULL is not allowed. Disable strict mode when installing testlink.