### PR TITLE
correction of linking to add and remove test cases

### DIFF
--- a/lib/general/frmWorkArea.php
+++ b/lib/general/frmWorkArea.php
@@ -46,7 +46,7 @@ $aa_tfp = array(
      'printReqSpec' => 'lib/results/printDocOptions.php?type=reqspec',
      'keywordsAssign' => 'lib/testcases/listTestCases.php?feature=keywordsAssign',
      'planAddTC'    => array('lib/plan/planAddTCNavigator.php?loadRightPaneAddTC=0',
-                             'lib/results/printDocOptions.php?activity=addTC'),
+                             'lib/results/planAddTC.php?activity=addTC'),
      'planRemoveTC' => 'lib/plan/planTCNavigator.php?feature=removeTC&help_topic=planRemoveTC',
      'planUpdateTC'    => 'lib/plan/planTCNavigator.php?feature=planUpdateTC',
      'show_ve' => 'lib/plan/planTCNavigator.php?feature=show_ve',  

--- a/lib/plan/planAddTC.php
+++ b/lib/plan/planAddTC.php
@@ -46,6 +46,7 @@ switch($args->item_level) {
   case 'testsuite':
   case 'req':
   case 'req_spec':
+  case 'testproject':
     $do_display = 1;
   break;
 
@@ -54,11 +55,8 @@ switch($args->item_level) {
     $do_display_coverage = 1;
   break;
   
-  case 'testproject':
-	  redirect($_SESSION['basehref'] . 
-      "lib/results/printDocOptions.php?activity=$args->activity");
-    exit();
-  break;
+  default:
+      break;
 }
 
 


### PR DESCRIPTION
Hello,
When selecting the entire project or when loading the "Add/Remove Test Cases" page for the first time, the Test Plan Design Report overview was always displayed in the right frame. This incorrect link has been corrected.

Best regards,
Dan