### PR TITLE
Update object.class.php

### DIFF
--- a/lib/functions/object.class.php
+++ b/lib/functions/object.class.php
@@ -597,7 +597,7 @@ abstract class tlDBObject extends tlObject implements iDBSerialization
       $items = self::bulkCreateObjectsFromDB($db,$ids,$className,$returnAsMap,$detailLevel);
     else
     {
-      for($i = 0;$i < sizeof($ids);$i++)
+      for($i = 0;$i < sizeof((array)$ids);$i++)
       {
         $id = $ids[$i];
         $item = self::createObjectFromDB($db,$id,$className,self::TLOBJ_O_SEARCH_BY_ID,$detailLevel);


### PR DESCRIPTION
We need an explicit cast to array in the sizeOf for PHP8 to avoid error : 

PHP Fatal error:  Uncaught TypeError: sizeof(): Argument #1 ($value) must be of type Countable|array, null given in /var/www/html/testlink-code-testlink_1_9_20_fixed/lib/functions/object.class.php:600