### PR TITLE
Update mysql db_schema_update.sql v.1.9.18 for needed /*prefix*/ missing

### DIFF
--- a/install/sql/alter_tables/1.9.18/mysql/DB.1.9.18/step1/db_schema_update.sql
+++ b/install/sql/alter_tables/1.9.18/mysql/DB.1.9.18/step1/db_schema_update.sql
@@ -52,10 +52,10 @@ AS SELECT
    `LRQVN`.`req_id` AS `req_id`,
    `LRQVN`.`version` AS `version`,
    `REQV`.`id` AS `req_version_id`
-FROM `latest_req_version` `LRQVN` 
-join `nodes_hierarchy` `NHRQV` 
+FROM /*prefix*/latest_req_version `LRQVN` 
+join /*prefix*/nodes_hierarchy `NHRQV` 
 on `NHRQV`.`parent_id` = `LRQVN`.`req_id`
-join `req_versions` `REQV` 
+join /*prefix*/req_versions `REQV` 
 on `REQV`.`id` = `NHRQV`.`id` and 
 `REQV`.`version` = `LRQVN`.`version`;
 


### PR DESCRIPTION
In the mysql db_schema_update.sql migration script for version 1.9.18, added the needed /*prefix*/ where missing.
When using a prefix, the tables in the view at row 50 can't be found