### PR TITLE
Fixing PHP fatal error:  Uncaught TypeError: count(): must be of type…

### DIFF
--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -6210,7 +6210,7 @@ class testcase extends tlObjectWithAttachments {
 
     $stepSet = $this->get_steps($tcversion_id,0,
                         array('fields2get' => 'id', 'accessKey' => 'id'));
-    if( count($stepSet) > 0 )
+    if (isset($stepSet) && is_countable($stepSet)  )
     {
       $this->delete_step_by_id(array_keys($stepSet));
     }


### PR DESCRIPTION
PHP 8 now throw TypeError on invalid countable types passed to the value parameter. Before it was only a warning on invalid countable types passed. This fix prevents typeError from being raised in the web server log like :

`[php:error] [pid 123456] [client 192.168.x.x:53090] PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in /var/www/html/testlink-code-testlink_1_9_20_fixed/lib/functions/testcase.class.php:6213`