### PR TITLE
Fixing issue with LDAP connexion under PHP 8.1 or >

### DIFF
--- a/lib/functions/ldap_api.php
+++ b/lib/functions/ldap_api.php
@@ -44,7 +44,8 @@ function ldap_connect_bind( $p_binddn = '', $p_password = '' )
         } 
     }
 
-	if( $t_ds !== false && $t_ds > 0 ) 
+	if( ( version_compare(PHP_VERSION, '8.1.0') >= 0 && $t_ds !== false ) || 
+	    ( version_compare(PHP_VERSION, '8.1.0') < 0  && $t_ds !== false && $t_ds > 0 ) )
 	{
 		ldap_set_option($t_ds, LDAP_OPT_PROTOCOL_VERSION, $authCfg['ldap_version']);
 		ldap_set_option($t_ds, LDAP_OPT_REFERRALS, 0);


### PR DESCRIPTION
LDAP connexion cannot work with PHP8.1 because ldap_connect returns now an LDAP\Connection instance previously, a resource was returned. https://www.php.net/manual/en/function.ldap-connect.php So testing resource is not "0" have some judicious sens but not testing an object > 0 so :  if( $t_ds !== false && $t_ds > 0 )  => replace to if( $t_ds !== false)