### PR TITLE
Fix broken init_settings() in tlTestCaseFilterControl

### DIFF
--- a/lib/functions/tlTestCaseFilterControl.class.php
+++ b/lib/functions/tlTestCaseFilterControl.class.php
@@ -557,11 +557,11 @@ class tlTestCaseFilterControl extends tlFilterControl {
         ($this->args->feature != 'tc_exec_assignment' && $this->args->feature != 'test_urgency') ) {
       $this->settings['setting_build'] = [
         "items" => null,
-        "selected" -1
+        "selected" => -1
       ];
       $this->settings['setting_platform'] = [
         "items" => null,
-        "selected" -1
+        "selected" => -1
       ];
     }
   


### PR DESCRIPTION
After commit e78e6e3bb5fd7 some invalid syntax remained in tlTestCaseFilterControl.class.php which caused a HTTP 500 error on "Update Linked Test Cases Versions"