### PR TITLE
0009208: Add a filter on the service getTestCaseBugs to be able to restrict bugs related to a given execution

### DIFF
--- a/lib/api/xmlrpc/v1/sample_clients/php/clientGetTestCaseBugs.php
+++ b/lib/api/xmlrpc/v1/sample_clients/php/clientGetTestCaseBugs.php
@@ -3,25 +3,44 @@
  * TestLink Open Source Project - http://testlink.sourceforge.net/
  * This script is distributed under the GNU General Public License 2 or later.
  *
- * Filename $RCSfile: clientGetTestCaseBugs.php,v $
- *
  */
  
 require_once 'util.php';
 require_once 'sample.inc.php';
-show_api_db_sample_msg();
+//show_api_db_sample_msg();
 
 // -------------------------------------------------------------------------------------
-$method='getTestCaseBugs';
+$method=lcfirst(str_replace('client','',basename(__FILE__,".php")));
 $unitTestDescription="Test - {$method}";
 
 $args=array();
-$args["devKey"]=DEV_KEY;
-$args["testplanid"]="177244";
-$args["testcaseid"]="177317";
+$args["devKey"]=isset($_REQUEST['apiKey']) ? $_REQUEST['apiKey'] : DEV_KEY;
 
 $debug=true;
-echo $unitTestDescription;
+echo $unitTestDescription . "<br />";
 $client = new IXR_Client($server_url);
 $client->debug=$debug;
-runTest($client,$method,$args);
+
+$args["testplanid"]="21";
+$args["testcaseid"]="4";
+runTest($client,$method,$args,1);
+
+echo "Test adding a filter on a the build 2<br \>";
+$args["buildid"]="2";
+runTest($client,$method,$args,2);
+
+echo "Test adding a filter on the build 1<br \>";
+$args["buildid"]="1";
+runTest($client,$method,$args,3);
+
+echo "Test adding a filter on a platform<br \>";
+$args["platformid"]="1";
+runTest($client,$method,$args,4);
+
+echo "Test adding a filter on an execution ID<br \>";
+$args["executionid"]=1;
+runTest($client,$method,$args,5);
+
+echo "Test adding a filter on another execution ID<br \>";
+$args["executionid"]=3;
+runTest($client,$method,$args,6);


### PR DESCRIPTION
The XMLRPC API service getTestCaseBugs() reports all bugs related to a given Test Case (during its whole history). Sometimes we are interested only on bugs opened for a given execution (the last one).

We add a (optional) filter on this service to be able to restrict bugs on a given execution ID.