### PR TITLE
Vulnerability in password comparison. (Type Juggling)

### DIFF
--- a/lib/functions/tlUser.class.php
+++ b/lib/functions/tlUser.class.php
@@ -589,7 +589,7 @@ class tlUser extends tlDBObject {
     $encriptedPWD = $this->getPassword();
     if (strlen($encriptedPWD) == 32) {
       /* Update the old MD5 hash to the new bcrypt */
-      if ($encriptedPWD == md5($pwd)) {
+      if ($encriptedPWD === md5($pwd)) {
         $this->password = $this->encryptPassword($pwd,$this->authentication);
         $this->writePasswordToDB($dbH);
         return tl::OK;


### PR DESCRIPTION
Sorry for the duplicate i think i did it on the bad branch: https://github.com/TestLinkOpenSourceTRMS/testlink-code/pull/356

### POC in version 1.9.19:
I found a vulnerability in /lib/functions/tlUser.class.php the line 586:
   ` if ($this->getPassword($pwd) == $this->encryptPassword($pwd,$this->authentication))`

**Problem example**:
If i register a user with a password like : 
240610708, the md5 value is 0e462097431906509019562988736854.

If another user type this password by example: QLTHNDT the md5 value is 0e405967825401955372549139051580. 

The software compare the user md5 hash and the password typed:
"0e462097431906509019562988736854" == "0e405967825401955372549139051580" is true.

And you're logged ! 🗡️ 

**In version 1.9.20 and 2.x.x** :
it's the same thing in /lib/functions/tlUser.class.php the line 592:
    ` if ($encriptedPWD == md5($pwd)) {`

You need to use "===" comparison operator.

There is a list of magic hash here: https://github.com/spaze/hashes/blob/master/md5.md