### PR TITLE
Fix typo: "arrya" to "array" causing syntax error.

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -3554,7 +3554,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $opt = array(
                     'outputFormat' => 'mapAccessByID'
             );
-            $platformSet = (arrya)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
+            $platformSet = (array)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
             $hasPlatforms = (count( $platformSet ) > 0);
             $hasPlatformIDArgs = $this->_isParamPresent( self::$platformIDParamName );
 
@@ -9201,3 +9201,4 @@ class TestlinkXMLRPCServer extends IXR_Server {
         );
     }
 } // class end
+

--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -9201,4 +9201,3 @@ class TestlinkXMLRPCServer extends IXR_Server {
         );
     }
 } // class end
-


### PR DESCRIPTION
Hello,

I encountered a PHP fatal error while trying to use the XML-RPC API.

Error found in logs:
`PHP Parse error: syntax error, unexpected '$this' (T_VARIABLE) in /var/www/html/lib/api/xmlrpc/v1/xmlrpc.class.php on line 3557`

-> changed "arrya" to "array"
After the change, my API call correctly work.

Best Regards