### PR TITLE
Corrected spelling of 'droping'

### DIFF
--- a/install/installNewDB.php
+++ b/install/installNewDB.php
@@ -664,7 +664,7 @@ function drop_tables(&$dbHandler,$dbTablePrefix,$dbType)
       if( in_array($targetTable,$tablesOnDB) )
       {
         // Need to add option (CASCADE ?) to delete dependent object
-        echo "Droping $targetTable" . "<br />";
+        echo "Dropping $targetTable" . "<br />";
         $sql="DROP TABLE $targetTable";
         $sql .= (($dbType != 'mssql') && ($dbType != 'sqlsrv')) ? " CASCADE " : ' ';
         $dbHandler->exec_query($sql);
@@ -690,7 +690,7 @@ function drop_views(&$dbHandler,$dbItemPrefix,$dbType)
       if( in_array($target,$itemsOnDB) )
       {
         // Need to add option (CASCADE ?) to delete dependent object
-        echo "Droping $target" . "<br />";
+        echo "Dropping $target" . "<br />";
         $sql="DROP VIEW $target";
         $sql .= (($dbType != 'mssql') && ($dbType != 'sqlsrv')) ? " CASCADE " : ' ';
         $dbHandler->exec_query($sql);

--- a/third_party/tinymce/jscripts/tiny_mce/tiny_mce_src.js
+++ b/third_party/tinymce/jscripts/tiny_mce/tiny_mce_src.js
@@ -1161,7 +1161,7 @@ TinyMCE_Engine.prototype = {
 /*				if (tinyMCE.selectedInstance)
 					tinyMCE.selectedInstance.setBaseHREF(null);
 
-				// Fixes odd MSIE bug where drag/droping elements in a iframe with height 100% breaks
+				// Fixes odd MSIE bug where drag/dropping elements in a iframe with height 100% breaks
 				// This logic forces the width/height to be in pixels while the user is drag/dropping
 				// NOTE: This has been disabled for now since it messes up copy/paste that is far more important than image drag
 				if (tinyMCE.isRealIE) {
@@ -7604,4 +7604,3 @@ tinyMCE.add(TinyMCE_Engine, {
 	}
 
 	});
-


### PR DESCRIPTION
Updated references of `droping` to `dropping`.