### PR TITLE
Fix hyperlink in readme to release notes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Next TestLink version will 2.x with a new UX based on the Dashio - Bootstrap Adm
 
 ## Contents
  1. [Introduction](#1-introduction)
- 2. [Release notes / Critical Configuration Notes](2-release-notes--critical-configuration-notes)
+ 2. [Release notes / Critical Configuration Notes](#2-release-notes--critical-configuration-notes)
  3. [System Requirements](#3-system-requirements---server)
  4. [Installation & SECURITY](#4-installation--security)
  5. [Upgrade and Migration](#5-upgrade-and-migration)


### PR DESCRIPTION
In the testlink README on the github project page, when I click the "[Release notes / Critical Configuration Notes](https://github.com/TestLinkOpenSourceTRMS/testlink-code/blob/testlink_1_9/2-release-notes--critical-configuration-notes)" link I get a page not found 404. This PR fixes the link.