### PR TITLE
Fix `getTestCaseAssignedTester` and `manageTestCaseExecutionTask`

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -7340,7 +7340,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $link = current( $info );
             $link = $link[$tplan_id];
             $hits = count( $link );
-            $check_platform =(count( $hits ) > 1) || ! isset( $link[0] );
+            $check_platform =($hits > 1) || ! isset( $link[0] );
         }
 
         if($status_ok && $check_platform) {
@@ -7608,7 +7608,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $link = $link[$tplan_id]; // Inside test plan, is indexed by platform
             $hits = count( $link );
             $platform_id = 0;
-            $check_platform =(count( $hits ) > 1) || ! isset( $link[0] );
+            $check_platform =( $hits > 1) || ! isset( $link[0] );
         }
 
         if($status_ok && $check_platform) {


### PR DESCRIPTION
As `$hits` is the result of `count( $link );` its a number, but `count` expects an array..This PR fix it.