### PR TITLE
fix: Cannot access results metrics dashboard

### DIFF
--- a/lib/results/metricsDashboard.php
+++ b/lib/results/metricsDashboard.php
@@ -463,7 +463,7 @@ function checkRights(&$db,&$user,$context = null)
   $checkOrMode = array('testplan_metrics','testplan_execute');
   foreach($checkOrMode as $right)
   {
-    if( $user->hasRight($db,$right,$context->tproject_id,$context->tplan_id,$context->getAccessAttr) )
+    if( $user->hasRightOnProj($db,$right,$context->tproject_id,$context->tplan_id,$context->getAccessAttr) )
     {
       return true;  
     }


### PR DESCRIPTION
Even owning required rights, a non super-user cannot access the results metrics dashboard. We loop on the desktop.