### PR TITLE
fix: TICKET 0009387: Do not set OAuth prompt

### DIFF
--- a/lib/functions/oauth_providers/OAuth2Call.php
+++ b/lib/functions/oauth_providers/OAuth2Call.php
@@ -73,7 +73,6 @@ if (!isset($_GET['code'])) {
       $oap['client_id'] = $cfg['oauth_client_id'];
       $oap['scope'] = $cfg['oauth_scope'];
 
-      $oap['prompt'] = 'none';
       $oap['response_type'] = 'code';
 
       if ($oauth2Name == 'azuread') {


### PR DESCRIPTION
We need prompt, the first time, if consent is not predefined for the application. Once the user consents, next logins are non-interactive.