### PR TITLE
Fix "PHP Fatal error" on kintParser.class.php and tlRole.class.php

### DIFF
--- a/lib/functions/tlRole.class.php
+++ b/lib/functions/tlRole.class.php
@@ -260,7 +260,7 @@ class tlRole extends tlDBObject
   public function getDisplayName()
   {
     $displayName = $this->name;
-    if ($displayName{0} == "<")
+    if ($displayName[0] == "<")
     {
       $roleName = str_replace(" ","_",substr($displayName,1,-1));
       $displayName = "<".lang_get($roleName).">";

--- a/third_party/kint/inc/kintParser.class.php
+++ b/third_party/kint/inc/kintParser.class.php
@@ -460,9 +460,9 @@ abstract class kintParser extends kintVariableData
 			 * These prepended values have null bytes on either side.
 			 * http://www.php.net/manual/en/language.types.array.php#language.types.array.casting
 			 */
-			if ( $key{0} === "\x00" ) {
+			if ( $key[0] === "\x00" ) {
 
-				$access = $key{1} === "*" ? "protected" : "private";
+				$access = $key[1] === "*" ? "protected" : "private";
 
 				// Remove the access level from the variable name
 				$key = substr( $key, strrpos( $key, "\x00" ) + 1 );


### PR DESCRIPTION
Fix this error for newer PHP versions:
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported