### PR TITLE
fix: correct typo arrya to array in getPlatforms cast (line 3557)

### DIFF
--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -3554,7 +3554,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $opt = array(
                     'outputFormat' => 'mapAccessByID'
             );
-            $platformSet = (arrya)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
+            $platformSet = (array)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
             $hasPlatforms = (count( $platformSet ) > 0);
             $hasPlatformIDArgs = $this->_isParamPresent( self::$platformIDParamName );
 


### PR DESCRIPTION
#Description

## Problem

A typo in 'lib/api/xmlrpc/v1/xmlrpc.class.php' at line 3557 causes a PHP parse error that makes the entire
XML-RPC API unavailable.

## Error in Apache logs:**

'PHP Parse error: syntax error, unexpected '$this' (T_VARIABLE) in xmlrpc.class.php o line 3557'

## Impact 

This single typo makes the XML-RPC API return HTTP 500 for all requests, completely breaking any external
integration (pytest, CI/CD pipelines, etc...)

## Tested on

-Testlink version: 1.9.20 [fixed]
-PHP 7.x / Apache 2.4.58 on Ubuntu