### PR TITLE
Update const.inc.php

### DIFF
--- a/cfg/const.inc.php
+++ b/cfg/const.inc.php
@@ -370,6 +370,7 @@ $att_model_m2->show_upload_column = true;
  * The code is used in DB to store results (not GUI).  
  * Do not do localisation here, i.e do not change "passed" by your national language.
  */ 
+$tlCfg = new stdClass();
 $tlCfg->results['status_code'] = array('failed' => 'f','blocked' => 'b',
                                        'passed' => 'p','not_run' => 'n',
                                        'not_available' => 'x','unknown' => 'u',


### PR DESCRIPTION
the object was **not initialized** previously and causes this error:  

Fatal error: Uncaught Error: Attempt to modify property "results" on null in C:\xampp\htdocs\testlink\cfg\const.inc.php:410 Stack trace: #0 C:\xampp\htdocs\testlink\install\index.php(20): require_once() #1 {main} thrown in C:\xampp\htdocs\testlink\cfg\const.inc.php on line 410