### PR TITLE
Php8 compatibility fixes

### DIFF
--- a/install/installUtils.php
+++ b/install/installUtils.php
@@ -497,9 +497,7 @@ function _mysql_make_user($dbhandler,$db_host,$db_name,$login,$passwd) {
   $safeLogin = $dbhandler->prepare_string($login);
 
   $stmt = " CREATE USER '$safeLogin' ";
-  if (strlen(trim($db_host)) != 0) {
-    $stmt .= "@" . "'$safeDBHost'";
-  }         
+  $stmt .= "@'%'"; // Docker: use wildcard host         
 
   // to guess if we are using MariaDB or MySQL
   // does not seems to be a reliable way to do this
@@ -570,7 +568,7 @@ function _mysql_assign_grants($dbhandler,$db_host,$db_name,$login,$passwd) {
   $safeLogin = $dbhandler->prepare_string($login);
 
   $stmt = "GRANT SELECT, UPDATE, DELETE, INSERT ON 
-           `$safeDBName`.* TO '$safeLogin'@'$safeDBHost' 
+           `$safeDBName`.* TO '$safeLogin'@'%' 
             WITH GRANT OPTION ";
 
   if ( !@$dbhandler->exec_query($stmt) ) {
@@ -590,7 +588,7 @@ function _mysql_assign_grants($dbhandler,$db_host,$db_name,$login,$passwd) {
   //
   if( strcasecmp('localhost',$db_host) != 0 ) {
     $stmt = "GRANT SELECT, UPDATE, DELETE, INSERT ON 
-            `$safeDBName`.* TO '$safeLogin'@'localhost' 
+            `$safeDBName`.* TO '$safeLogin'@'%' 
             WITH GRANT OPTION ";
 
     if ( !@$dbhandler->exec_query($stmt) ) {

--- a/lib/ajax/getreqcoveragenodes.php
+++ b/lib/ajax/getreqcoveragenodes.php
@@ -124,7 +124,7 @@ function display_children($dbHandler,$root_node,$parent,$filter_node,
           $path['forbidden_parent'] = $forbidden_parent[$row['node_type']];
    	      if(!is_null($req_list))
 	        {
-            $item_qty = count($req_list);
+            $item_qty = count((array)$req_list);
 	        	$path['text'] .= " ({$item_qty})";   
 	        }
 	      break;

--- a/lib/ajax/getrequirementnodes.php
+++ b/lib/ajax/getrequirementnodes.php
@@ -140,7 +140,7 @@ function display_children($dbHandler,$root_node,$parent,$filter_node,
           $path['forbidden_parent'] = $forbidden_parent[$row['node_type']];
           if(!is_null($req_list))
           {
-            $item_qty = count($req_list);
+            $item_qty = count((array)$req_list);
             $path['text'] .= " ({$item_qty})";   
           }
         break;

--- a/lib/ajax/gettprojectnodes.php
+++ b/lib/ajax/gettprojectnodes.php
@@ -127,7 +127,7 @@ function display_children($dbHandler,$root_node,$parent,$filter_node,
         case 'testsuite':
           $items = array();
           getAllTCasesID($row['id'],$items);
-          $tcase_qty = sizeof($items);
+          $tcase_qty = sizeof((array)$items);
 
           $path['href'] = "javascript:" . $js_function[$row['node_type']]. "({$path['id']})";
           $path['forbidden_parent'] = $forbidden_parent[$row['node_type']];
@@ -195,7 +195,7 @@ function getAllTCasesID($idList,&$tcIDs) {
           $suiteIDs[] = $row['id'];
         }
       }
-      if (sizeof($suiteIDs)) {
+      if (sizeof((array)$suiteIDs)) {
         $suiteIDs  = implode(",",$suiteIDs);
         getAllTCasesID($suiteIDs,$tcIDs);
       }

--- a/lib/api/rest/v1/tlRestApi.class.php
+++ b/lib/api/rest/v1/tlRestApi.class.php
@@ -262,7 +262,7 @@ class tlRestApi
     if( !is_null($tproject) )
     {
       $items = $this->tprojectMgr->get_all_testplans($tproject[0]['id']);
-      $op['items'] = (!is_null($items) && count($items) > 0) ? $items : null;
+      $op['items'] = (!is_null($items) && count((array)$items) > 0) ? $items : null;
     }
     else 
     {
@@ -290,7 +290,7 @@ class tlRestApi
     {
       $tcaseIDSet = array();
       $this->tprojectMgr->get_all_testcases_id($tproject[0]['id'],$tcaseIDSet);
-      if( !is_null($tcaseIDSet) && count($tcaseIDSet) > 0 )
+      if( !is_null($tcaseIDSet) && count((array)$tcaseIDSet) > 0 )
       {
         $op['items'] = array();
         foreach( $tcaseIDSet as $key => $tcaseID )

--- a/lib/api/rest/v2/tlRestApi.class.php
+++ b/lib/api/rest/v2/tlRestApi.class.php
@@ -326,7 +326,7 @@ class tlRestApi
  
     if( !is_null($tproject) ) {
       $items = $this->tprojectMgr->get_all_testplans($tproject['id']);
-      $op['items'] = (!is_null($items) && count($items) > 0) ? $items : null;
+      $op['items'] = (!is_null($items) && count((array)$items) > 0) ? $items : null;
     } else {
       $op['message'] = "No Test Project identified by '" . $idCard . "'!";
       $op['status']  = 'error';
@@ -352,7 +352,7 @@ class tlRestApi
       $tcaseIDSet = array();
       $this->tprojectMgr->get_all_testcases_id($tproject['id'],$tcaseIDSet);
 
-      if( !is_null($tcaseIDSet) && count($tcaseIDSet) > 0 ) {
+      if( !is_null($tcaseIDSet) && count((array)$tcaseIDSet) > 0 ) {
         $op['items'] = array();
         foreach( $tcaseIDSet as $key => $tcaseID ) {
           $item = $this->tcaseMgr->get_last_version_info($tcaseID);
@@ -1010,7 +1010,7 @@ class tlRestApi
 
         if(!$attrOK) {
           $msg = "Attribute: {$key} mandatory key (";
-          if(count($attr) > 1) {
+          if(count((array)$attr) > 1) {
             $msg .= "one of set: ";
           }  
           $msg .= implode('/',$attr) . ") is missing";
@@ -1236,7 +1236,7 @@ class tlRestApi
  
     if( !is_null($tplan) ) {
       $items = $this->tplanMgr->get_builds($tplan['id']);
-      $op['items'] = (!is_null($items) && count($items) > 0) ? $items : null;
+      $op['items'] = (!is_null($items) && count((array)$items) > 0) ? $items : null;
     } else {
       $op['message'] = "No Test Plan identified by '" . $idCard . "'!";
       $op['status']  = 'error';
@@ -1531,7 +1531,7 @@ class tlRestApi
             $p2link[$plat_id]=$plat_id;
           }
         }
-        if (count($p2link) >0){
+        if (count((array)$p2link) >0){
           $platMgr->linkToTestplan($p2link,$tplan_id);
         }
       }  

--- a/lib/api/rest/v3/RestApi.class.php
+++ b/lib/api/rest/v3/RestApi.class.php
@@ -273,7 +273,7 @@ class RestApi
   {
     $options = array_merge(array('output' => 'rest'), (array)$opt);
     $op = array('status' => 'ok', 'message' => 'ok', 'item' => null);
-    if(is_null($idCard) || count($idCard) == 0) {
+    if(is_null($idCard) || count((array)$idCard) == 0) {
       $opOptions = array('output' => 'array_of_map', 
                          'order_by' => " ORDER BY name ", 
                          'add_issuetracker' => true,
@@ -337,7 +337,7 @@ class RestApi
       $tcaseIDSet = array();
       $this->tprojectMgr->get_all_testcases_id($tproject['id'],$tcaseIDSet);
 
-      if( !is_null($tcaseIDSet) && count($tcaseIDSet) > 0 ) {
+      if( !is_null($tcaseIDSet) && count((array)$tcaseIDSet) > 0 ) {
         $op['items'] = array();
         foreach( $tcaseIDSet as $key => $tcaseID ) {
           $item = $this->tcaseMgr->get_last_version_info($tcaseID);
@@ -427,7 +427,7 @@ class RestApi
  
     if( !is_null($tproj) ) {
       $items = $this->tprojectMgr->get_all_testplans($tproj['id']);
-      $op['items'] = (!is_null($items) && count($items) > 0) 
+      $op['items'] = (!is_null($items) && count((array)$items) > 0) 
                      ? $items : null;
     } else {
       $op['message'] = "No Test Project identified by '" . $idCard . "'!";
@@ -455,7 +455,7 @@ class RestApi
  
     if( !is_null($tplan) ) {
       $items = $this->tplanMgr->get_builds($tplan['id']);
-      $op['items'] = (!is_null($items) && count($items) > 0) 
+      $op['items'] = (!is_null($items) && count((array)$items) > 0) 
                      ? $items : null;
     } else {
       $op['message'] = "No Test Plan identified by API KEY:" . 
@@ -1107,7 +1107,7 @@ class RestApi
             $p2link[$plat_id]=$plat_id;
           }
         }
-        if (count($p2link) >0){
+        if (count((array)$p2link) >0){
           $platMgr->linkToTestplan($p2link,$tplan_id);
         }
       }  
@@ -1364,7 +1364,7 @@ class RestApi
 
         if(!$attrOK) {
           $msg = "Attribute: {$key} mandatory key (";
-          if(count($attr) > 1) {
+          if(count((array)$attr) > 1) {
             $msg .= "one of set: ";
           }  
           $msg .= implode('/',$attr) . ") is missing";

--- a/lib/api/rest/v3/custom/api/RestApiCustomExample.class.php
+++ b/lib/api/rest/v3/custom/api/RestApiCustomExample.class.php
@@ -6,7 +6,7 @@
  */
 $bd = dirname(__FILE__);
 $ds = DIRECTORY_SEPARATOR;
-$dummy = explode($ds. lib . $ds, $bd);
+$dummy = explode($ds . 'lib' . $ds, $bd);
 require_once($dummy[0] . $ds . 'config.inc.php');
 require_once('common.php');
 

--- a/lib/api/xmlrpc/v1/poc/php/example01/autom01.php
+++ b/lib/api/xmlrpc/v1/poc/php/example01/autom01.php
@@ -60,7 +60,7 @@ foreach($phpSteps as $xx)
     }  
   }  
 }  
-$whatWillBeDone .= count($actions) ? implode('<br>',$actions) : 'Nothing!!';
+$whatWillBeDone .= count((array)$actions) ? implode('<br>',$actions) : 'Nothing!!';
 echo $whatWillBeDone . '<br>';
 
 foreach( $phpSteps as $m2i)

--- a/lib/api/xmlrpc/v1/sample_clients/php/clientGetProjects.php
+++ b/lib/api/xmlrpc/v1/sample_clients/php/clientGetProjects.php
@@ -33,7 +33,7 @@ $client->debug=$debug;
 $answer = runTest($client,$method,$args);
 new dBug($answer);
 
-$items_qty = count($answer);
+$items_qty = count((array)$answer);
 foreach($answer as $item)
 {
 	if( isset($item['name']) )

--- a/lib/api/xmlrpc/v1/sample_clients/php/clientTestSuiteTestCaseStepsManagement.php
+++ b/lib/api/xmlrpc/v1/sample_clients/php/clientTestSuiteTestCaseStepsManagement.php
@@ -65,7 +65,7 @@ if( !is_null($ret) && isset($ret['steps']) && !is_null($ret['steps']) && $ret['s
 	$originalSteps = (array)$ret['steps'];
 }
 
-if( ($loop2do = count($originalSteps)) > 0 )
+if( ($loop2do = count((array)$originalSteps)) > 0 )
 {
 	$runDelete = true;
 	$allSteps = null;

--- a/lib/api/xmlrpc/v1/sample_extended_server/extended_server.php
+++ b/lib/api/xmlrpc/v1/sample_extended_server/extended_server.php
@@ -29,7 +29,7 @@ class SampleXMLRPCServer extends TestlinkXMLRPCServer {
 
         $result = $this->tsuiteMgr->get_by_name($testSuiteName);
 
-        $num = sizeof($result);
+        $num = sizeof((array)$result);
         if ($num == 0) {
             $msg = $msg_prefix . sprintf("Name %s does not belong to a test suite present on system!", $testSuiteName);
             $this->errors[] = new IXR_Error(8004, $msg);

--- a/lib/api/xmlrpc/v1/test/TestlinkXMLRPCServerTest.php
+++ b/lib/api/xmlrpc/v1/test/TestlinkXMLRPCServerTest.php
@@ -367,7 +367,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		$response = $this->client->getResponse();
 		var_dump($response);
 		// Just check the size is good since we don't know the insert id
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}
 	
 	function testReportTCResultRequestWithPassedStatus()
@@ -387,7 +387,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		
 		$response = $this->client->getResponse();
 		// Just check the size is good since we don't know the insert id
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}			
 	
 	function testReportTCResultRequestWithFailedStatus()
@@ -407,7 +407,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		
 		$response = $this->client->getResponse();
 		// Just check the size is good since we don't know the insert id
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}
 		
 	function testReportTCResultWithNoParams()
@@ -448,7 +448,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		
 		$response = $this->client->getResponse();
 		// Just check the size is good since we don't know the insert id
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}
 
     function testGetLastTestResult()
@@ -480,7 +480,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
         $response = $this->client->getResponse();
         // Just check the size is good since we don't know the insert id
         print_r($response);
-        $this->assertEquals(9, sizeof($response[0]));
+        $this->assertEquals(9, sizeof((array)$response[0]));
         $this->assertEquals('b', $response[0]['status']);
 		
 	}
@@ -505,7 +505,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		
 		$response = $this->client->getResponse();
 		// Just check the size is good since we don't know the insert id
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}		
 	
 	function testReportTCResultNotGuessingBuildID()
@@ -558,7 +558,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		// Just check the size is good since we don't know the insert id
 		var_dump($response);
 		
-		$this->assertEquals(3, sizeof($response[0]));				
+		$this->assertEquals(3, sizeof((array)$response[0]));				
 	}
 	
 	function testCreateBuildWithInsufficientRights()
@@ -593,7 +593,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 		}		
 		$response = $this->client->getResponse();
 		var_dump($response);
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}
 	
 	function testCreateBuildWithNotes()
@@ -609,7 +609,7 @@ class TestlinkXMLRPCServerTest extends PHPUnit_Framework_TestCase
 					$this->client->getErrorMessage();
 		}		
 		$response = $this->client->getResponse();
-		$this->assertEquals(3, sizeof($response[0]));
+		$this->assertEquals(3, sizeof((array)$response[0]));
 	}
 	
 	function testCreateBuildWithInvalidTPID()

--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -1977,7 +1977,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                         $sql = " SELECT id FROM {$this->tables['builds']} " . " WHERE id = " . $sourceBuild . " AND testplan_id = " . $testPlanID;
                         $rs = $this->dbObj->get_recordset( $sql );
 
-                        if(count( $rs ) == 1) {
+                        if(count((array)$rs) == 1) {
                             $taskMgr = new assignment_mgr( $this->dbObj );
                             $taskMgr->copy_assignments( $sourceBuild, $insertID, $this->userID );
                         }
@@ -2035,7 +2035,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
         if($status_ok) {
             $testProjectID = $this->args[self::$testProjectIDParamName];
             $info = $this->tprojectMgr->get_all_testplans( $testProjectID );
-            if(! is_null( $info ) && count( $info ) > 0) {
+            if(! is_null( $info ) && count((array)$info) > 0) {
                 $info = array_values( $info );
             }
             return $info;
@@ -2385,7 +2385,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                 $result = $testCaseMgr->get_by_name( $testCaseName, $optional[self::$testSuiteNameParamName], $optional[self::$testProjectNameParamName] );
             }
 
-            $match_count = count( $result );
+            $match_count = count((array)$result);
             switch($match_count) {
                 case 0 :
                     $status_ok = false;
@@ -2675,7 +2675,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             ) );
             $targetPlatform = null;
 
-            if(count($platformSet) > 0) {
+            if(count((array)$platformSet) > 0) {
                 $status_ok = $this->checkPlatformIdentity( $this->args[self::$testPlanIDParamName], $platformSet, $msg_prefix );
                 if($status_ok) {
                     $targetPlatform[$this->args[self::$platformIDParamName]] = $platformSet[$this->args[self::$platformIDParamName]];
@@ -3342,7 +3342,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
         $keywords = trim( $keywords );
         if($keywords != "") {
             $a_keywords = explode( ",", $keywords );
-            $items_qty = count( $a_keywords );
+            $items_qty = count((array)$a_keywords);
             for($idx = 0; $idx < $items_qty; $idx ++) {
                 $a_keywords[$idx] = trim( $a_keywords[$idx] );
             }
@@ -3490,7 +3490,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
 
             $rs = $this->dbObj->get_recordset( $sql );
 
-            if(count( $rs ) != 1) {
+            if(count((array)$rs) != 1) {
                 $status_ok = false;
                 $tproject_info = $this->tprojectMgr->get_by_id( $tproject_id );
                 $msg = sprintf( TPLAN_TPROJECT_KO_STR, $tplan_info['name'], $tplan_id, $tproject_info['name'], $tproject_id );
@@ -3515,7 +3515,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $sql = " SELECT TCV.version,TCV.id " . " FROM {$this->tables['nodes_hierarchy']} NH, {$this->tables['tcversions']} TCV " . " WHERE NH.parent_id = {$tcase_id} " . " AND TCV.version = {$version_number} " . " AND TCV.id = NH.id ";
 
             $target_tcversion = $this->dbObj->fetchRowsIntoMap( $sql, 'version' );
-            if(is_null( $target_tcversion ) || count( $target_tcversion ) != 1) {
+            if(is_null( $target_tcversion ) || count((array)$target_tcversion) != 1) {
                 $status_ok = false;
                 $tcase_info = $this->tcaseMgr->get_by_id( $tcase_id );
                 $msg = sprintf( TCASE_VERSION_NUMBER_KO_STR, $version_number, $tcase_external_id, $tcase_info[0]['name'] );
@@ -3555,7 +3555,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                     'outputFormat' => 'mapAccessByID'
             );
             $platformSet = (arrya)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
-            $hasPlatforms = (count( $platformSet ) > 0);
+            $hasPlatforms = (count((array)$platformSet) > 0);
             $hasPlatformIDArgs = $this->_isParamPresent( self::$platformIDParamName );
 
             if($hasPlatforms) {
@@ -4574,7 +4574,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
 
             $result = $testCaseMgr->get_by_id( $id, $version_id, $filters );
 
-            if(0 == sizeof( $result )) {
+            if(0 == sizeof((array)$result)) {
                 $status_ok = false;
                 $this->errors[] = new IXR_ERROR( NO_TESTCASE_FOUND, $msg_prefix . NO_TESTCASE_FOUND_STR );
                 return $this->errors;
@@ -4823,7 +4823,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
         $tplanID = $this->args[self::$testPlanIDParamName];
         $cfieldMgr = $this->tprojectMgr->cfield_mgr;
         $cfieldsMap = $cfieldMgr->get_linked_cfields_at_execution( $tprojectID, 1, 'testcase', null, null, null, 'name' );
-        $status_ok = !(is_null( $rs ) || is_null( $cfieldSet ) || count( $cfieldSet ) == 0);
+        $status_ok = !(is_null( $rs ) || is_null( $cfieldSet ) || count((array)$cfieldSet) == 0);
         $cfield4write = null;
         if($status_ok && ! is_null( $cfieldsMap )) {
             foreach( $cfieldSet as $name => $value ) {
@@ -5837,7 +5837,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
         }
 
         if(! $status) {
-            $msg = $msg_prefix . sprintf( ATTACH_INVALID_ATTACHMENT_STR, $this->args[self::$fileNameParamName], sizeof( $this->args[self::$contentParamName] ) );
+            $msg = $msg_prefix . sprintf( ATTACH_INVALID_ATTACHMENT_STR, $this->args[self::$fileNameParamName], sizeof((array)$this->args[self::$contentParamName]) );
             $this->errors[] = new IXR_ERROR( ATTACH_INVALID_ATTACHMENT, $msg );
         }
 
@@ -5890,7 +5890,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
         $sql = " SELECT TCV.version,TCV.id " . " FROM {$this->tables['nodes_hierarchy']} NH, {$this->tables['tcversions']} TCV " . " WHERE NH.parent_id = {$tcase_id} " . " AND TCV.version = {$version_number} " . " AND TCV.id = NH.id ";
 
         $target_tcversion = $this->dbObj->fetchRowsIntoMap( $sql, 'version' );
-        if(! is_null( $target_tcversion ) && count( $target_tcversion ) == 1) {
+        if(! is_null( $target_tcversion ) && count((array)$target_tcversion) == 1) {
             $dummy = current( $target_tcversion );
             $this->tcVersionID = $dummy['id'];
         } else {
@@ -7364,7 +7364,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             // access key => tcversion_id, tplan_id, platform_id
             $link = current( $info );
             $link = $link[$tplan_id]; // Inside test plan, is indexed by platform
-            $check_platform =(count( $link ) > 1) || ! isset( $link[0] );
+            $check_platform =(count((array)$link) > 1) || ! isset( $link[0] );
         }
 
         if($status_ok && $check_platform) {
@@ -7536,7 +7536,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                 $targetIDs[] = $execContext['execution_id'];
             }
 
-            if ( count($targetIDs) > 0 ) {
+            if ( count((array)$targetIDs) > 0 ) {
                 $resultInfo[0]['bugs'] = array();
                 $sql = " SELECT DISTINCT bug_id FROM {$this->tables['execution_bugs']} " . " WHERE execution_id in(" . implode( ',', $targetIDs ) . ")";
                 $resultInfo[0]['bugs'] =( array ) $this->dbObj->get_recordset( $sql );
@@ -7631,7 +7631,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $link = current( $info );
             $link = $link[$tplan_id]; // Inside test plan, is indexed by platform
             $platform_id = 0;
-            $check_platform =(count( $link ) > 1) || ! isset( $link[0] );
+            $check_platform =(count((array)$link) > 1) || ! isset( $link[0] );
         }
 
         if($status_ok && $check_platform) {
@@ -8453,7 +8453,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $items = $tprojectMgr->get_subtree( $tproj['id'], $filters, $opt );
 
             $ni = array();
-            if(! is_null( $items ) &&($l2d = count( $items )) > 0) {
+            if(! is_null( $items ) &&($l2d = count((array)$items)) > 0) {
                 $tg = $this->args[self::$testSuiteNameParamName];
                 for($ydx = 0; $ydx <= $l2d; $ydx ++) {
                     if(strcmp( $items[$ydx]['name'], $tg ) == 0) {
@@ -8958,7 +8958,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             );
             $buildInfo = $bm->get_by_id( $buildID, $opx );
 
-            if($buildInfo == false || count( $buildInfo ) == 0) {
+            if($buildInfo == false || count((array)$buildInfo) == 0) {
                 $status_ok = false;
                 $msg = sprintf( INVALID_BUILDID_STR, $buildID );
                 $this->errors[] = new IXR_Error( INVALID_BUILDID, $msg );
@@ -9058,7 +9058,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                     $sql = "SELECT id FROM $target $where";
                     $rs = $this->dbObj->get_recordset( $sql );
 
-                    if(is_null( $rs ) or count( $rs ) != 1) {
+                    if(is_null( $rs ) or count((array)$rs) != 1) {
                         $sql = " INSERT INTO $target(";
 
                         $dbField[] = 'tcstep_id';

--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -2992,12 +2992,12 @@ class TestlinkXMLRPCServer extends IXR_Server {
 
         // Do we need to get Test Case Steps?
         if(! is_null( $recordset ) && $opt[self::$getStepsInfoParamName]) {
-            $itemSet = array_keys( $recordset );
+            $itemSet = array_keys((array)$recordset);
             switch($options['output']) {
                 case 'mapOfArray' :
                 case 'mapOfMap' :
                     foreach( $itemSet as $itemKey ) {
-                        $keySet = array_keys( $recordset[$itemKey] );
+                        $keySet = array_keys((array)$recordset[$itemKey]);
                         $target = &$recordset[$itemKey];
                         foreach( $keySet as $accessKey ) {
                             $steps = $this->tcaseMgr->get_steps( $target[$accessKey]['tcversion_id'] );
@@ -3019,12 +3019,12 @@ class TestlinkXMLRPCServer extends IXR_Server {
 
         // Do we need the custom fields?
         if (! is_null( $recordset ) && ($opt[self::$customFieldsParamName] || is_array($opt[self::$customFieldsParamName]))) {
-            $itemSet = array_keys( $recordset );
+            $itemSet = array_keys((array)$recordset);
             switch($options['output']) {
                 case 'mapOfArray' :
                 case 'mapOfMap' :
                     foreach( $itemSet as $itemKey ) {
-                        $keySet = array_keys( $recordset[$itemKey] );
+                        $keySet = array_keys((array)$recordset[$itemKey]);
                         $target = &$recordset[$itemKey];
                         foreach( $keySet as $accessKey ) {
                             $target[$accessKey]['customfields'] = $this->_testcaseCustomFieldData(
@@ -3596,7 +3596,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $sql = " SELECT TCV.version,TCV.id " . " FROM {$this->tables['nodes_hierarchy']} NH, {$this->tables['tcversions']} TCV " . " WHERE NH.parent_id = " . intval( $tcase_id ) . " AND TCV.id = NH.id ";
 
             $all_tcversions = $this->dbObj->fetchRowsIntoMap( $sql, 'id' );
-            $id_set = array_keys( $all_tcversions );
+            $id_set = array_keys((array)$all_tcversions);
 
             // get records regarding all test case versions linked to test plan
             $in_clause = implode( ",", $id_set );
@@ -6352,7 +6352,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                         'accessKey' => 'step_number'
                 );
                 $stepSet =( array ) $this->tcaseMgr->get_steps( $tcversion_id, 0, $opt );
-                $stepNumberIDSet = array_flip( array_keys( $stepSet ) );
+                $stepNumberIDSet = array_flip( array_keys((array)$stepSet) );
                 foreach( $stepNumberIDSet as $sn => $dummy ) {
                     $stepNumberIDSet[$sn] = $stepSet[$sn]['id'];
                 }
@@ -7967,7 +7967,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
         // to same test project
         $status_ok = $this->_runChecks( $checkFunctions, $msg_prefix );
         if($status_ok) {
-            $items = array_keys( $this->args[self::$keywordNameParamName] );
+            $items = array_keys((array)$this->args[self::$keywordNameParamName]);
             $status_ok = $this->checkTestCaseSetIdentity( $msg_prefix, $items );
         }
 
@@ -8044,7 +8044,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
                 if(! isset( $cacheLTCV[$tcaseID] )) {
                     $cacheLTCV[$tcaseID] = $this->tcaseMgr->getLatestVersionID( $tcaseID );
                 }
-                $this->tcaseMgr->$method2call( $this->tcaseE2I[$ak], $cacheLTCV[$tcaseID], array_keys( $val ) );
+                $this->tcaseMgr->$method2call( $this->tcaseE2I[$ak], $cacheLTCV[$tcaseID], array_keys((array)$val) );
             }
         }
 

--- a/lib/api/xmlrpc/v1/xmlrpc.class.php
+++ b/lib/api/xmlrpc/v1/xmlrpc.class.php
@@ -3554,7 +3554,7 @@ class TestlinkXMLRPCServer extends IXR_Server {
             $opt = array(
                     'outputFormat' => 'mapAccessByID'
             );
-            $platformSet = (arrya)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
+            $platformSet = (array)$this->tplanMgr->getPlatforms( $tplan_id, $opt );
             $hasPlatforms = (count((array)$platformSet) > 0);
             $hasPlatformIDArgs = $this->_isParamPresent( self::$platformIDParamName );
 

--- a/lib/attachments/attachmentupload.php
+++ b/lib/attachments/attachmentupload.php
@@ -33,7 +33,7 @@ if ($args->bPostBack) {
       $opt['allow_empty_title'] = true;
     }  
 
-    $l2d = count($fInfo);
+    $l2d = count((array)$fInfo);
     for($fdx=0; $fdx <= $l2d; $fdx++) {
       $fSize = isset($fInfo['size'][$fdx]) ? $fInfo['size'][$fdx] : 0;
       $fTmpName = isset($fInfo['tmp_name'][$fdx]) ? 
@@ -88,7 +88,7 @@ function init_args()
   $args = new stdClass();
   I_PARAMS($iParams,$args);
   
-  $args->bPostBack = sizeof($_POST);
+  $args->bPostBack = sizeof((array)$_POST);
   
   return $args;
 }

--- a/lib/cfields/cfieldsEdit.php
+++ b/lib/cfields/cfieldsEdit.php
@@ -279,7 +279,7 @@ function edit(&$argsObj,&$cfieldMgr)
 		
 		$op->operation_descr = lang_get('title_cfield_edit') . TITLE_SEP_TYPE3 . $op->cf['name'];
 		$op->linked_tprojects = $cfieldMgr->get_linked_testprojects($argsObj->cfield_id); 
- 		$op->cf_is_linked = !is_null($op->linked_tprojects) && count($op->linked_tprojects) > 0;
+ 		$op->cf_is_linked = !is_null($op->linked_tprojects) && count((array)$op->linked_tprojects) > 0;
 	}
   return $op;
 }

--- a/lib/cfields/cfieldsTprojectAssign.php
+++ b/lib/cfields/cfieldsTprojectAssign.php
@@ -14,7 +14,7 @@ $templateCfg = templateConfiguration();
 
 $cfield_mgr = new cfield_mgr($db);
 $args = init_args($db);
-$checkedIDSet = array_keys($args->checkedCF);
+$checkedIDSet = array_keys((array)$args->checkedCF);
 
 switch ($args->doAction) {
   case 'doAssign':
@@ -126,7 +126,7 @@ function initializeGui(&$args,&$cfield_mgr)
   $gui->tproject_name = $args->tproject_name;
   
   $gui->linkedCF = $cfield_mgr->get_linked_to_testproject($args->tproject_id);
-  $cf2exclude = is_null($gui->linkedCF) ? null :array_keys($gui->linkedCF);
+  $cf2exclude = is_null($gui->linkedCF) ? null :array_keys((array)$gui->linkedCF);
   $gui->other_cf = $cfield_mgr->get_all($cf2exclude);
 
   $gui->cf_available_types = $cfield_mgr->get_available_types();
@@ -222,7 +222,7 @@ function doSimpleBooleanMgmt(&$cfieldMgr,$argsObj,$cfg)
   // This way user does not need to check cf for this operations
   // Think makes life easier   
   $serviceInput = $cfg['ha'];
-  $cfSet = array_keys($argsObj->$serviceInput);
+  $cfSet = array_keys((array)$argsObj->$serviceInput);
 
   $m2c = $cfg['m2c'];
   $operativeInput = $cfg['attr'];

--- a/lib/codetrackerintegration/stashrestInterface.class.php
+++ b/lib/codetrackerintegration/stashrestInterface.class.php
@@ -328,7 +328,7 @@ class stashrestInterface extends codeTrackerInterface
     $ret = null;
     if(!is_null($attrSet))
     {
-      $ic = count($attrSet);
+      $ic = count((array)$attrSet);
       for($idx=0; $idx < $ic; $idx++)
       {
         $ret[$attrSet[$idx]->key] = $attrSet[$idx]->name . " (" . $attrSet[$idx]->key . ")"; 
@@ -346,7 +346,7 @@ class stashrestInterface extends codeTrackerInterface
     $ret = null;
     if(!is_null($attrSet))
     {
-      $ic = count($attrSet);
+      $ic = count((array)$attrSet);
       for($idx=0; $idx < $ic; $idx++)
       {
         $ret[$attrSet[$idx]->$id] = $attrSet[$idx]->$name;
@@ -364,7 +364,7 @@ class stashrestInterface extends codeTrackerInterface
     $ret = null;
     if(!is_null($attrSet))
     {
-      $ic = count($attrSet);
+      $ic = count((array)$attrSet);
       for($idx=0; $idx < $ic; $idx++)
       {
         $ret[$attrSet[$idx]->id] = $attrSet[$idx]->name . " (" . $attrSet[$idx]->key . ")";

--- a/lib/events/eventviewer.php
+++ b/lib/events/eventviewer.php
@@ -60,7 +60,7 @@ $gui->events = $g_tlLogger->getEventsFor($args->logLevel,$args->object_id ? $arg
                                          $args->object_type ? $args->object_type : null,null,500,$filters->startTime,
                                          $filters->endTime,$filters->users);
 
-if (count($gui->events) > 0) 
+if (count((array)$gui->events) > 0) 
 {
   $table = buildExtTable($gui, $show_icon, $charset);
   if (!is_null($table)) 
@@ -218,7 +218,7 @@ function getFilters(&$argsObj=null,$dateFormat=null)
 function buildExtTable($gui,$show_icon,$charset)
 {
   $table = null;
-  if(count($gui->events) > 0) 
+  if(count((array)$gui->events) > 0) 
   {
     $columns = array();
     $columns[] = array('title_key' => 'th_timestamp', 'width' => 15);

--- a/lib/execute/execExport.php
+++ b/lib/execute/execExport.php
@@ -147,7 +147,7 @@ function contextAsXML(&$dbHandler,$contextSet,&$tplanMgr)
     					 	 "\n\t" . "</platform>";
 	}
 	
-	$key2loop = array_keys($info);
+	$key2loop = array_keys((array)$info);
 	foreach($key2loop as $item_key)
 	{
 		if(!is_null($info[$item_key]))

--- a/lib/execute/execHistory.php
+++ b/lib/execute/execHistory.php
@@ -135,12 +135,12 @@ function getIssues(&$dbHandler,&$execSet,$tprojectID)
   $tcv2loop = array_keys($execSet);
   foreach($tcv2loop as $tcvid)
   {
-    $execQty = count($execSet[$tcvid]);
+    $execQty = count((array)$execSet[$tcvid]);
     for($idx=0; $idx < $execQty; $idx++)
     {
       $exec_id = $execSet[$tcvid][$idx]['execution_id'];
       $dummy = get_bugs_for_exec($dbHandler,$its,$exec_id);
-      if(count($dummy) > 0)
+      if(count((array)$dummy) > 0)
       {
         $issues[$exec_id] = $dummy;
       } 
@@ -159,13 +159,13 @@ function getCustomFields(&$tcaseMgr,&$execSet)
   $tcv2loop = array_keys($execSet);
   foreach($tcv2loop as $tcvid)
   {
-    $execQty = count($execSet[$tcvid]);
+    $execQty = count((array)$execSet[$tcvid]);
     for($idx=0; $idx < $execQty; $idx++)
     {
       $exec_id = $execSet[$tcvid][$idx]['execution_id'];
       $tplan_id = $execSet[$tcvid][$idx]['testplan_id'];
       $dummy = (array)$tcaseMgr->html_table_of_custom_field_values($tcvid,'execution',null,$exec_id,$tplan_id);
-      $cf[$exec_id] = (count($dummy) > 0) ? $dummy : '';
+      $cf[$exec_id] = (count((array)$dummy) > 0) ? $dummy : '';
     } 
   }
   return $cf;
@@ -183,7 +183,7 @@ function getAttachments(&$dbHandler,&$execSet)
   $tcv2loop = array_keys($execSet);
   foreach($tcv2loop as $tcvid)
   {
-    $execQty = count($execSet[$tcvid]);
+    $execQty = count((array)$execSet[$tcvid]);
     for($idx=0; $idx < $execQty; $idx++)
     {
       $exec_id = $execSet[$tcvid][$idx]['execution_id'];

--- a/lib/execute/execHistory.php
+++ b/lib/execute/execHistory.php
@@ -132,7 +132,7 @@ function getIssues(&$dbHandler,&$execSet,$tprojectID)
   
   // we will see in future if we can use a better algorithm
   $issues = array();
-  $tcv2loop = array_keys($execSet);
+  $tcv2loop = array_keys((array)$execSet);
   foreach($tcv2loop as $tcvid)
   {
     $execQty = count((array)$execSet[$tcvid]);
@@ -156,7 +156,7 @@ function getIssues(&$dbHandler,&$execSet,$tprojectID)
 function getCustomFields(&$tcaseMgr,&$execSet)
 {
   $cf = array();
-  $tcv2loop = array_keys($execSet);
+  $tcv2loop = array_keys((array)$execSet);
   foreach($tcv2loop as $tcvid)
   {
     $execQty = count((array)$execSet[$tcvid]);
@@ -180,7 +180,7 @@ function getAttachments(&$dbHandler,&$execSet)
   $attachmentMgr = tlAttachmentRepository::create($dbHandler);
 
   $att = null;
-  $tcv2loop = array_keys($execSet);
+  $tcv2loop = array_keys((array)$execSet);
   foreach($tcv2loop as $tcvid)
   {
     $execQty = count((array)$execSet[$tcvid]);

--- a/lib/execute/execSetResults.php
+++ b/lib/execute/execSetResults.php
@@ -79,7 +79,7 @@ if ($do_show_instructions) {
 
 // Testplan executions and result archiving. 
 // Checks whether execute cases button was clicked
-if($args->doExec == 1 && !is_null($args->tc_versions) && count($args->tc_versions)) {
+if($args->doExec == 1 && !is_null($args->tc_versions) && count((array)$args->tc_versions)) {
   $gui->remoteExecFeedback = launchRemoteExec($db,$args,$gui->tcasePrefix,$tplan_mgr,$tcase_mgr);
 }  
 
@@ -263,7 +263,7 @@ if(!is_null($linked_tcversions)) {
             $args->testcases_to_show = array_keys($xx);
           }
 
-          $chainLen = count($args->testcases_to_show);
+          $chainLen = count((array)$args->testcases_to_show);
           foreach($args->testcases_to_show as $ix => $val) {
             if( $val == $args->tc_id) {
               $nextInChain = $ix+1;
@@ -385,7 +385,7 @@ if(!is_null($linked_tcversions)) {
       }       
     }
 
-    if( count($stepSet) > 0 ) {
+    if( count((array)$stepSet) > 0 ) {
       // test case version under exec has steps
       $ctx = new stdClass();
       $ctx->testplan_id = $args->tplan_id;
@@ -465,7 +465,7 @@ if(!is_null($linked_tcversions)) {
         $gui->other_exec_cfields=$other_info['cfexec_values'];
          
         // this piece of code is useful to avoid error on smarty template due to undefined value   
-        if( is_array($tcversion_id) && (count($gui->other_execs) != count($gui->map_last_exec)) ) {
+        if( is_array($tcversion_id) && (count((array)$gui->other_execs) != count((array)$gui->map_last_exec)) ) {
           foreach($tcversion_id as $version_id) {
             if( !isset($gui->other_execs[$version_id]) ) {
               $gui->other_execs[$version_id]=null;  
@@ -673,7 +673,7 @@ function init_args(&$dbHandler,$cfgObj) {
     // Need to understand is still needed
     $tsuite_mgr = new testsuite($dbHandler);
     $xx = $tsuite_mgr->get_children($args->tsuite_id,array('details' => 'id'));
-    $ldx = count($xx);
+    $ldx = count((array)$xx);
     $xx[$ldx] = $args->tsuite_id;
     $args->tsuitesInBranch = $xx;
     unset($tsuite_mgr);
@@ -871,7 +871,7 @@ function get_ts_name_details(&$db,$tcase_id) {
                {$tables['nodes_hierarchy']} NHB
           WHERE TS.id=NHA.parent_id
           AND   NHB.id=NHA.parent_id ";
-  if( is_array($tcase_id) && count($tcase_id) > 0) {
+  if( is_array($tcase_id) && count((array)$tcase_id) > 0) {
     $in_list = implode(",",$tcase_id);
     $sql .= "AND NHA.id IN (" . $in_list . ")";
   } else if(!is_null($tcase_id)) {
@@ -966,7 +966,7 @@ function smarty_assign_tsuite_info(&$smarty,&$tree_mgr,$tcase_id,$tproject_id,$c
       $ts_cf_smarty[$tc_id] = $cached_cf[$tsuite_id];
     }
 
-    if( count($a_tsval) > 0 ) {
+    if( count((array)$a_tsval) > 0 ) {
       $ckObj->value = $a_tsval[0];
       tlSetCookie($ckObj);
     }
@@ -1000,7 +1000,7 @@ function exec_additional_info(&$db, $fileRepo, &$tcase_mgr, $other_execs,
 
   
   foreach($other_execs as $tcversion_id => $execInfo) {
-    $num_elem = sizeof($execInfo);   
+    $num_elem = sizeof((array)$execInfo);   
     for($idx = 0;$idx < $num_elem;$idx++) {
       $exec_id = $execInfo[$idx]['execution_id'];
       $aInfo = getAttachmentInfos($fileRepo,$exec_id,'executions',true,1);
@@ -1010,7 +1010,7 @@ function exec_additional_info(&$db, $fileRepo, &$tcase_mgr, $other_execs,
       
       if($bugInterfaceOn) {
         $the_bugs = get_bugs_for_exec($db,$bugInterface,$exec_id);
-        if(count($the_bugs) > 0) {
+        if(count((array)$the_bugs) > 0) {
           $bugs[$exec_id] = $the_bugs;
         }  
       }
@@ -1293,7 +1293,7 @@ function setCanExecute($exec_info,$execution_mode,$can_execute,$tester_id)
 */
 function createExecNotesWebEditor(&$tcversions,$basehref,$editorCfg,$execCfg,$initValue=null) {
   
-    if(is_null($tcversions) || count($tcversions) == 0 ) {
+    if(is_null($tcversions) || count((array)$tcversions) == 0 ) {
       return null;  // nothing todo >>>------> bye!  
     }
      
@@ -1932,7 +1932,7 @@ function processTestSuite(&$dbHandler,&$guiObj,&$argsObj,$testSet,&$treeMgr,&$tc
   $tsuite_data = $tsuite_mgr->get_by_id($argsObj->id);
  
   // Get the path for every test case, grouping test cases that have same parent.
-  $testCaseQty = count($testSet->tcase_id);
+  $testCaseQty = count((array)$testSet->tcase_id);
   if( $testCaseQty > 0 )
   {
     $dummy = $tcaseMgr->cfield_mgr->getLocations();
@@ -2324,7 +2324,7 @@ function getSettingsAndFilters(&$argsObj) {
   if (isset($sf['filter_keywords'])) 
   {
     $argsObj->keyword_id = $sf['filter_keywords'];
-    if (is_array($argsObj->keyword_id) && count($argsObj->keyword_id) == 1) 
+    if (is_array($argsObj->keyword_id) && count((array)$argsObj->keyword_id) == 1) 
     {
       $argsObj->keyword_id = $argsObj->keyword_id[0];
     }

--- a/lib/execute/execSetResults.php
+++ b/lib/execute/execSetResults.php
@@ -164,7 +164,7 @@ if(!is_null($linked_tcversions)) {
         $ctx->platform_id = $args->platform_id;
         $ctx->build_id = $args->build_id;
 
-        $tcase_mgr->deleteStepsPartialExec(array_keys($_REQUEST['step_notes']),$ctx);
+        $tcase_mgr->deleteStepsPartialExec(array_keys((array)$_REQUEST['step_notes']),$ctx);
       }
       
       list($execSet,$gui->addIssueOp,$gui->uploadOp) = 
@@ -260,7 +260,7 @@ if(!is_null($linked_tcversions)) {
 
             // key test case id
             // inside an idx array
-            $args->testcases_to_show = array_keys($xx);
+            $args->testcases_to_show = array_keys((array)$xx);
           }
 
           $chainLen = count((array)$args->testcases_to_show);
@@ -397,7 +397,7 @@ if(!is_null($linked_tcversions)) {
       
       if( null != $gui->stepsPartialExec ) {
         // will reload it!
-        $kij = current(array_keys($gui->map_last_exec));
+        $kij = current(array_keys((array)$gui->map_last_exec));
         $cucu = &$gui->map_last_exec[$kij];
         foreach($cucu['steps'] as $ccx => $se) {
           $stepID = $se['id'];
@@ -2219,7 +2219,7 @@ function getLinkedItems($argsObj,$historyOn,$cfgObj,$tcaseMgr,$tplanMgr,$identit
 
         if(!is_null($argsObj->filter_cfields))
         {
-          $tk = array_keys($argsObj->filter_cfields);
+          $tk = array_keys((array)$argsObj->filter_cfields);
           $cf = null;  
           // foreach( array('design','testplan_design') as $l4)
           foreach( array('design') as $l4)

--- a/lib/functions/assignment_mgr.class.php
+++ b/lib/functions/assignment_mgr.class.php
@@ -184,7 +184,7 @@ class assignment_mgr extends tlObjectWithDB
                   " AND user_id = " . $safe['user_id'];
 
         $rs = $this->db->get_recordset($check);
-        if( is_null($rs) || count($rs) == 0 )
+        if( is_null($rs) || count((array)$rs) == 0 )
         {
           if($safe['user_id'] > 0)
           {
@@ -526,7 +526,7 @@ class assignment_mgr extends tlObjectWithDB
 
     
     $bye = true;
-    if( !is_null($rs) && count($rs) > 0)
+    if( !is_null($rs) && count((array)$rs) > 0)
     {
       $bye = false;
       $sql = " SELECT NHTPRJ.name AS tproject, " .

--- a/lib/functions/assignment_mgr.class.php
+++ b/lib/functions/assignment_mgr.class.php
@@ -102,7 +102,7 @@ class assignment_mgr extends tlObjectWithDB
   // delete assignments by feature id and build_id
   function delete_by_feature_id_and_build_id($feature_map) 
   {
-    $feature_id_list = implode(",",array_keys($feature_map));
+    $feature_id_list = implode(",",array_keys((array)$feature_map));
     $where_clause = " WHERE feature_id IN ($feature_id_list) ";
       
     $sql = " DELETE FROM {$this->tables['user_assignments']}  {$where_clause} ";

--- a/lib/functions/attachments.inc.php
+++ b/lib/functions/attachments.inc.php
@@ -100,7 +100,7 @@ function checkAttachmentID(&$db,$id,$attachmentInfo)
   if ($attachmentInfo)
   {
     $sLastAttachmentInfos = isset($_SESSION['s_lastAttachmentInfos']) ? $_SESSION['s_lastAttachmentInfos'] : null;
-    for($i = 0;$i < sizeof($sLastAttachmentInfos);$i++)
+    for($i = 0;$i < sizeof((array)$sLastAttachmentInfos);$i++)
     {
       $info = $sLastAttachmentInfos[$i];
       if ($info['id'] == $id)

--- a/lib/functions/bareBonesRestAPI.class.php
+++ b/lib/functions/bareBonesRestAPI.class.php
@@ -213,7 +213,7 @@ class bareBonesRestAPI {
     curl_setopt($this->curl, CURLOPT_DNS_CACHE_TIMEOUT, 2 );
     curl_setopt($this->curl, CURLOPT_HEADER, 0); 
 
-    if (count($this->curlHeader) >0) {
+    if (count((array)$this->curlHeader) >0) {
       curl_setopt($this->curl, CURLOPT_HTTPHEADER, $this->curlHeader); 
     }
 

--- a/lib/functions/cfield_mgr.class.php
+++ b/lib/functions/cfield_mgr.class.php
@@ -20,7 +20,7 @@ require_once(dirname(__FILE__) . '/string_api.php');
 // Copied from mantis, allow load of user custom implementations
 // some sort of poor's man plugin
 $cf_files=glob( TL_ABS_PATH . "custom/cf_*.php");
-if( count($cf_files) > 0 )
+if( count((array)$cf_files) > 0 )
 {
   foreach($cf_files as $inc)
   {
@@ -537,7 +537,7 @@ class cfield_mgr extends tlObject
         $locFilter = (array)$filters[$filterKey];
         $additional_filter .= " AND CFTP.$filterKey IN(" . implode(",",$locFilter ) . ") ";
         
-        if ( $replaceLocation = (count($locFilter) > 1) ) {
+        if ( $replaceLocation = (count((array)$locFilter) > 1) ) {
           $locMap = $this->buildLocationMap('testcase');
           $targetLocationCode = " {$locMap['standard_location']['location']} AS location ";
         }
@@ -640,7 +640,7 @@ class cfield_mgr extends tlObject
   		case 'list':
   		case 'multiselection list':
    			$t_values = explode( '|', $p_field_def['possible_values']);
-   			$t_values_count = count($t_values);
+   			$t_values_count = count((array)$t_values);
         $window_size = intval($size);
         if($t_values_count < $window_size)
         {
@@ -1453,7 +1453,7 @@ class cfield_mgr extends tlObject
       $this->remove_all_scopes_values($id);
 		}
 		$linked_tprojects = $this->get_linked_testprojects($id);
-		if( !is_null($linked_tprojects) && count($linked_tprojects) > 0 )
+		if( !is_null($linked_tprojects) && count((array)$linked_tprojects) > 0 )
 		{
 		  $target=array_keys($linked_tprojects);
 		  foreach($target as $tproject_id)
@@ -1807,7 +1807,7 @@ function name_is_unique($id,$name)
         }
         $safe_value=$this->db->prepare_string($value);
 
-        $howMany = count($rs);
+        $howMany = count((array)$rs);
         if( $howMany > 0 && $value != "" ) {
           $sql = " UPDATE {$this->tables['cfield_execution_values']} " .
                  " SET value='{$safe_value}' " .   $where_clause;
@@ -1922,7 +1922,7 @@ function name_is_unique($id,$name)
           // date part indicator is Position 5, instead of 4
           //        	
           $dummy = explode('_',$key);
-          $last_idx = count($dummy)-1;
+          $last_idx = count((array)$dummy)-1;
 
           $the_value = null;  // without this #0008347 :(
           if( isset($this->html_date_input_suffix[$dummy[$last_idx]]) ) {
@@ -1946,7 +1946,7 @@ function name_is_unique($id,$name)
           case 'multiselection list':
           case 'checkbox':
             $valueIsArray = is_array($value);
-            if( $valueIsArray && count($value) > 1) {
+            if( $valueIsArray && count((array)$value) > 1) {
               $value=implode('|',$value);
             }
             else {
@@ -2483,7 +2483,7 @@ function getXMLRPCServerParams($nodeID,$tplanLinkID=null)
   */
   function build_cfield_radio($custom_field_value) 
   {
-      if( count($custom_field_value) > 1)
+      if( count((array)$custom_field_value) > 1)
       {
         $value=implode('|',$custom_field_value);
       }
@@ -2624,7 +2624,7 @@ function buildLocationMap($nodeType)
   $dummy = $this->getLocations();
 	$verboseLocationCode = array_flip($dummy[$nodeType]);
 	if( !is_null($verboseLocationCode)
-      && count($verboseLocationCode) > 0 ) {
+      && count((array)$verboseLocationCode) > 0 ) {
 		foreach($verboseLocationCode as $key => $value) {
 			$locationMap[$key]['location']=$value;
 		}
@@ -3034,7 +3034,7 @@ function getValuesFromUserInput($cf_map,$name_suffix='',$input_values=null)
     $gogo->cf_types = $gogo->cfield_types = $this->get_available_types();
     
     // MAGIC 10
-    $gogo->drawControlsOnTop = (null != $gogo->cf_map && count($gogo->cf_map) > 10); 
+    $gogo->drawControlsOnTop = (null != $gogo->cf_map && count((array)$gogo->cf_map) > 10); 
 
     return $gogo;
   }

--- a/lib/functions/cfield_mgr.class.php
+++ b/lib/functions/cfield_mgr.class.php
@@ -970,7 +970,7 @@ class cfield_mgr extends tlObject
     $map = $this->db->fetchRowsIntoMap($sql,'id');
     if(!is_null($map) && !is_null($opt))
     {  
-      $k2l = array_keys($map);
+      $k2l = array_keys((array)$map);
       foreach($k2l as $key)
       {
         $map[$key]['enabled_on_context'] = '';
@@ -1455,7 +1455,7 @@ class cfield_mgr extends tlObject
 		$linked_tprojects = $this->get_linked_testprojects($id);
 		if( !is_null($linked_tprojects) && count((array)$linked_tprojects) > 0 )
 		{
-		  $target=array_keys($linked_tprojects);
+		  $target=array_keys((array)$linked_tprojects);
 		  foreach($target as $tproject_id)
 		  {
         $this->unlink_from_testproject($tproject_id,(array)$id);
@@ -2194,7 +2194,7 @@ function getXMLRPCServerParams($nodeID,$tplanLinkID=null)
 		}
 		else
 		{
-			$key2loop = array_keys($server_info);
+			$key2loop = array_keys((array)$server_info);
 			foreach($key2loop as $target)
 			{
 				$dummy = explode('_',$target);

--- a/lib/functions/code_testing/dBug.php
+++ b/lib/functions/code_testing/dBug.php
@@ -81,7 +81,7 @@ class dBug {
 		$arrInclude = array("include","include_once","require","require_once");
 		
 		//check for any included/required files. if found, get array of the last included file (they contain the right line numbers)
-		for($i=count($arrBacktrace)-1; $i>=0; $i--) {
+		for($i=count((array)$arrBacktrace)-1; $i>=0; $i--) {
 			$arrCurrent = $arrBacktrace[$i];
 			if(array_key_exists("function", $arrCurrent) && 
 				(in_array($arrCurrent["function"], $arrInclude) || (0 != strcasecmp($arrCurrent["function"], "dbug"))))
@@ -282,7 +282,7 @@ class dBug {
 		echo "<tr><td class=\"dBug_resourceKey\">&nbsp;</td>";
 		for($i=0;$i<$numfields;$i++) {
 			$field_header = "";
-			for($j=0; $j<count($arrFields); $j++) {
+			for($j=0; $j<count((array)$arrFields); $j++) {
 				$db_func = $db."_field_".$arrFields[$j];
 				if(function_exists($db_func)) {
 					$fheader = call_user_func($db_func, $var, $i). " ";
@@ -380,7 +380,7 @@ class dBug {
 		$this->xmlSData[$this->xmlCount].='$this->makeTDHeader("xml","xmlName");';
 		$this->xmlSData[$this->xmlCount].='echo "<strong>'.$this->xmlName[$this->xmlCount].'</strong>".$this->closeTDRow();';
 		$this->xmlSData[$this->xmlCount].='$this->makeTDHeader("xml","xmlAttributes");';
-		if(count($attribs)>0)
+		if(count((array)$attribs)>0)
 			$this->xmlSData[$this->xmlCount].='$this->varIsArray($this->xmlAttrib['.$this->xmlCount.']);';
 		else
 			$this->xmlSData[$this->xmlCount].='echo "&nbsp;";';

--- a/lib/functions/code_testing/get_linked_tcversions.testplan.class.test.php
+++ b/lib/functions/code_testing/get_linked_tcversions.testplan.class.test.php
@@ -31,7 +31,7 @@ $descr='Get all linked test case versions WITHOUT any kind of filter and/or opti
 $lt=$obj_mgr->get_linked_tcversions($tplan_id);
 echo '<hr>';
 echo $descr . '<br>';
-echo 'Qta records:' . count($lt)  . '<br>';
+echo 'Qta records:' . count((array)$lt)  . '<br>';
 new dBug($lt);
 */
 // ------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ if( !is_null($opt) )
 	echo 'Options:';
 	new dBug($opt);
 }
-echo 'Qta records:' . count($lt)  . '<br>';
+echo 'Qta records:' . count((array)$lt)  . '<br>';
 new dBug($lt);
 // ------------------------------------------------------------------------------------
 
@@ -79,7 +79,7 @@ if( !is_null($opt) )
 	echo 'Options:';
 	new dBug($opt);
 }
-echo 'Qta records:' . count($lt)  . '<br>';
+echo 'Qta records:' . count((array)$lt)  . '<br>';
 new dBug($lt);
 // ------------------------------------------------------------------------------------
 
@@ -102,7 +102,7 @@ if( !is_null($opt) )
 	echo 'Options:';
 	new dBug($opt);
 }
-echo 'Qta records:' . count($lt)  . '<br>';
+echo 'Qta records:' . count((array)$lt)  . '<br>';
 new dBug($lt);
 // ------------------------------------------------------------------------------------
 
@@ -125,7 +125,7 @@ if( !is_null($opt) )
 	echo 'Options:';
 	new dBug($opt);
 }
-echo 'Qta records:' . count($lt)  . '<br>';
+echo 'Qta records:' . count((array)$lt)  . '<br>';
 new dBug($lt);
 // ------------------------------------------------------------------------------------
 
@@ -150,7 +150,7 @@ if( !is_null($opt) )
 	echo 'Options:';
 	new dBug($opt);
 }
-echo 'Qta records:' . count($lt)  . '<br>';
+echo 'Qta records:' . count((array)$lt)  . '<br>';
 new dBug($lt);
 // ------------------------------------------------------------------------------------
 

--- a/lib/functions/code_testing/testcase.class.test.php
+++ b/lib/functions/code_testing/testcase.class.test.php
@@ -34,7 +34,7 @@ $context->build_id = 20;
 $context->tester_id = 10;
 
 
-$stepsID = array_keys($steps['notes']);
+$stepsID = array_keys((array)$steps['notes']);
 //$tcase_mgr->deleteStepsPartialExec($stepsID,$context);
 
 $m2r = 'saveStepsPartialExec';

--- a/lib/functions/code_testing/testplan.class.test.php
+++ b/lib/functions/code_testing/testplan.class.test.php
@@ -216,7 +216,7 @@ new dBug($build_mgr);
 
 
 $all_builds=$tplan_mgr->get_builds($tplan_id);
-$dummy=array_keys($all_builds);
+$dummy=array_keys((array)$all_builds);
 $build_id=$dummy[0];
 
 echo "<pre> build manager - get_by_id(\$id)";echo "</pre>";

--- a/lib/functions/common.php
+++ b/lib/functions/common.php
@@ -1210,12 +1210,12 @@ function setUpEnvForRemoteAccess(&$dbHandler,$apikey,$rightsCheck=null,$opt=null
 
    $tlCfg->workflowStatus=array('draft' => 1, 'review' => 2);
    $i18nlabels = getLabels('workflowStatus','key');
-   array_keys($i18nlabels) will return array('draft','review');
+   array_keys((array)$i18nlabels) will return array('draft','review');
  
 
    $tlCfg->workflowStatus=array('draft' => 1, 'review' => 2);
    $i18nlabels = getLabels('workflowStatus','code');
-   array_keys($i18nlabels) will return array(1,2);
+   array_keys((array)$i18nlabels) will return array(1,2);
 
    @internal revisions
    @since 1.9.7
@@ -1885,7 +1885,7 @@ function getGrantSetWithExit(&$dbHandler,&$argsObj,&$tprojMgr,$opt=null) {
 
   if( ($forceToNo = $argsObj->userIsBlindFolded) ) {
     $tr = array_merge($systemWideRights, $r2cTranslate);
-    $grants = array_fill_keys(array_keys($tr), 'no');
+    $grants = array_fill_keys(array_keys((array)$tr), 'no');
 
     foreach($r2cSame as $rr) {
       $grants[$rr] = 'no';

--- a/lib/functions/common.php
+++ b/lib/functions/common.php
@@ -556,7 +556,7 @@ function strings_stripSlashes($parameter,$bGPC = true)
   if (is_array($parameter))
   {
     $retParameter = null;
-    if (sizeof($parameter))
+    if (sizeof((array)$parameter))
     {
       foreach($parameter as $key=>$value)
       {
@@ -950,7 +950,7 @@ function split_localized_date($timestamp,$dateFormat)
   $format = preg_split('//', $strippedDateFormat, -1, PREG_SPLIT_NO_EMPTY);
   $pieces = explode($splitChar,$timestamp);
   $result = array();
-  if( count($pieces) == 3 )  // MAGIC ALLOWED 
+  if( count((array)$pieces) == 3 )  // MAGIC ALLOWED 
   {
     $k2t = array('Y' => 'year', 'm' => 'month', 'd' => 'day');
     foreach ($format as $idx => $access) 
@@ -1136,7 +1136,7 @@ function setUpEnvForRemoteAccess(&$dbHandler,$apikey,$rightsCheck=null,$opt=null
   doDBConnect($dbHandler);
 
   $user = tlUser::getByAPIKey($dbHandler,$apikey);
-  if( count($user) == 1 ) {
+  if( count((array)$user) == 1 ) {
     $_SESSION['lastActivity'] = time();
     $userObj = new tlUser(key($user));
     $userObj->readFromDB($dbHandler);
@@ -1571,7 +1571,7 @@ function initUserEnv(&$dbH, $context, $opt=null) {
   $args->zeroTestProjects = $gui->zeroTestProjects; 
 
   $args->userIsBlindFolded = 
-    (is_null($gui->prjSet) || count($gui->prjSet) == 0) 
+    (is_null($gui->prjSet) || count((array)$gui->prjSet) == 0) 
     && $gui->prjQtyWholeSystem > 0;
   if( $args->userIsBlindFolded ) {
     $args->current_tproject_id = 0;
@@ -1607,7 +1607,7 @@ function initUserEnv(&$dbH, $context, $opt=null) {
     // $gpOpt = array('output' => 'map');
     $gpOpt = null;
     $gui->tplanSet = (array)$args->user->getAccessibleTestPlans($dbH,$args->tproject_id,$gpOpt);
-    $gui->countPlans = count($gui->tplanSet);
+    $gui->countPlans = count((array)$gui->tplanSet);
   
     /* 20191212 - will remove because have created issues
        with IVU, and I not sure anymore of usefulness 
@@ -2052,7 +2052,7 @@ function getFirstLevelMenuStructure()
  *
  */
 function doTestPlanSetup(&$gui) {
-  $loop2do = count($gui->tplanSet);
+  $loop2do = count((array)$gui->tplanSet);
   if( $loop2do == 0 ) {
     return $gui->tplan_id;
   }

--- a/lib/functions/csrf.php
+++ b/lib/functions/csrf.php
@@ -181,7 +181,7 @@ function smarty_csrf_filter($source, $smarty) {
  */
 function csrfguard_start()
 {
-  if (count($_POST))
+  if (count((array)$_POST))
   {
     if (!isset($_POST['CSRFName']))
     {

--- a/lib/functions/csv.inc.php
+++ b/lib/functions/csv.inc.php
@@ -29,7 +29,7 @@ function exportDataToCSV($data,$sourceKeys,$destKeys,$bWithHeader = 0,$delimiter
 		$csvContent .= $header . $newLine;
 	}
 
-	$len = count($sourceKeys);
+	$len = count((array)$sourceKeys);
   foreach($data as $values) { 
 		$line = '';
 		for($k = 0;$k < $len;$k++) {
@@ -131,7 +131,7 @@ function importCSVData($fileName,$fieldMappings, $options = null) {
 	        	{
 					if( $check_syntax)
 					{
-						$fieldsQty = count($data);
+						$fieldsQty = count((array)$data);
 						if( !($do_import = ($fieldsQty == $my['options']['fieldQty'])))
 						{
 							$msg = 'Field count:' . $fieldsQty . ' Required Field count: ' . 

--- a/lib/functions/database.class.php
+++ b/lib/functions/database.class.php
@@ -449,7 +449,7 @@ class database {
 
   /** @return integer count queries */
   function count_queries () {
-    return count( $this->queries_array );
+    return count((array)$this->queries_array);
     }
 
 
@@ -470,7 +470,7 @@ class database {
 
   /** get total time for queries */
   function time_queries () {
-    $t_count = count( $this->queries_array );
+    $t_count = count((array)$this->queries_array);
     $t_total = 0;
     for ( $i = 0; $i < $t_count; $i++ ) {
       $t_total += $this->queries_array[$i][1];

--- a/lib/functions/database.class.php
+++ b/lib/functions/database.class.php
@@ -577,7 +577,7 @@ class database {
       $row = $this->fetchFirstRow($sql);
     if ($row)
       {
-      $fieldName = array_keys($row);   
+      $fieldName = array_keys((array)$row);   
       return $row[$fieldName[0]];
     }
     return null;

--- a/lib/functions/doAuthorize.php
+++ b/lib/functions/doAuthorize.php
@@ -385,7 +385,7 @@ function doSSOWebServerVar(&$dbHandler,$authCfg=null)
 
     $rs = $dbHandler->get_recordset($sql);
     
-    $login_exists = !is_null($rs) && ($accountQty =count($rs)) == 1;
+    $login_exists = !is_null($rs) && ($accountQty =count((array)$rs)) == 1;
     $loginKO = true;
 
     if( $login_exists  ) {

--- a/lib/functions/exec.inc.php
+++ b/lib/functions/exec.inc.php
@@ -109,7 +109,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
   // because our choice is also get the test steps ids fromm these inputs.
   //
   if( isset($_REQUEST['step_notes']) ) {
-    $stepsIDSet = array_keys($_REQUEST['step_notes']);
+    $stepsIDSet = array_keys((array)$_REQUEST['step_notes']);
     $ctx = new stdClass();
     $ctx->testplan_id = $execSign->tplan_id;
     $ctx->platform_id = $executedInPlatform;
@@ -170,7 +170,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
       // 
       $tcvRelations = (array)$tcaseMgr->getTCVRelationsRaw($tcversion_id);
       if( count((array)$tcvRelations) > 0 ) {
-        $itemSet = array_keys($tcvRelations);
+        $itemSet = array_keys((array)$tcvRelations);
         $tcaseMgr->closeOpenTCVRelation($itemSet,LINK_TC_RELATION_CLOSED_BY_EXEC);
       }
 
@@ -224,7 +224,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
 
       if( $hasMoreData->nike ) {
         $target = DB_TABLE_PREFIX . 'execution_tcsteps';
-        $key2loop = array_keys($exec_data['step_notes']);
+        $key2loop = array_keys((array)$exec_data['step_notes']);
 
         $stepsSql = " SELECT id, step_number FROM " . DB_TABLE_PREFIX . 'tcsteps' . 
                     " WHERE id IN (" . implode(",", $key2loop) . ")"; 
@@ -272,7 +272,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
                               $_FILES['uploadedFile']['tmp_name'][$step_id][$moe] : '';
 
                   if ($fSize && $fTmpName != "") {
-                    $fk2loop = array_keys($_FILES['uploadedFile']);
+                    $fk2loop = array_keys((array)$_FILES['uploadedFile']);
                     foreach($fk2loop as $tk) {
                       $fInfo[$tk] = $_FILES['uploadedFile'][$tk][$step_id][$moe];
                     }  
@@ -307,7 +307,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
                             $_FILES['uploadedFile']['tmp_name'][$step_id] : '';
 
                 if ($fSize && $fTmpName != "") {
-                  $fk2loop = array_keys($_FILES['uploadedFile']);
+                  $fk2loop = array_keys((array)$_FILES['uploadedFile']);
                   foreach($fk2loop as $tk) {
                     $fInfo[$tk] = $_FILES['uploadedFile'][$tk][$step_id];
                   }  
@@ -770,7 +770,7 @@ function copyIssues(&$dbHandler,$source,$dest) {
   $linkedIssues = $dbHandler->fetchRowsIntoMap($sql,'bug_id');
   if( !is_null($linkedIssues) )
   {  
-    $idSet = array_keys($linkedIssues);
+    $idSet = array_keys((array)$linkedIssues);
     $safeDest = intval($dest);
 
     $blist = implode("','", $idSet);
@@ -1068,7 +1068,7 @@ function addAttachmentsToExec($execID,&$docRepo) {
     $fTmpName = isset($honeyPot['tmp_name'][$moe]) ? $honeyPot['tmp_name'][$moe] : '';
 
     if ($fSize >0  && $fTmpName != "") {
-      $fk2loop = array_keys($_FILES['uploadedFile']);
+      $fk2loop = array_keys((array)$_FILES['uploadedFile']);
       foreach($fk2loop as $tk) {
         $fInfo[$tk] = $honeyPot[$tk][$moe];
       }  

--- a/lib/functions/exec.inc.php
+++ b/lib/functions/exec.inc.php
@@ -169,7 +169,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
 
       // 
       $tcvRelations = (array)$tcaseMgr->getTCVRelationsRaw($tcversion_id);
-      if( count($tcvRelations) > 0 ) {
+      if( count((array)$tcvRelations) > 0 ) {
         $itemSet = array_keys($tcvRelations);
         $tcaseMgr->closeOpenTCVRelation($itemSet,LINK_TC_RELATION_CLOSED_BY_EXEC);
       }
@@ -263,7 +263,7 @@ function write_execution(&$db,&$execSign,&$exec_data,&$issueTracker) {
 
               // May be we have enabled MULTIPLE on file upload
               if( is_array($_FILES['uploadedFile']['name'][$step_id])) {
-                $curly = count($_FILES['uploadedFile']['name'][$step_id]); 
+                $curly = count((array)$_FILES['uploadedFile']['name'][$step_id]); 
                 for($moe=0; $moe < $curly; $moe++) {
                   $fSize = isset($_FILES['uploadedFile']['size'][$step_id][$moe]) ? 
                            $_FILES['uploadedFile']['size'][$step_id][$moe] : 0;
@@ -573,7 +573,7 @@ function delete_execution(&$db,$exec_id)
   $sql[] = "DELETE FROM {$tables['execution_tcsteps']} WHERE execution_id = {$sid}";
   
   // This delete HAS TO BE THE LATEST, because is the PARENT
-  $ldx = count($sql);
+  $ldx = count((array)$sql);
   $sql[$ldx] = "DELETE FROM {$tables['executions']} WHERE id = {$sid}";
 
   foreach ($sql as $the_stm)
@@ -853,7 +853,7 @@ function generateIssueText($dbHandler,$argsObj,$itsObj,$opt=null) {
                      'tc_name', 'tc_external_id');
 
     $lbl = array();
-    $l2d = count($lblKeys);
+    $l2d = count((array)$lblKeys);
     for($ldx=0; $ldx < $l2d; $ldx++) {
       $lbl[$lblKeys[$ldx]] = lang_get($lblKeys[$ldx]);
     }
@@ -1057,7 +1057,7 @@ function addAttachmentsToExec($execID,&$docRepo) {
     $honeyPot[$bee] = (array)$_FILES['uploadedFile'][$bee][0];
   }
 
-  $curly = count($honeyPot);
+  $curly = count((array)$honeyPot);
   $op = new stdClass();
   $op->msg = '';
 

--- a/lib/functions/execTreeMenu.inc.php
+++ b/lib/functions/execTreeMenu.inc.php
@@ -194,7 +194,7 @@ function execTree(&$dbHandler,&$menuUrl,$context,$objFilters,$objOptions)
 
     if( $filters['keyword_filter_type'] == 'And' && !is_null($tplan_tcases)) {
       $kwc = count((array)$filters['keyword_id']);
-      $ak = array_keys($tplan_tcases);
+      $ak = array_keys((array)$tplan_tcases);
       $mx = null;
       foreach($ak as $tk) {
         if($tplan_tcases[$tk]['recordcount'] == $kwc) {
@@ -226,7 +226,7 @@ function execTree(&$dbHandler,&$menuUrl,$context,$objFilters,$objOptions)
       }
 
       if( null !== $tcc && count((array)$tcc) > 0 ) {
-        $tcIDSet = array_keys($tplan_tcases);
+        $tcIDSet = array_keys((array)$tplan_tcases);
         foreach($tcIDSet as $iID) {
           if( isset($tcc[$iID]) ) {
             $tplan_tcases[$iID]['exec_status'] = 
@@ -422,7 +422,7 @@ function prepareExecTreeNode(&$db,&$node,&$map_node_tccount,
     $debugMsg = 'Class: ' . __CLASS__ . ' - ' . 'Method: ' . __FUNCTION__ . ' - ';
 
     $resultsCfg = config_get('results');
-    $status_descr_list = array_keys($resultsCfg['status_code']);
+    $status_descr_list = array_keys((array)$resultsCfg['status_code']);
     $status_descr_list[] = 'testcase_count';
 
     $my = array();
@@ -779,7 +779,7 @@ function testPlanTree(&$dbHandler,&$menuUrl,$tproject_id,$tproject_name,$tplan_i
         if($doPinBall && !is_null($tplan_tcases))
         {
           $kwc = count((array)$filters['keyword_id']);
-          $ak = array_keys($tplan_tcases);
+          $ak = array_keys((array)$tplan_tcases);
           $mx = null;
           foreach($ak as $tk)
           {
@@ -834,7 +834,7 @@ function testPlanTree(&$dbHandler,&$menuUrl,$tproject_id,$tproject_name,$tplan_i
       $test_spec[$key] = $testcase_counters[$key];
     }
   
-    $keys = array_keys($tplan_tcases);
+    $keys = array_keys((array)$tplan_tcases);
     $renderTreeNodeOpt['hideTestCases'] = $my['options']['hideTestCases'];
     $renderTreeNodeOpt['tc_action_enabled'] = isset($my['options']['tc_action_enabled']) ? 
                                               $my['options']['tc_action_enabled'] : 1;
@@ -880,7 +880,7 @@ function testPlanTree(&$dbHandler,&$menuUrl,$tproject_id,$tproject_name,$tplan_i
 function helperInitCounters()
 {
   $resultsCfg = config_get('results');
-  $items = array_keys($resultsCfg['status_code']);
+  $items = array_keys((array)$resultsCfg['status_code']);
   $items[] = 'testcase_count';
   $cc = array_fill_keys($items, 0);
   return $cc;

--- a/lib/functions/execTreeMenu.inc.php
+++ b/lib/functions/execTreeMenu.inc.php
@@ -193,7 +193,7 @@ function execTree(&$dbHandler,&$menuUrl,$context,$objFilters,$objOptions)
     }   
 
     if( $filters['keyword_filter_type'] == 'And' && !is_null($tplan_tcases)) {
-      $kwc = count($filters['keyword_id']);
+      $kwc = count((array)$filters['keyword_id']);
       $ak = array_keys($tplan_tcases);
       $mx = null;
       foreach($ak as $tk) {
@@ -225,7 +225,7 @@ function execTree(&$dbHandler,&$menuUrl,$context,$objFilters,$objOptions)
         }  
       }
 
-      if( null !== $tcc && count($tcc) > 0 ) {
+      if( null !== $tcc && count((array)$tcc) > 0 ) {
         $tcIDSet = array_keys($tplan_tcases);
         foreach($tcIDSet as $iID) {
           if( isset($tcc[$iID]) ) {
@@ -513,7 +513,7 @@ function prepareExecTreeNode(&$db,&$node,&$map_node_tccount,
     {
       // node is a Test Suite or Test Project
       $childNodes = &$node['childNodes'];
-      $childNodesQty = count($childNodes);
+      $childNodesQty = count((array)$childNodes);
       for($idx = 0;$idx < $childNodesQty ;$idx++)
       {
         $current = &$childNodes[$idx];
@@ -778,7 +778,7 @@ function testPlanTree(&$dbHandler,&$menuUrl,$tproject_id,$tproject_name,$tplan_i
         $tplan_tcases = $dbHandler->$kmethod($sql2run,'tcase_id');
         if($doPinBall && !is_null($tplan_tcases))
         {
-          $kwc = count($filters['keyword_id']);
+          $kwc = count((array)$filters['keyword_id']);
           $ak = array_keys($tplan_tcases);
           $mx = null;
           foreach($ak as $tk)

--- a/lib/functions/exec_cfield_mgr.class.php
+++ b/lib/functions/exec_cfield_mgr.class.php
@@ -102,7 +102,7 @@ function html_table_of_custom_field_inputs($htmlInputSize=0)
       // make it a parameter if someone really wants to keep it.
       $custom_field_types_id=array_flip($this->custom_field_types);
 
-      if( !is_null($cf) and count($cf) > 0 )
+      if( !is_null($cf) and count((array)$cf) > 0 )
       {
         foreach ($cf as $key => $value )
         {
@@ -127,7 +127,7 @@ function html_table_of_custom_field_inputs($htmlInputSize=0)
                 // unset($cf[$key]);
             //}
         }
-      } // if( !is_null($cf) and count($cf) > 0 )
+      } // if( !is_null($cf) and count((array)$cf) > 0 )
       return($cf);
     }
 

--- a/lib/functions/exttable.class.php
+++ b/lib/functions/exttable.class.php
@@ -226,7 +226,7 @@ class tlExtTable extends tlTable
     }
     
     $s = '[';
-    $n_columns = sizeof($this->columns);
+    $n_columns = sizeof((array)$this->columns);
     $options = array('width','hidden','groupable','hideable');
 
     for ($i=0; $i<$n_columns; $i++) 
@@ -339,7 +339,7 @@ class tlExtTable extends tlTable
   function buildFields()
   {
     $s = '[';
-    $n_columns = sizeof($this->columns);
+    $n_columns = sizeof((array)$this->columns);
     for ($i=0; $i < $n_columns; $i++) {
       $column = $this->columns[$i];
       $s .= "{name: '{$column['col_id']}'";

--- a/lib/functions/exttable.class.php
+++ b/lib/functions/exttable.class.php
@@ -491,7 +491,7 @@ class tlExtTable extends tlTable
     $resultsCfg = config_get('results');
     $jsCode = "status_code_order = new Array();\n";
         
-    $verboseStatusOrder=array_keys($resultsCfg["status_label_for_exec_ui"]);
+    $verboseStatusOrder=array_keys((array)$resultsCfg["status_label_for_exec_ui"]);
     foreach( $verboseStatusOrder as $order => $status )
     {
       $code = $resultsCfg['status_code'][$status];

--- a/lib/functions/lang_api.php
+++ b/lib/functions/lang_api.php
@@ -195,7 +195,7 @@ function lang_get_smarty($params, $smarty) {
   $myLocale=isset($params['locale']) ? $params['locale'] : null;
   if(  isset($params['var']) ) {
     $labels2translate=explode(',',$params['s']);
-    if( count($labels2translate) == 1) {
+    if( count((array)$labels2translate) == 1) {
       $myLabels=lang_get($params['s'], $myLocale);
     } else {
       $myLabels=array();

--- a/lib/functions/lang_api.php
+++ b/lib/functions/lang_api.php
@@ -262,7 +262,7 @@ function lang_load( $p_lang, $p_dir = null ) {
   }
 
   $t_vars = get_defined_vars();
-  foreach( array_keys($t_vars) as $t_var ) 
+  foreach( array_keys((array)$t_vars) as $t_var ) 
   {
     $t_lang_var = preg_replace( '/^TLS_/', '', $t_var );
     if ( $t_lang_var != $t_var) 

--- a/lib/functions/ldap_api.php
+++ b/lib/functions/ldap_api.php
@@ -29,7 +29,7 @@ function ldap_connect_bind( $authCfg, $p_binddn = '', $p_password = '')
 
   $t_message = "Attempting connection to LDAP ";
   $t_ldap_uri = parse_url($authCfg['ldap_server']);
-  if(count( $t_ldap_uri ) > 1) 
+  if(count((array)$t_ldap_uri) > 1) 
   {
     $t_message .= "URI {$authCfg['ldap_server']}.";
     $t_ds = ldap_connect($authCfg['ldap_server']);

--- a/lib/functions/logger.class.php
+++ b/lib/functions/logger.class.php
@@ -93,7 +93,7 @@ class tlLogger extends tlObject
   {
     parent::__construct();
     
-    $this->loggerTypeDomain = array_flip(array_keys($this->loggerTypeClass));
+    $this->loggerTypeDomain = array_flip(array_keys((array)$this->loggerTypeClass));
     foreach($this->loggerTypeClass as $id => $className)
     {
       $class2call = $className;

--- a/lib/functions/metastring.class.php
+++ b/lib/functions/metastring.class.php
@@ -157,7 +157,7 @@ class tlMetaString extends tlObject
 		$subjects = array();
 		$replacements = array();
 		$params = (array)$this->helper->params;
-		for($i = 0;$i < sizeof($params); $i++) {
+		for($i = 0;$i < sizeof((array)$params); $i++) {
 			$param = $params[$i];
 			if (is_array($param)) {
 				$item = null;

--- a/lib/functions/object.class.php
+++ b/lib/functions/object.class.php
@@ -319,7 +319,7 @@ abstract class tlObject implements iSerialization
       $tableNames = (array)$tableNames;
       $tableNames = array_flip($tableNames);      
       $tables = array_intersect_key($tables,$tableNames);
-      if (sizeof($tables) != sizeof($tableNames)) {
+      if (sizeof((array)$tables) != sizeof((array)$tableNames)) {
         throw new Exception("Wrong table name(s) for getDBTables() detected!");
       } 
     }
@@ -355,7 +355,7 @@ abstract class tlObject implements iSerialization
       $itemNames = (array)$itemNames;
       $itemNames = array_flip($itemNames);      
       $items = array_intersect_key($items,$itemNames);
-      if (sizeof($items) != sizeof($itemNames)) {
+      if (sizeof((array)$items) != sizeof((array)$itemNames)) {
         $msg = "Wrong view name(s) for " . __FUNCTION__ . " detected!";
         throw new Exception($msg);
       } 
@@ -633,7 +633,7 @@ abstract class tlDBObject extends tlObject implements iDBSerialization
                                              $detailLevel = self::TLOBJ_O_GET_DETAIL_FULL)
   {
     $items = null;
-    if (null != $ids && sizeof($ids)) { 
+    if (null != $ids && sizeof((array)$ids)) { 
       $dummyItem = new $className();
       $query = $dummyItem->getReadFromDBQuery($ids,self::TLOBJ_O_SEARCH_BY_ID,$detailLevel);
       $result = $db->exec_query($query);

--- a/lib/functions/plugin_api.php
+++ b/lib/functions/plugin_api.php
@@ -513,7 +513,7 @@ function plugin_init_installed()
 
   plugin_register_installed();
 
-  $t_plugins = array_keys($g_plugin_cache);
+  $t_plugins = array_keys((array)$g_plugin_cache);
 
   foreach ($t_plugins as $t_basename) 
   {

--- a/lib/functions/print.inc.php
+++ b/lib/functions/print.inc.php
@@ -241,7 +241,7 @@ function renderReqForPrinting(&$db,$node, &$options, $tocPrefix, $reqLevel, $tpr
       (array)$req_mgr->getGoodForReqVersion($req['version_id'],
         array('verbose' => true, 'tproject_id' => $tprojectID));
 
-    if (count($req_coverage) > 0) {
+    if (count((array)$req_coverage) > 0) {
       $output .=  "<tr><td width=\"$firstColWidth\"><span class=\"label\">" . $labels['related_tcs'] . 
                   "</span></td>" . "<td>";
       foreach ($req_coverage[$req['version_id']] as $tc) {
@@ -273,7 +273,7 @@ function renderReqForPrinting(&$db,$node, &$options, $tocPrefix, $reqLevel, $tpr
   // since 1.9.18 => we need to use req version
   $attachSet =  (array)$req_mgr->getAttachmentInfos($req['revision_id']);
 
-  if (count($attachSet)) {
+  if (count((array)$attachSet)) {
     $output .= "<tr><td width=\"$firstColWidth\"><span class=\"label\">" .
                $labels['attached_files'] . "</span></td><td>";
     
@@ -485,7 +485,7 @@ function renderReqSpecNodeForPrinting(&$db, &$node, &$options, $tocPrefix, $rsLe
   }
   
   $attachSet =  (array)$req_spec_mgr->getAttachmentInfos($spec_id);
-  if (count($attachSet)) {
+  if (count((array)$attachSet)) {
     $output .= "<tr><td width=\"$firstColWidth\"><span class=\"label\">" .
                $labels['attached_files'] . "</span></td><td><ul>";
 
@@ -564,7 +564,7 @@ function renderReqSpecTreeForPrinting(&$db, &$node, &$options,$tocPrefix, $rsCnt
     
     $childNodes = $node['childNodes'];
     $rsCnt = 0;
-         $children_qty = sizeof($childNodes);
+         $children_qty = sizeof((array)$childNodes);
     for($i = 0;$i < $children_qty ;$i++)
     {
       $current = $childNodes[$i];
@@ -833,7 +833,7 @@ function renderTestSpecTreeForPrinting(&$db,&$node,&$options,$env,$context,$tocP
     // Need to be a LOCAL COUNTER for each PARENT
     $TOCCounter = 0;
     $childNodes = $node['childNodes'];
-    $children_qty = sizeof($childNodes);
+    $children_qty = sizeof((array)$childNodes);
     for($idx = 0;$idx < $children_qty ;$idx++)
     {
       $current = $childNodes[$idx];
@@ -1064,7 +1064,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
                             'renderImageInline' => true));
 
 
-  if( null != $tcInfo && count($tcInfo) > 0) {
+  if( null != $tcInfo && count((array)$tcInfo) > 0) {
     $tcInfo = $tcInfo[0];
   } else {
     $msg = basename(__FILE__) . ' >' .
@@ -1231,7 +1231,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
 
           $code .= '</tr>';     
 
-          $loop2do = count($tcInfo[$key]);
+          $loop2do = count((array)$tcInfo[$key]);
           for($ydx=0 ; $ydx < $loop2do; $ydx++) {
             $code .= '<tr>' .
                      '<td width="5">' .  $tcInfo[$key][$ydx]['step_number'] . 
@@ -1434,7 +1434,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
              $labels['reqs'].'</span>'; 
     $code .= '<td colspan="' . ($cfg['tableColspan']-1) . '">';
 
-    if (sizeof($requirements)) {
+    if (sizeof((array)$requirements)) {
       foreach ($requirements as $req) {
         $code .=  htmlspecialchars($req['req_doc_id'] . ":  " . $req['title']) .
                   " " .
@@ -1457,7 +1457,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
     $code .= '<td colspan="' . ($cfg['tableColspan']-1) . '">';
 
     $kwSet = (array)$st->tc_mgr->getKeywords($id,$tcVersionID,null,array('fields' => 'keyword_id,KW.keyword'));
-    if (sizeof($kwSet)) {
+    if (sizeof((array)$kwSet)) {
       foreach ($kwSet as $kw) {
         $code .= htmlspecialchars($kw['keyword']) . "<br />";
       }
@@ -1475,7 +1475,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
     $code .= '<td colspan="' . ($cfg['tableColspan']-1) . '">';
 
     $itSet = (array)$st->tc_mgr->getPlatforms($id,$tcVersionID,null,array('fields' => 'platform_id,PL.name'));
-    if (sizeof($itSet)) {
+    if (sizeof((array)$itSet)) {
       foreach ($itSet as $it) {
         $code .= htmlspecialchars($it['name']) . "<br />";
       }
@@ -1489,7 +1489,7 @@ function renderTestCaseForPrinting(&$db,&$node,&$options,$env,$context,$indentLe
 
   // Attachments
   $attachSet =  (array)$st->tc_mgr->getAttachmentInfos($tcVersionID);
-  if (count($attachSet) > 0) {
+  if (count((array)$attachSet) > 0) {
     $code .= '<tr><td> <span class="label">' . $labels['attached_files'] . '</span></td>';
     $code .= '<td colspan="' . ($cfg['tableColspan']-2) . '"><ul>';
 
@@ -1751,7 +1751,7 @@ function renderTestSuiteNodeForPrinting(&$db,&$node,$env,&$options,$context,$toc
     $tInfo = null;
 
     $attachSet =  (array)$tsuite_mgr->getAttachmentInfos($node['id']);
-    if (count($attachSet) > 0) {
+    if (count((array)$attachSet) > 0) {
       $code .= '<table><caption style="text-align:left;">' . $l10n['attached_files'] . '</caption>';
       $code .= '<tr><td>&nbsp</td>';
       $code .= '<td><ul>';
@@ -1967,7 +1967,7 @@ function initRenderTestCaseCfg($options) {
                     'priority', 'high_priority','medium_priority','low_priority',
                     'attached_files','platforms');
                       
-  $labelsQty=count($labelsKeys);         
+  $labelsQty=count((array)$labelsKeys);         
   for($idx=0; $idx < $labelsQty; $idx++) {
     $labels[$labelsKeys[$idx]] = lang_get($labelsKeys[$idx]);
   }

--- a/lib/functions/requirement_mgr.class.php
+++ b/lib/functions/requirement_mgr.class.php
@@ -169,7 +169,7 @@ function get_by_id($id,$version_id=self::ALL_VERSIONS,$version_number=1,$options
     }
   }
 
-  if( count($dummy) > 1) {
+  if( count((array)$dummy) > 1) {
     $filter_clause = implode(" AND ",$dummy);
   }
 
@@ -1142,7 +1142,7 @@ function create_tc_from_requirement($mixIdReq,$srs_id, $user_id, $tproject_id = 
       // Useful for audit 
       $tcInfo = $this->tree_mgr->get_node_hierarchy_info($testcase_id);
 
-      $loop2do = count($reqLatestVersionIDSet);
+      $loop2do = count((array)$reqLatestVersionIDSet);
       for($idx=0; $idx < $loop2do; $idx++) {
         if( is_null($coverage) || 
             !isset($coverage[$reqLatestVersionIDSet[$idx]]) ) {
@@ -1347,7 +1347,7 @@ function exportReqToXML($id,$tproject_id=null, $inc_attachments=false)
 			}
 		}
 	  
-		if( !is_null($attachments) && count($attachments) > 0 )
+		if( !is_null($attachments) && count((array)$attachments) > 0 )
 		{
 			$attchRootElem = "<attachments>\n{{XMLCODE}}\t\t</attachments>\n";
 			$attchElemTemplate = "\t\t\t<attachment>\n" .
@@ -1751,7 +1751,7 @@ function createFromMap($req,$tproject_id,$parent_id,$author_id,$filters = null,$
 					" WHERE ATT.id='{$this->db->prepare_string($attachment[id])}' " .
 					" AND ATT.fk_id={$srs_id} ";
 				$rsx=$this->db->get_recordset($sql);
-				$addAttachment = ( is_null($rsx) || count($rsx) < 1 );
+				$addAttachment = ( is_null($rsx) || count((array)$rsx) < 1 );
 				if( $addAttachment === false ){ // inform user that the attachment has been skipped
 					$knownAttachments[] = $attachment['name'];
 				}
@@ -1952,7 +1952,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
  {
     $xml = null;
     $cfMap=$this->get_linked_cfields($id,$version_id,$tproject_id);
-    if( !is_null($cfMap) && count($cfMap) > 0 ) {
+    if( !is_null($cfMap) && count((array)$cfMap) > 0 ) {
       $xml = $this->cfield_mgr->exportValueAsXML($cfMap);
     }
     return $xml;
@@ -2437,7 +2437,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
     $tproject_mgr = new testproject($this->db);
     $all_reqs = $tproject_mgr->get_all_requirement_ids($tproj_id);
     
-    if(count($all_reqs) > 0) 
+    if(count((array)$all_reqs) > 0) 
     {
       //only use maximum value of all reqs array
       $last_req = max($all_reqs);
@@ -2575,7 +2575,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
            " ORDER BY id ASC ";
    
     $relations['relations']= $this->db->get_recordset($sql);  
-    if( !is_null($relations['relations']) && count($relations['relations']) > 0 )
+    if( !is_null($relations['relations']) && count((array)$relations['relations']) > 0 )
     {
       $labels = $this->get_all_relation_labels();
       $label_keys = array_keys($labels);
@@ -2622,7 +2622,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
                  
         } // end foreach
         
-        $relations['num_relations'] = count($relations['relations']);
+        $relations['num_relations'] = count((array)$relations['relations']);
     }
     return $relations;
   }
@@ -3386,7 +3386,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
   
     // we borrow logic (may be one day we can put it on a central place) from
     // testcase class create_tcase_only()
-    if( !is_null($itemSet) && ($siblingQty=count($itemSet)) > 0 )
+    if( !is_null($itemSet) && ($siblingQty=count((array)$itemSet)) > 0 )
     {
             $nameSet = array_flip(array_keys($itemSet));
       $target = $title2check . ($suffix = sprintf($mask,++$siblingQty));
@@ -3542,7 +3542,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
       // FRL : interproject linking support
       $tproject_mgr = new testproject($this->db);
       $reqs = $this->get_by_id($relation['source_id'],requirement_mgr::LATEST_VERSION);
-      if ( ! is_null ( $reqs ) && count($reqs) > 0 )
+      if ( ! is_null ( $reqs ) && count((array)$reqs) > 0 )
       {
         $source_docid = $reqs[0]['req_doc_id'];
         if ($check_for_req_project)
@@ -3556,7 +3556,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
       }
   
       $reqs = $this->get_by_id($relation['destination_id'],requirement_mgr::LATEST_VERSION);
-      if( !is_null($reqs) && count($reqs) > 0 )
+      if( !is_null($reqs) && count((array)$reqs) > 0 )
       {
         $destination_docid = $reqs[0]['req_doc_id'];
         if ($check_for_req_project)
@@ -4051,7 +4051,7 @@ function getCoverageCounter($id) {
         $xx = explode($beginTag,$rse[$item_key]);
 
         // How many requests to replace ?
-        $xx2do = count($xx);
+        $xx2do = count((array)$xx);
         $ghost = '';
         for($xdx=0; $xdx < $xx2do; $xdx++) {
           // Hope was not a false request.
@@ -4060,7 +4060,7 @@ function getCoverageCounter($id) {
             // Theorically can be just ONE, but it depends
             // is user had not messed things.
             $yy = explode($endTag,$xx[$xdx]);
-            if( ($elc = count($yy)) > 0) {
+            if( ($elc = count((array)$yy)) > 0) {
               $atx = $yy[0];
               try {
                 if(isset($attSet[$id][$atx]) && $attSet[$id][$atx]['is_image']) {
@@ -4827,7 +4827,7 @@ function getCoverageCounter($id) {
         }                
       }
 
-      if( count($values) > 0 ) {
+      if( count((array)$values) > 0 ) {
         $sql .= " VALUES " . implode(',',$values);
         $this->db->exec_query($sql);
       }
@@ -4887,7 +4887,7 @@ function getCoverageCounter($id) {
                   WHERE id=$tprj";
         $dummy = $this->db->get_recordset($sqlP);
         
-        if( count($dummy) == 1 ) {
+        if( count((array)$dummy) == 1 ) {
           $prefix = $dummy[0]['prefix'];
         }          
         $glue = config_get('testcase_cfg');

--- a/lib/functions/requirement_mgr.class.php
+++ b/lib/functions/requirement_mgr.class.php
@@ -255,7 +255,7 @@ function get_by_id($id,$version_id=self::ALL_VERSIONS,$version_number=1,$options
 
   $rs = null;
   if(!is_null($recordset) && $my['options']['renderImageInline']) {
-    $k2l = array_keys($recordset);
+    $k2l = array_keys((array)$recordset);
     foreach($k2l as $akx) { 
       $this->renderImageAttachments($id,$recordset[$akx]);
     } 
@@ -267,9 +267,9 @@ function get_by_id($id,$version_id=self::ALL_VERSIONS,$version_number=1,$options
     switch ($decodeUserMode) {
       case 'complex':
         // output[REQID][0] = array('id' =>, 'xx' => ...)
-        $flevel = array_keys($recordset);
+        $flevel = array_keys((array)$recordset);
         foreach($flevel as $flk) {
-          $key2loop = array_keys($recordset[$flk]);
+          $key2loop = array_keys((array)$recordset[$flk]);
           foreach( $key2loop as $key ) {
             foreach( $user_keys as $ukey => $userid_field) {
               $rs[$flk][$key][$ukey] = '';
@@ -290,7 +290,7 @@ function get_by_id($id,$version_id=self::ALL_VERSIONS,$version_number=1,$options
       
       case 'simple':
       default:
-        $key2loop = array_keys($recordset);
+        $key2loop = array_keys((array)$recordset);
         foreach( $key2loop as $key ) {
           foreach( $user_keys as $ukey => $userid_field) {
             $rs[$key][$ukey] = '';
@@ -616,7 +616,7 @@ function update($id,$version_id,$reqdoc_id,$title, $scope, $user_id, $status, $t
       $sql .= " AND node_type_id=" . $this->node_types_descr_id['requirement_version'];
       
       $children_rs=$this->db->fetchRowsIntoMap($sql,'id');
-      $children = array_keys($children_rs); 
+      $children = array_keys((array)$children_rs); 
 
       // delete dependencies with test specification
       $sql = "DELETE FROM {$this->tables['req_coverage']} " . 
@@ -683,7 +683,7 @@ function update($id,$version_id,$reqdoc_id,$title, $scope, $user_id, $status, $t
              
       $revisionSet = $this->db->fetchRowsIntoMap($sql,'id');
       if( !is_null($revisionSet) ) {
-        $this->cfield_mgr->remove_all_design_values_from_node(array_keys($revisionSet));
+        $this->cfield_mgr->remove_all_design_values_from_node(array_keys((array)$revisionSet));
 
         $sql = "/* $debugMsg */ DELETE FROM {$this->tables['req_revisions']}
                                 WHERE parent_id IN ( {$implosion} ) ";
@@ -1025,7 +1025,7 @@ function create_tc_from_requirement($mixIdReq,$srs_id, $user_id, $tproject_id = 
 
     $nameSet = null;
     if( !is_null($itemSet) ){
-      $nameSet = array_flip(array_keys($itemSet));
+      $nameSet = array_flip(array_keys((array)$itemSet));
     }
     
     for ($idx = 0; $idx < $count; $idx++) {
@@ -2217,7 +2217,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
       
       // req_doc_id has limited size then we need to be sure that generated id will
       // not exceed DB size
-          $nameSet = array_flip(array_keys($itemSet));
+          $nameSet = array_flip(array_keys((array)$itemSet));
         $prefix = trim_and_limit($item_info['req_doc_id'],
                      $this->fieldSize->req_docid-strlen($mask)-$safety_len);
                      
@@ -2578,7 +2578,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
     if( !is_null($relations['relations']) && count((array)$relations['relations']) > 0 )
     {
       $labels = $this->get_all_relation_labels();
-      $label_keys = array_keys($labels);
+      $label_keys = array_keys((array)$labels);
       foreach($relations['relations'] as $key => $rel) 
       {
           
@@ -2802,7 +2802,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
     else 
     {
       // "related to" is not configured, so take last element as selected one
-      $keys = array_keys($htmlSelect['items']);
+      $keys = array_keys((array)$htmlSelect['items']);
       $selected_key = end($keys);
     }
     $htmlSelect['selected'] = $selected_key;
@@ -3108,7 +3108,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
       if( !is_null($rs) )
       {
         $lbl = init_labels(array('undefined' => 'undefined'));
-        $key2loop = array_keys($rs);
+        $key2loop = array_keys((array)$rs);
         foreach($key2loop as $ap)
         {
           $rs[$ap]['item_id'] = ($rs[$ap]['revision_id'] > 0) ? $rs[$ap]['revision_id'] : $rs[$ap]['version_id'];
@@ -3309,7 +3309,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
     $rs = $this->db->get_recordset($sql);
     
     if(!is_null($rs) && $my['opt']['renderImageInline']) {
-      $k2l = array_keys($rs);
+      $k2l = array_keys((array)$rs);
       foreach($k2l as $akx) { 
         $this->renderImageAttachments($rs[$akx]['req_id'],$rs[$akx]);
       } 
@@ -3327,7 +3327,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
   function decode_users(&$rs)
   {
       $userCache = null;  // key: user id, value: display name
-      $key2loop = array_keys($rs);
+      $key2loop = array_keys((array)$rs);
       $labels['undefined'] = lang_get('undefined');
       $user_keys = array('author' => 'author_id', 'modifier' => 'modifier_id');
       foreach( $key2loop as $key )
@@ -3388,7 +3388,7 @@ function html_table_of_custom_field_values($id,$child_id,$tproject_id=null)
     // testcase class create_tcase_only()
     if( !is_null($itemSet) && ($siblingQty=count((array)$itemSet)) > 0 )
     {
-            $nameSet = array_flip(array_keys($itemSet));
+            $nameSet = array_flip(array_keys((array)$itemSet));
       $target = $title2check . ($suffix = sprintf($mask,++$siblingQty));
       $final_len = strlen($target);
       if( $final_len > $title_max_len)
@@ -3871,10 +3871,10 @@ function getByIDBulkLatestVersionRevision($id,$opt=null)
     if( is_int($x[0]) )
     {
       // output[REQID][0] = array('id' =>, 'xx' => ...)
-      $flevel = array_keys($recordset);
+      $flevel = array_keys((array)$recordset);
       foreach($flevel as $flk)
       {
-        $key2loop = array_keys($recordset[$flk]);
+        $key2loop = array_keys((array)$recordset[$flk]);
         foreach( $key2loop as $key )
         {
           foreach( $user_keys as $ukey => $userid_field)
@@ -3901,7 +3901,7 @@ function getByIDBulkLatestVersionRevision($id,$opt=null)
     else
     {
       // output[REQID] = array('id' =>, 'xx' => ...)
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $key )
       {
         foreach( $user_keys as $ukey => $userid_field)
@@ -4131,7 +4131,7 @@ function getCoverageCounter($id) {
     $safe['user_id'] = intval($user_id);
     $safe['testproject_id'] = intval($tproject_id);
 
-    $fields = implode(',',array_keys($safe));
+    $fields = implode(',',array_keys((array)$safe));
 
     foreach($safe as $key => $val)
     {
@@ -4371,9 +4371,9 @@ function getCoverageCounter($id) {
                  "%logmsg%" => $log_msg,
                  "%version%" => $req['version'],
                  "%timestamp%" => date("D M j G:i:s T Y"));
-    $body['target'] = array_keys($trf);
+    $body['target'] = array_keys((array)$trf);
     $body['values'] = array_values($trf);
-    $subj['target'] = array_keys($trf);
+    $subj['target'] = array_keys((array)$trf);
     $subj['values'] = array_values($trf);
 
     foreach($iuSet as $ue)

--- a/lib/functions/requirement_mgr.class.php
+++ b/lib/functions/requirement_mgr.class.php
@@ -3867,7 +3867,7 @@ function getByIDBulkLatestVersionRevision($id,$opt=null)
     $rs = $recordset;
 
     // try to guess output structure
-    $x = array_keys(current($rs));
+    $x = array_keys((array)current($rs));
     if( is_int($x[0]) )
     {
       // output[REQID][0] = array('id' =>, 'xx' => ...)

--- a/lib/functions/requirement_spec_mgr.class.php
+++ b/lib/functions/requirement_spec_mgr.class.php
@@ -275,14 +275,14 @@ class requirement_spec_mgr extends tlObjectWithAttachments
     $output['nottestable'] = $this->get_requirements($id,'all',null,$getOptions,$getFilters);   
 
     // get coverage
-    if (sizeof($validReq))
+    if (sizeof((array)$validReq))
     {
       foreach ($validReq as $req)
       {
         // collect TC for REQ
         $arrCoverage = $this->req_mgr->get_coverage($req['id']);
         
-        if (count($arrCoverage) > 0) 
+        if (count((array)$arrCoverage) > 0) 
         {
           // add information about coverage
           $req['coverage'] = $arrCoverage;
@@ -329,7 +329,7 @@ class requirement_spec_mgr extends tlObjectWithAttachments
     $rs = $this->db->get_recordset($sql);
     if (!is_null($rs))
     {
-      $output['covered'] = count($rs);
+      $output['covered'] = count((array)$rs);
     }
     $output['uncovered'] = $output['expectedTotal'] - $output['total'];
     
@@ -402,7 +402,7 @@ class requirement_spec_mgr extends tlObjectWithAttachments
      
    	$path=$this->tree_mgr->get_path($item['id']); 
    	$tproject_id = $path[0]['parent_id'];
-   	$last_idx=count($path)-1;
+   	$last_idx=count((array)$path)-1;
    	$parent_id = $last_idx==0 ? null : $path[$last_idx]['parent_id'];
    	$chk=$this->check_main_data($title,$doc_id,$path[0]['parent_id'],$parent_id,$item['id']);
     
@@ -653,7 +653,7 @@ class requirement_spec_mgr extends tlObjectWithAttachments
 		  break;
 		    
 		  case 'count':
-		   	return(!is_null($rs) ? count($rs) : 0);	   
+		   	return(!is_null($rs) ? count((array)$rs) : 0);	   
 		  break;
 		}
 	}
@@ -721,7 +721,7 @@ class requirement_spec_mgr extends tlObjectWithAttachments
 				  break;
 					
 				  case 'count':
-					$rs = !is_null($rs) ? count($rs) : 0;	   
+					$rs = !is_null($rs) ? count((array)$rs) : 0;	   
 				  break;
 				}
 			}
@@ -1101,7 +1101,7 @@ function get_requirement_child_by_id_req($id){
 			}
 	  }
 	  
-		if( !is_null($attachments) && count($attachments) > 0 ) {
+		if( !is_null($attachments) && count((array)$attachments) > 0 ) {
 			$attchRootElem = 
         "\t<attachments>\n{{XMLCODE}}\t</attachments>\n";
 			$attchElemTemplate = "\t\t<attachment>\n" .
@@ -1124,7 +1124,7 @@ function get_requirement_child_by_id_req($id){
   	$req_spec = $this->getReqTree($id);
   	$childNodes = isset($req_spec['childNodes']) ? $req_spec['childNodes'] : null ;
   	if( !is_null($childNodes) ) {
-      $loop_qty=sizeof($childNodes); 
+      $loop_qty=sizeof((array)$childNodes); 
       for($idx = 0;$idx < $loop_qty;$idx++) {
   	    $cNode = $childNodes[$idx];
   	    $nTable = $cNode['node_table'];
@@ -1136,7 +1136,7 @@ function get_requirement_child_by_id_req($id){
           $xmlData .= $this->req_mgr->exportReqToXML($cNode['id'],$tproject_id,$optForExport['ATTACHMENTS']);
 
           $relations = $this->req_mgr->get_relations($cNode['id']);
-          if( !is_null($relations['relations']) && count($relations['relations']) > 0 )
+          if( !is_null($relations['relations']) && count((array)$relations['relations']) > 0 )
           {
             foreach($relations['relations'] as $key => $rel) 
             {
@@ -1266,13 +1266,13 @@ function get_requirement_child_by_id_req($id){
       // Process children
       if( property_exists($xml_item,'requirement') )	              
       {
-          $loop2do=count($xml_item->requirement);
+          $loop2do=count((array)$xml_item->requirement);
           for($idx=0; $idx <= $loop2do; $idx++)
           {
               $xml_req=$this->req_mgr->xmlToMapRequirement($xml_item->requirement[$idx]);
               if(!is_null($xml_req))
               { 
-                  $fdx=count($mapped)-1;
+                  $fdx=count((array)$mapped)-1;
                   $mapped[$fdx]['requirements'][]=$xml_req;
               }    
           }    
@@ -1280,13 +1280,13 @@ function get_requirement_child_by_id_req($id){
 
       if( property_exists($xml_item,'relation') )               
       {
-          $loop3do=count($xml_item->relation);
+          $loop3do=count((array)$xml_item->relation);
           for($idx=0; $idx <= $loop3do; $idx++)
           {
               $rel=$this->req_mgr->convertRelationXmlToRelationMap($xml_item->relation[$idx]);
               if(!is_null($rel))
               { 
-                  $fdx=count($mapped)-1;
+                  $fdx=count((array)$mapped)-1;
                   $mapped[$fdx]['relations'][]=$rel;
               }    
           } 
@@ -1294,7 +1294,7 @@ function get_requirement_child_by_id_req($id){
 
       if( property_exists($xml_item,'req_spec') )	              
       {
-          $loop2do=count($xml_item->req_spec);
+          $loop2do=count((array)$xml_item->req_spec);
           for($idx=0; $idx <= $loop2do; $idx++)
           {
               $this->xmlToMapReqSpec($xml_item->req_spec[$idx],$depth);
@@ -1513,7 +1513,7 @@ function get_requirement_child_by_id_req($id){
 	
     $idCard = array('parent_id' => $id, 'item_id' => null, 'tproject_id' => $tproject_id); 
   	$cfMap = $this->get_linked_cfields($idCard);
-  	if( !is_null($cfMap) && count($cfMap) > 0 )
+  	if( !is_null($cfMap) && count((array)$cfMap) > 0 )
   	{
   		$xml = $this->cfield_mgr->exportValueAsXML($cfMap);
   	}
@@ -1576,7 +1576,7 @@ function get_requirement_child_by_id_req($id){
       }
     }
     
-    $loop2do = count($items);
+    $loop2do = count((array)$items);
     $container_id[0] = (is_null($parent_id) || $parent_id == 0) ? $tproject_id : $parent_id;
     
     // items is an array of req. specs
@@ -1687,7 +1687,7 @@ function get_requirement_child_by_id_req($id){
         $create_req = (!$has_filters || isset($copy_req[$idx])) && !is_null($reqSet);
         if($create_req)
         {
-          $items_qty = isset($copy_req[$idx]) ? count($copy_req[$idx]) : count($reqSet);
+          $items_qty = isset($copy_req[$idx]) ? count((array)$copy_req[$idx]) : count((array)$reqSet);
           $keys2insert = isset($copy_req[$idx]) ? $copy_req[$idx] : array_keys($reqSet);
           for($jdx = 0;$jdx < $items_qty; $jdx++)
           {
@@ -1700,7 +1700,7 @@ function get_requirement_child_by_id_req($id){
         if(isset($items[$idx]['relations']))
         {  
           $relationsMap = $items[$idx]['relations'];
-          $numberOfRelations = count($relationsMap);
+          $numberOfRelations = count((array)$relationsMap);
           for($jdx=0; $jdx < $numberOfRelations; $jdx++)
           {
             $rel = $relationsMap[$jdx];
@@ -1794,7 +1794,7 @@ function get_requirement_child_by_id_req($id){
         				$where . ' GROUP BY RSPEC_REV.parent_id ';
 
   	$maxi = (array)$this->db->fetchRowsIntoMap($sql_max,'rev_id');;
-  	if( count($maxi) > 0)
+  	if( count((array)$maxi) > 0)
   	{
       $sql =	" /* $debugMsg */ SELECT RSPEC.id,RSPEC.testproject_id,RSPEC.doc_id,NH_RSPEC.name AS title, " .
   				" RSPEC_REV.revision ";
@@ -1895,7 +1895,7 @@ function get_requirement_child_by_id_req($id){
   			// Few test indicates that it's true, but that using a counter
   			// is still better.
   			//
-			  $loop2do = count($subtree);
+			  $loop2do = count((array)$subtree);
   			for($sdx=0; $sdx <= $loop2do; $sdx++) {
 		  		$elem = &$subtree[$sdx];
 				  $the_parent_id = isset($parent_decode[$elem['parent_id']]) ? $parent_decode[$elem['parent_id']] : null;
@@ -2005,7 +2005,7 @@ function get_requirement_child_by_id_req($id){
 					" WHERE ATT.id='{$this->db->prepare_string($attachment[id])}' " .
 					" AND ATT.fk_id={$rs_id} ";
 				$rsx=$this->db->get_recordset($sql);
-				$addAttachment = ( is_null($rsx) || count($rsx) < 1 );
+				$addAttachment = ( is_null($rsx) || count((array)$rsx) < 1 );
 				if( $addAttachment === false ){ // inform user that the attachment has been skipped
 					$knownAttachments[] = $attachment['name'];
 				}

--- a/lib/functions/requirement_spec_mgr.class.php
+++ b/lib/functions/requirement_spec_mgr.class.php
@@ -631,14 +631,14 @@ class requirement_spec_mgr extends tlObjectWithAttachments
 	$itemSet = $this->db->fetchRowsIntoMap($sql,'id');
 
 	if( !is_null($itemSet) ) {
-		$reqSet = array_keys($itemSet);
+		$reqSet = array_keys((array)$itemSet);
 		$sql = "/* $debugMsg */ SELECT MAX(NH_REQV.id) AS version_id" . 
 		       " FROM {$this->tables['nodes_hierarchy']} NH_REQV " .
 		       " WHERE NH_REQV.parent_id IN (" . implode(",",$reqSet) . ") " .
 		       " GROUP BY NH_REQV.parent_id ";
 
 		$latestVersionSet = $this->db->fetchRowsIntoMap($sql,'version_id');
-	  $reqVersionSet = array_keys($latestVersionSet);
+	  $reqVersionSet = array_keys((array)$latestVersionSet);
 
     $getOptions['order_by'] = $my['options']['order_by'];
     $getOptions['outputLevel'] = $my['options']['outputLevel'];
@@ -695,14 +695,14 @@ class requirement_spec_mgr extends tlObjectWithAttachments
 
 			if( !is_null($itemSet) )
 			{
-				$reqSet = array_keys($itemSet);
+				$reqSet = array_keys((array)$itemSet);
 				$sql = "/* $debugMsg */ SELECT MAX(NH_REQV.id) AS version_id" . 
 					   " FROM {$this->tables['nodes_hierarchy']} NH_REQV " .
 					   " WHERE NH_REQV.parent_id IN (" . implode(",",$reqSet) . ") " .
 					   " GROUP BY NH_REQV.parent_id ";
 
 				$latestVersionSet = $this->db->fetchRowsIntoMap($sql,'version_id');
-				$reqVersionSet = array_keys($latestVersionSet);
+				$reqVersionSet = array_keys((array)$latestVersionSet);
 				
 				$getOptions['order_by'] = $my['options']['order_by'];
 				$getOptions['outputLevel'] = $my['options']['outputLevel'];
@@ -1571,7 +1571,7 @@ function get_requirement_child_by_id_req($id){
       {
         foreach($filters['requirements'] as $reqspec_pos => $requirements_pos)
         {
-            $copy_req[$reqspec_pos] = is_null($requirements_pos) ? null : array_keys($requirements_pos);
+            $copy_req[$reqspec_pos] = is_null($requirements_pos) ? null : array_keys((array)$requirements_pos);
         }
       }
     }
@@ -1688,7 +1688,7 @@ function get_requirement_child_by_id_req($id){
         if($create_req)
         {
           $items_qty = isset($copy_req[$idx]) ? count((array)$copy_req[$idx]) : count((array)$reqSet);
-          $keys2insert = isset($copy_req[$idx]) ? $copy_req[$idx] : array_keys($reqSet);
+          $keys2insert = isset($copy_req[$idx]) ? $copy_req[$idx] : array_keys((array)$reqSet);
           for($jdx = 0;$jdx < $items_qty; $jdx++)
           {
             $req = $reqSet[$keys2insert[$jdx]];
@@ -1817,7 +1817,7 @@ function get_requirement_child_by_id_req($id){
       				" JOIN {$this->tables['nodes_hierarchy']} NH_RSPEC " .
       				" ON NH_RSPEC.id = RSPEC.id ";
   				
-  		$sql .= $where . ' AND RSPEC_REV.id IN (' . implode(",",array_keys($maxi)) . ') '; 
+  		$sql .= $where . ' AND RSPEC_REV.id IN (' . implode(",",array_keys((array)$maxi)) . ') '; 
   		$output = $this->db->fetchRowsIntoMap($sql,$my['options']['access_key']);
     }
     	
@@ -2040,7 +2040,7 @@ function get_requirement_child_by_id_req($id){
 		{
 			// doc_id has limited size => we need to be sure that generated id 
       // will not exceed DB size
-      $nameSet = array_flip(array_keys($itemSet));
+      $nameSet = array_flip(array_keys((array)$itemSet));
 	    
       // 6 magic from " [xxx]"
 	    $prefix = trim_and_limit($item_info['doc_id'],$this->field_size->docid-6);
@@ -2262,7 +2262,7 @@ function get_requirement_child_by_id_req($id){
   		
   	if( !is_null($rs) )
   	{
-  		$key2loop = array_keys($rs);
+  		$key2loop = array_keys((array)$rs);
   		foreach($key2loop as $ap)
   		{
   			$rs[$ap]['item_id'] = $rs[$ap]['revision_id'];
@@ -2309,7 +2309,7 @@ function get_requirement_child_by_id_req($id){
 	function decode_users(&$rs)
 	{
   	$userCache = null;  // key: user id, value: display name
-  	$key2loop = array_keys($rs);
+  	$key2loop = array_keys((array)$rs);
   	$labels['undefined'] = lang_get('undefined');
   	$user_keys = array('author' => 'author_id', 'modifier' => 'modifier_id');
   	foreach( $key2loop as $key )

--- a/lib/functions/requirements.inc.php
+++ b/lib/functions/requirements.inc.php
@@ -118,7 +118,7 @@ function compareImportedReqs(&$dbHandler,$arrImportSource,$tprojectID,$reqSpecID
   $labels = array('type' => $reqCfg->type_labels, 'status' => $reqCfg->status_labels);
   $verbose = array('type' => null, 'status' => null);
   $cache = array('type' => null, 'status' => null);
-  $cacheKeys = array_keys($cache);
+  $cacheKeys = array_keys((array)$cache);
   
   $unknown_code = lang_get('unknown_code');
   $reqMgr = new requirement_mgr($dbHandler);
@@ -572,7 +572,7 @@ function getReqCoverage(&$dbHandler,$reqs,&$execMap)
   
   $coverageAlgorithm=config_get('req_cfg')->coverageStatusAlgorithm;
   $resultsCfg=config_get('results');
-  $status2check=array_keys($resultsCfg['status_label_for_exec_ui']);
+  $status2check=array_keys((array)$resultsCfg['status_label_for_exec_ui']);
   
   // $coverage['byStatus']=null;
   $coverage['withTestCase']=null;
@@ -723,7 +723,7 @@ function getLastExecutions(&$db,$tcaseSet,$tplanId)
   if (sizeof((array)$tcaseSet))
   {
     $tcase_mgr = new testcase($db);
-      $items=array_keys($tcaseSet);
+      $items=array_keys((array)$tcaseSet);
       $path_info=$tcase_mgr->tree_manager->get_full_path_verbose($items);
     $options=array('getNoExecutions' => 1, 'groupByBuild' => 0);
     foreach($tcaseSet as $tcaseId => $tcInfo)

--- a/lib/functions/requirements.inc.php
+++ b/lib/functions/requirements.inc.php
@@ -123,7 +123,7 @@ function compareImportedReqs(&$dbHandler,$arrImportSource,$tprojectID,$reqSpecID
   $unknown_code = lang_get('unknown_code');
   $reqMgr = new requirement_mgr($dbHandler);
   $arrImport = null;
-  if( ($loop2do=count($arrImportSource)) )
+  if( ($loop2do=count((array)$arrImportSource)) )
   {
     $getOptions = array('output' => 'minimun');
     $messages = array('ok' => '', 'import_req_conflicts_other_branch' => '','import_req_exists_here' => '');
@@ -193,7 +193,7 @@ function getReqDocIDs(&$db,$srs_id)
   $arrCurrentReq = $req_spec_mgr->get_requirements($srs_id);
 
   $result = null;
-  if (count($arrCurrentReq))
+  if (count((array)$arrCurrentReq))
   {
     // only if some reqs exist
     foreach ($arrCurrentReq as $data)
@@ -258,7 +258,7 @@ function importReqDataFromCSV($fileName)
   $fieldMappings = array("docid","title","description","type","status","expected_coverage","node_order");
     
 
-  $options = array('delimiter' => ',' , 'fieldQty' => count($fieldMappings));
+  $options = array('delimiter' => ',' , 'fieldQty' => count((array)$fieldMappings));
   $impData = importCSVData($fileName,$fieldMappings,$options);
   
   $reqData = &$impData['info'];
@@ -272,7 +272,7 @@ function importReqDataFromCSV($fileName)
     $fieldDefault = array("type" => array('check' => 'type_labels', 'value' => TL_REQ_TYPE_FEATURE), 
                           "status" => array('check' => 'status_labels' , 'value' => TL_REQ_STATUS_VALID));
   
-    $loop2do = count($reqData);
+    $loop2do = count((array)$reqData);
     for($ddx=0; $ddx < $loop2do; $ddx++)
     {
       foreach($reqData[$ddx] as $fieldKey => &$fieldValue)
@@ -310,7 +310,7 @@ function importReqDataFromCSVDoors($fileName)
   $fieldMappings = array("Object Identifier" => "title","Object Text" => "description",
                  "Created By","Created On","Last Modified By","Last Modified On");
   
-  $options = array('delimiter' => ',', 'fieldQty' => count($fieldMappings), 'processHeader' => true);
+  $options = array('delimiter' => ',', 'fieldQty' => count((array)$fieldMappings), 'processHeader' => true);
   $impData = importCSVData($fileName,$fieldMappings,$options);
 
   return $impData;
@@ -531,7 +531,7 @@ function doReqImport(&$dbHandler,$tprojectID,$userID,$reqSpecID,$fileName,$impor
   $arrImportSource = loadImportedReq($fileName, $importType);
   $arrImport = null;
 
-  if (count($arrImportSource))
+  if (count((array)$arrImportSource))
   {
     $map_cur_reqdoc_id = getReqDocIDs($dbHandler,$reqSpecID);
     if ($doImport)
@@ -585,13 +585,13 @@ function getReqCoverage(&$dbHandler,$reqs,&$execMap)
       $status_counters[$resultsCfg['status_code'][$status_code]]=0;
   }
   
-  $reqs_qty=count($reqs);
+  $reqs_qty=count((array)$reqs);
   if($reqs_qty > 0)
   {
     foreach($reqs as $requirement_id => $req_tcase_set)
     {
       $first_key=key($req_tcase_set);
-      $item_qty = count($req_tcase_set);
+      $item_qty = count((array)$req_tcase_set);
       $req = array("id" => $requirement_id, "title" => $req_tcase_set[$first_key]['req_title'],
                    "req_doc_id" => $req_tcase_set[$first_key]["req_doc_id"]);
       
@@ -720,7 +720,7 @@ function getReqCoverage(&$dbHandler,$reqs,&$execMap)
 function getLastExecutions(&$db,$tcaseSet,$tplanId)
 {
   $execMap = array();
-  if (sizeof($tcaseSet))
+  if (sizeof((array)$tcaseSet))
   {
     $tcase_mgr = new testcase($db);
       $items=array_keys($tcaseSet);
@@ -949,7 +949,7 @@ function req_link_replace($dbHandler, $scope, $tprojectID)
       $sql = $sql2exec[$accessKey] . "'{$matches[$patternPositions['doc_id']][$key]}'";
       $rs = $dbHandler->get_recordset($sql);
       
-      if (count($rs) > 0) 
+      if (count((array)$rs) > 0) 
       {
   
         foreach($rs as $key => $value) 

--- a/lib/functions/roles.inc.php
+++ b/lib/functions/roles.inc.php
@@ -258,12 +258,12 @@ function checkForRights($rights,$roleQuestion,$bAND = 1) {
     $r = array_intersect($roleQuestion,$rights);
     if ($bAND) {
       //for AND all rights must be present
-      if (sizeof($r) == sizeof($roleQuestion)) {
+      if (sizeof((array)$r) == sizeof((array)$roleQuestion)) {
         $ret = 'yes';
       }  
     } else {
       //for OR one of all must be present
-      if (sizeof($r)) {
+      if (sizeof((array)$r)) {
         $ret = 'yes';
       }  
     }  

--- a/lib/functions/specview.php
+++ b/lib/functions/specview.php
@@ -530,10 +530,10 @@ function getFilteredLinkedVersions(&$dbHandler,&$argsObj, &$tplanMgr,
   
   if( !is_null($tplan_tcases) && $doFilterByKeyword && $argsObj->keywordsFilterType == 'AND')
   {
-    $filteredSet = $tcaseMgr->filterByKeyword(array_keys($tplan_tcases),
+    $filteredSet = $tcaseMgr->filterByKeyword(array_keys((array)$tplan_tcases),
                                               $argsObj->keyword_id,$argsObj->keywordsFilterType);
     
-    $filters = array('tcase_id' => array_keys($filteredSet));
+    $filters = array('tcase_id' => array_keys((array)$filteredSet));
 
     // HERE WE CAN HAVE AN ISSUE
     $tplan_tcases = $tplanMgr->getLTCVNewGeneration($argsObj->tplan_id, $filters, $opx);
@@ -771,7 +771,7 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
 
 
   if( $applyFilters ) {
-    $key2loop = array_keys($test_spec);
+    $key2loop = array_keys((array)$test_spec);
     
     // first step: generate list of TEST CASE NODES
     $itemSet = null ;
@@ -805,13 +805,13 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
          $useFilter['status']) 
       ) {
       // This logic can have some Potential Performance ISSUE - 20120619 - fman
-      $targetSet = array_keys($itemSet);
+      $targetSet = array_keys((array)$itemSet);
       $options = ($specViewType == 'testPlanLinking') ? array( 'access_key' => 'testcase_id') : null;
 
       $getFilters = $useFilter['cfields'] ? array('cfields' => $filters['cfields']) : null;
       $s2h = config_get('tplanDesign')->hideTestCaseWithStatusIn;
       if( !is_null($s2h) ) {
-        $getFilters['status'] = array('not_in' => array_keys($s2h));   
+        $getFilters['status'] = array('not_in' => array_keys((array)$s2h));   
       }
       
       $tcversionSet = $tcaseMgr->get_last_active_version($targetSet,$getFilters,$options);
@@ -853,7 +853,7 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
         break;
         
         default:
-          $tcvidSet = array_keys($tcversionSet);
+          $tcvidSet = array_keys((array)$tcversionSet);
           foreach($tcvidSet as $zx) {
             $tcidSet[$tcversionSet[$zx]['testcase_id']] = $zx;  
           }  
@@ -886,13 +886,13 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
             // because we have applied it before on:
             // $tcversionSet = $tcaseMgr->get_last_active_version()
             if( $useFilter['cfields'] ) {
-              $filteredSet = (!is_null($allowedSet) &&  count((array)$allowedSet) > 0) ? array_keys($allowedSet) : $tcvidSet;
+              $filteredSet = (!is_null($allowedSet) &&  count((array)$allowedSet) > 0) ? array_keys((array)$allowedSet) : $tcvidSet;
               $dummySet = $tcaseMgr->filter_tcversions_by_cfields($filteredSet,$filters['cfields'],$options);
 
               // transform to make compatible with filter_tcversions_by_exec_type() return type
               if( !is_null($dummySet) &&  count((array)$dummySet) > 0 ) {
                 $allowedSet = null;
-                $work2do = array_keys($dummySet);
+                $work2do = array_keys((array)$dummySet);
                 foreach($work2do as $wkey) {
                   $allowedSet[$wkey] = $dummySet[$wkey][0];
                 }
@@ -1058,7 +1058,7 @@ function addCustomFieldsToView(&$testSuiteSet,$tprojectId,&$tcaseMgr)
         {
           if( ($linked_version_id=$svalue['linked_version_id']) > 0 )
           {
-            $platformSet = array_keys($svalue['feature_id']);
+            $platformSet = array_keys((array)$svalue['feature_id']);
             foreach($platformSet as $platform_id)
             {
               $testSuiteSet[$key]['testcases'][$skey]['custom_fields'][$platform_id]='';

--- a/lib/functions/specview.php
+++ b/lib/functions/specview.php
@@ -190,7 +190,7 @@ function gen_spec_view(&$db, $specViewType, $tobj_id, $id, $name, &$linked_items
   $idx = 0;
   $a_tcid = array();
   $a_tsuite_idx = array();
-  if (count($test_spec)) {
+  if (count((array)$test_spec)) {
     $cfg = array('node_types' => $hash_id_descr, 
                  'write_status' => $write_status,
                  'is_uncovered_view_type' => $is_uncovered_view_type);
@@ -222,7 +222,7 @@ function gen_spec_view(&$db, $specViewType, $tobj_id, $id, $name, &$linked_items
   }
   
   // Collect information related to linked testcase versions
-  if(!is_null($out) && count($out) > 0 && !is_null($out[0]) && count($a_tcid))
+  if(!is_null($out) && count((array)$out) > 0 && !is_null($out[0]) && count((array)$a_tcid))
   {
     $optGBI = array('output' => 'full_without_users',
                     'order_by' => " ORDER BY NHTC.node_order, NHTC.name, TCV.version DESC ");
@@ -234,14 +234,14 @@ function gen_spec_view(&$db, $specViewType, $tobj_id, $id, $name, &$linked_items
   // Try to prune empty test suites, to reduce memory usage and 
   // to remove elements
   // that do not need to be displayed on user interface.
-  if (count($result['spec_view']) > 0) {
+  if (count((array)$result['spec_view']) > 0) {
     removeEmptyTestSuites($result['spec_view'],$tcase_mgr->tree_manager,
                         ($my['options']['prune_unlinked_tcversions'] && $is_tplan_view_type),$hash_descr_id);
   }
   
   // Remove empty branches
   // Loop to compute test case qty ($tsuite_tcqty) on every level and prune test suite branchs that are empty
-  if (count($result['spec_view']) > 0) {
+  if (count((array)$result['spec_view']) > 0) {
     removeEmptyBranches($result['spec_view'],$tsuite_tcqty);
   }   
   
@@ -266,13 +266,13 @@ function gen_spec_view(&$db, $specViewType, $tobj_id, $id, $name, &$linked_items
   // {
   //  foreach($result['spec_view'] as $key => $value) 
   //     {
-  //        if(is_null($value) || !isset($value['testcases']) || !count($value['testcases']))
+  //        if(is_null($value) || !isset($value['testcases']) || !count((array)$value['testcases']))
   //          unset($result['spec_view'][$key]);
   //     }
   // }
   
   // #1650 We want to manage custom fields when user is doing test case execution assigment
-  if( count($result['spec_view']) > 0 && $my['options']['add_custom_fields'])
+  if( count((array)$result['spec_view']) > 0 && $my['options']['add_custom_fields'])
   {    
     addCustomFieldsToView($result['spec_view'],$tproject_id,$tcase_mgr);
   }
@@ -341,7 +341,7 @@ $map_node_tccount, $filters=null, $options = null, $tproject_id = null)
 	$idx = 0;
 	$a_tcid = array();
 	$a_tsuite_idx = array();
-	if (count($test_spec)) {
+	if (count((array)$test_spec)) {
 		$cfg = array('node_types' => $hash_id_descr, 
                  'write_status' => $write_status,
 				         'is_uncovered_view_type' => $is_uncovered_view_type);
@@ -375,7 +375,7 @@ $map_node_tccount, $filters=null, $options = null, $tproject_id = null)
 	}
 
 	// Collect information related to linked testcase versions
-	if(!is_null($out) && count($out) > 0 && !is_null($out[0]) && count($a_tcid))
+	if(!is_null($out) && count((array)$out) > 0 && !is_null($out[0]) && count((array)$a_tcid))
 	{
 	$optGBI = array('output' => 'full_without_users',
 	'order_by' => " ORDER BY NHTC.node_order, NHTC.name, TCV.version DESC ");
@@ -387,7 +387,7 @@ $map_node_tccount, $filters=null, $options = null, $tproject_id = null)
 
 	// Try to prune empty test suites, to reduce memory usage and to remove elements
 	// that do not need to be displayed on user interface.
-	if( count($result['spec_view']) > 0)
+	if( count((array)$result['spec_view']) > 0)
 	{
 		//removeEmptyTestSuites($result['spec_view'],$tcase_mgr->tree_manager,
 		//($my['options']['prune_unlinked_tcversions'] && $is_tplan_view_type),$hash_descr_id);
@@ -395,7 +395,7 @@ $map_node_tccount, $filters=null, $options = null, $tproject_id = null)
 
 	// Remove empty branches
   // Loop to compute test case qty ($tsuite_tcqty) on every level and prune test suite branchs that are empty
-	if( count($result['spec_view']) > 0)
+	if( count((array)$result['spec_view']) > 0)
 	{
 	//removeEmptyBranches($result['spec_view'],$tsuite_tcqty);
 }
@@ -423,13 +423,13 @@ $map_node_tccount, $filters=null, $options = null, $tproject_id = null)
 		// {
 	//  foreach($result['spec_view'] as $key => $value)
 	//     {
-	//        if(is_null($value) || !isset($value['testcases']) || !count($value['testcases']))
+	//        if(is_null($value) || !isset($value['testcases']) || !count((array)$value['testcases']))
 		//          unset($result['spec_view'][$key]);
 	//     }
 	// }
 
 	// #1650 We want to manage custom fields when user is doing test case execution assigment
-	if( count($result['spec_view']) > 0 && $my['options']['add_custom_fields'])
+	if( count((array)$result['spec_view']) > 0 && $my['options']['add_custom_fields'])
 	{
 	addCustomFieldsToView($result['spec_view'],$tproject_id,$tcase_mgr);
 }
@@ -800,7 +800,7 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
       }
     }
 
-    if( count($itemSet) > 0 && 
+    if( count((array)$itemSet) > 0 && 
         ($useFilter['execution_type'] || $useFilter['importance'] || $useFilter['cfields'] || 
          $useFilter['status']) 
       ) {
@@ -876,7 +876,7 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
             // Potential Performance ISSUE
             $allowedSet = $tcaseMgr->filter_tcversions_by_exec_type($tcvidSet,$filters['execution_type'],$options);
 
-             $doFilter = (!is_null($allowedSet) &&  count($allowedSet) > 0);
+             $doFilter = (!is_null($allowedSet) &&  count((array)$allowedSet) > 0);
              $emptySet = !$doFilter;
           }
 
@@ -886,11 +886,11 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
             // because we have applied it before on:
             // $tcversionSet = $tcaseMgr->get_last_active_version()
             if( $useFilter['cfields'] ) {
-              $filteredSet = (!is_null($allowedSet) &&  count($allowedSet) > 0) ? array_keys($allowedSet) : $tcvidSet;
+              $filteredSet = (!is_null($allowedSet) &&  count((array)$allowedSet) > 0) ? array_keys($allowedSet) : $tcvidSet;
               $dummySet = $tcaseMgr->filter_tcversions_by_cfields($filteredSet,$filters['cfields'],$options);
 
               // transform to make compatible with filter_tcversions_by_exec_type() return type
-              if( !is_null($dummySet) &&  count($dummySet) > 0 ) {
+              if( !is_null($dummySet) &&  count((array)$dummySet) > 0 ) {
                 $allowedSet = null;
                 $work2do = array_keys($dummySet);
                 foreach($work2do as $wkey) {
@@ -899,11 +899,11 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
                 unset($dummySet);
               }
             }
-            $doFilter = (!is_null($allowedSet) &&  count($allowedSet) > 0);
+            $doFilter = (!is_null($allowedSet) &&  count((array)$allowedSet) > 0);
             $emptySet = !$doFilter;
           }
           
-          if( $doFilter && !is_null($allowedSet) &&  count($allowedSet) > 0 ) {
+          if( $doFilter && !is_null($allowedSet) &&  count((array)$allowedSet) > 0 ) {
             $useAllowed = true;
             foreach($allowedSet as $key => $value) {
               $tspecKey = $itemSet[$value['testcase_id']];  
@@ -917,7 +917,7 @@ function getTestSpecFromNode(&$dbHandler,&$tcaseMgr,&$linkedItems,$masterContain
           }
 
           $setToRemove = array_diff_key($tcversionSet,$allowedSet);
-          if( !is_null($setToRemove) &&  count($setToRemove) > 0 ) {
+          if( !is_null($setToRemove) &&  count((array)$setToRemove) > 0 ) {
             foreach($setToRemove as $key => $value) {
               $tspecKey = $itemSet[$value['testcase_id']];  
               $test_spec[$tspecKey]=null; 
@@ -964,7 +964,7 @@ function removeEmptyTestSuites(&$testSuiteSet,&$treeMgr,$pruneUnlinkedTcversions
       {
         // Only if test suite has children test cases we need to understand
         // if they are linked or not
-        if( isset($value['testcases']) && count($value['testcases']) > 0 )
+        if( isset($value['testcases']) && count((array)$value['testcases']) > 0 )
         {
           foreach($value['testcases'] as $skey => $svalue)
           {
@@ -1052,7 +1052,7 @@ function addCustomFieldsToView(&$testSuiteSet,$tprojectId,&$tcaseMgr)
   {
     if( !is_null($value) )
     {
-      if( isset($value['testcases']) && count($value['testcases']) > 0 )
+      if( isset($value['testcases']) && count((array)$value['testcases']) > 0 )
       {
         foreach($value['testcases'] as $skey => $svalue)
         {
@@ -1543,7 +1543,7 @@ function genSpecViewFlat(&$db, $specViewType, $tobj_id, $id, $name, &$linked_ite
   $idx = 0;
   $a_tcid = array();
   $a_tsuite_idx = array();
-  if(count($test_spec)) {
+  if(count((array)$test_spec)) {
     $cfg = array('node_types' => $hash_id_descr, 
                  'write_status' => $write_status,
                  'is_uncovered_view_type' => $is_uncovered_view_type);
@@ -1558,7 +1558,7 @@ function genSpecViewFlat(&$db, $specViewType, $tobj_id, $id, $name, &$linked_ite
   // Collect information related to linked testcase versions
   // DAMMED 0!!!!
   $firtsElemIDX = key($out);
-  if(!is_null($out) && count($out) > 0 && !is_null($out[$firtsElemIDX]) && count($a_tcid)) {
+  if(!is_null($out) && count((array)$out) > 0 && !is_null($out[$firtsElemIDX]) && count((array)$a_tcid)) {
     $optGBI = array('output' => 'full_without_users',
                     'order_by' => " ORDER BY NHTC.node_order, NHTC.name, TCV.version DESC ");
     
@@ -1574,7 +1574,7 @@ function genSpecViewFlat(&$db, $specViewType, $tobj_id, $id, $name, &$linked_ite
     $result = addLinkedVersionsInfo($tcaseVersionSet,$a_tsuite_idx,$out,$linked_items,$options);
   }
 
-  if( count($result['spec_view']) > 0 && $my['options']['add_custom_fields']) {    
+  if( count((array)$result['spec_view']) > 0 && $my['options']['add_custom_fields']) {    
     addCustomFieldsToView($result['spec_view'],$tproject_id,$tcase_mgr);
   }
 
@@ -1778,11 +1778,11 @@ function buildSkeletonFlat($branchRootID,$name,$config,&$test_spec,&$platforms)
   $tsuite_tcqty[$branchRootID] = $out[$hash_id_pos[$branchRootID]]['testcase_qty'];
 
   // Clean up
-  $loop2do = count($out);
+  $loop2do = count((array)$out);
   $toUnset = null;
   for($lzx=0; $lzx < $loop2do; $lzx++)
   {
-    if(count($out[$lzx]['testcases']) == 0)
+    if(count((array)$out[$lzx]['testcases']) == 0)
     {
       $toUnset[$lzx]=$lzx;
     }  

--- a/lib/functions/string_api.php
+++ b/lib/functions/string_api.php
@@ -20,7 +20,7 @@
 function string_preserve_spaces_at_bol( $p_string ) 
 {
 	$lines = explode( "\n", $p_string );
-	$line_count = count( $lines );
+	$line_count = count((array)$lines);
 	for ( $i = 0; $i < $line_count; $i++ ) {
 		$count	= 0;
 		$prefix	= '';
@@ -71,7 +71,7 @@ function string_nl2br( $p_string, $p_wrap = 100 )
 		// fix up eols within <pre> tags
 		$pre2 = array();
 		preg_match_all("/<pre[^>]*?>(.|\n)*?<\/pre>/", $p_string, $pre1);
-		for ( $x = 0; $x < count($pre1[0]); $x++ ) 
+		for ( $x = 0; $x < count((array)$pre1[0]); $x++ ) 
 		{
 			$pre2[$x] = preg_replace("/<br[^>]*?>/", "", $pre1[0][$x]);
 			// this may want to be replaced by html_entity_decode (or equivalent)
@@ -429,7 +429,7 @@ function string_shorten( $p_string ) {
 		$t_bits = preg_split( $t_pattern, $p_string, -1, PREG_SPLIT_DELIM_CAPTURE );
 
 		$t_string = '';
-		$t_last = $t_bits[ count( $t_bits ) - 1 ];
+		$t_last = $t_bits[ count((array)$t_bits) - 1 ];
 		$t_last_len = tlStrLen( $t_last );
 
 		foreach ( $t_bits as $t_bit ) {

--- a/lib/functions/testPlanUrgency.class.php
+++ b/lib/functions/testPlanUrgency.class.php
@@ -168,7 +168,7 @@ class testPlanUrgency extends testplan
     if( !is_null($my['filters']['testcases']) )
     {
       // sanitize
-      $loop2do = count($my['filters']['testcases']);
+      $loop2do = count((array)$my['filters']['testcases']);
       for($gdx=0; $gdx < $loop2do; $gdx++)
       {
         $my['filters']['testcases'][$gdx] = intval($my['filters']['testcases'][$gdx]);

--- a/lib/functions/testPlanUrgency.class.php
+++ b/lib/functions/testPlanUrgency.class.php
@@ -235,7 +235,7 @@ class testPlanUrgency extends testplan
     
     if( !is_null($rs) )
     {
-      $key2loop = array_keys($rs);
+      $key2loop = array_keys((array)$rs);
       switch($my['options']['details'])
       {
         case 'tcversion':
@@ -248,7 +248,7 @@ class testPlanUrgency extends testplan
         case 'platform':
           foreach($key2loop as  $key)
           {
-            $platformSet = array_keys($rs[$key]);
+            $platformSet = array_keys((array)$rs[$key]);
             foreach($platformSet as $platform_id) 
             {
               $rs[$key][$platform_id]['priority_level'] = priority_to_level($rs[$key][$platform_id]['priority']);

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -485,7 +485,7 @@ class testcase extends tlObjectWithAttachments {
             // check if already exists a test case with this external id
             $info = $this->get_by_external($sf, $parent_id);
             if( !is_null($info)) {
-              if( count($info) > 1) {
+              if( count((array)$info) > 1) {
                 // abort
                 throw new Exception("More than one test case with same external ID");
               }
@@ -532,7 +532,7 @@ class testcase extends tlObjectWithAttachments {
     if ($my['options']['check_duplicate_name']) {
       $itemSet = $this->getDuplicatesByName($name,$parent_id,$getDupOptions);
 
-      if( !is_null($itemSet) && ($siblingQty=count($itemSet)) > 0 ) {
+      if( !is_null($itemSet) && ($siblingQty=count((array)$itemSet)) > 0 ) {
         $ret['has_duplicate'] = true;
 
         switch($my['options']['action_on_duplicate_name']) {
@@ -744,7 +744,7 @@ class testcase extends tlObjectWithAttachments {
     $ret['status_ok']=1;
 
     if ($result && ( !is_null($item->steps) && is_array($item->steps) ) ) {
-      $steps2create = count($item->steps);
+      $steps2create = count((array)$item->steps);
       $op['status_ok'] = 1;
 
       // need to this to manage call to this method for REST API.
@@ -816,7 +816,7 @@ class testcase extends tlObjectWithAttachments {
 
     $rs = $this->db->fetchRowsIntoMap($sql,$my['options']['access_key']);
 
-    if( is_null($rs) || count($rs) == 0 ) {
+    if( is_null($rs) || count((array)$rs) == 0 ) {
       $rs=null;
     }
     return $rs;
@@ -869,7 +869,7 @@ class testcase extends tlObjectWithAttachments {
               " AND NH_TCASE_PARENT.node_type_id = {$this->node_types_descr_id['testsuite']} ";
     }
     $recordset = $this->db->get_recordset($sql);
-    if(count($recordset) && $tproject_name != "")
+    if(count((array)$recordset) && $tproject_name != "")
     {
       list($tproject_info)=$this->tproject_mgr->get_by_name($tproject_name);
       foreach($recordset as $idx => $tcase_info)
@@ -966,7 +966,7 @@ class testcase extends tlObjectWithAttachments {
     
     $userIDSet = array();
 
-    if($status_ok && sizeof($idSet)) {
+    if($status_ok && sizeof((array)$idSet)) {
 
       $cfPlaces = $this->buildCFLocationMap();
       $gui->linked_versions = null;
@@ -1113,11 +1113,11 @@ class testcase extends tlObjectWithAttachments {
         }
 
         // Other versions (if exists)
-        if(count($tcvSet) > 1) {
+        if(count((array)$tcvSet) > 1) {
           $gui->testcase_other_versions[] = array_slice($tcvSet,1);
 
-          $target_idx = count($gui->testcase_other_versions) - 1;
-          $loop2do = count($gui->testcase_other_versions[$target_idx]);
+          $target_idx = count((array)$gui->testcase_other_versions) - 1;
+          $loop2do = count((array)$gui->testcase_other_versions[$target_idx]);
 
           $cfCtx = array('scope' => 'design','tproject_id' => $gui->tproject_id);
 
@@ -1218,7 +1218,7 @@ class testcase extends tlObjectWithAttachments {
 
 
     $gui->additionalMessages = [];
-    if ($gui->currentVersionKeywords != null && count($gui->currentVersionKeywords) > 0) {
+    if ($gui->currentVersionKeywords != null && count((array)$gui->currentVersionKeywords) > 0) {
       // look for annotations in notes
       foreach($gui->currentVersionKeywords as $kwEntity) {
         foreach($this->keywordAnnotations as $kwAnnot) {
@@ -1448,11 +1448,11 @@ class testcase extends tlObjectWithAttachments {
 
     $auditContext = array('on' => self::AUDIT_ON, 'version' => $version);
     
-    if(!is_null($items['todelete']) && count($items['todelete'])) {
+    if(!is_null($items['todelete']) && count((array)$items['todelete'])) {
       $this->deleteKeywords($id,$version_id,array_keys($items['todelete']),$auditContext);
     }
 
-    if(!is_null($items['new']) && count($items['new']))
+    if(!is_null($items['new']) && count((array)$items['new']))
     {
       $this->addKeywords($id,$version_id,array_keys($items['new']),$auditContext);
     }
@@ -1514,7 +1514,7 @@ class testcase extends tlObjectWithAttachments {
       $linked_not_exec = $this->get_linked_versions($id,array('exec_status' => 'NOT_EXECUTED'));
 
       $status='linked_and_executed';
-      if(count($linked_tcversions) == count($linked_not_exec))
+      if(count((array)$linked_tcversions) == count((array)$linked_not_exec))
       {
         $status = 'linked_but_not_executed';
       }
@@ -1764,7 +1764,7 @@ class testcase extends tlObjectWithAttachments {
         }
       }
 
-      if( count($children['step']) > 0) {
+      if( count((array)$children['step']) > 0) {
         $step_list=trim(implode(',',$children['step']));
         $sql[]="/* $debugMsg */ DELETE FROM {$this->tables['tcsteps']}  " .
                " WHERE id IN ({$step_list})";
@@ -1856,7 +1856,7 @@ class testcase extends tlObjectWithAttachments {
           }
         }
 
-        if( count($children['step']) > 0) {
+        if( count((array)$children['step']) > 0) {
           $step_list=trim(implode(',',$children['step']));
        }
     }
@@ -1994,7 +1994,7 @@ class testcase extends tlObjectWithAttachments {
                        AND tcversion_number <> {$myVersionNum}";
       $rs = (array)$this->db->get_recordset($sqlCheckExec);
 
-      if (count($rs) != 0) {
+      if (count((array)$rs) != 0) {
         // Get latest execution to get the version number and then tcversion_id 
         // to update the testplan_tcversions.
         // We need to get version number for EACH TEST PLAN!!
@@ -2363,7 +2363,7 @@ class testcase extends tlObjectWithAttachments {
     if( $this->cfg->testcase->relations->enable && 
         $freezeTCVRelationsOnNewTCVersion ) {
       $oldVerRel = $this->getTCVRelationsRaw($source['version_id']);
-      if( null != $oldVerRel && count($oldVerRel) > 0 ) {
+      if( null != $oldVerRel && count((array)$oldVerRel) > 0 ) {
         $i2c = array_keys($oldVerRel);
         $this->closeOpenTCVRelation($i2c,LINK_TC_RELATION_CLOSED_BY_NEW_TCVERSION);
       }
@@ -2503,7 +2503,7 @@ class testcase extends tlObjectWithAttachments {
     // Need to get all steps
     $gso = array('renderGhostSteps' => false, 'renderImageInline' => false);
     $stepsSet = $this->get_steps($from_tcversion_id,0,$gso);
-    if( !is_null($stepsSet) && count($stepsSet) > 0) {
+    if( !is_null($stepsSet) && count((array)$stepsSet) > 0) {
       foreach($stepsSet as $key => $step) {
         $op = $this->create_step($to_tcversion_id,$step['step_number'],
                                  $step['actions'],$step['expected_results'],
@@ -3111,7 +3111,7 @@ class testcase extends tlObjectWithAttachments {
     $link_info = null;
     $in_set = null;
 
-    if (sizeof($rs))
+    if (sizeof((array)$rs))
     {
       foreach($rs as $idx => $elem)
       {
@@ -3196,7 +3196,7 @@ class testcase extends tlObjectWithAttachments {
               $rs[]=$value;
 
               // Must Update list of not executed
-              $kix=count($rs);
+              $kix=count((array)$rs);
               $item_not_executed[]=$kix > 0 ? $kix-1 : $kix;
             }
 
@@ -3405,7 +3405,7 @@ class testcase extends tlObjectWithAttachments {
                               WHERE keyword_id = K.id
                               {$keyword_filter}
                               GROUP BY testcase_id ) AS MAFALDA " .
-                          " WHERE MAFALDA.HITS=" . count($keyword_id) . ")";
+                          " WHERE MAFALDA.HITS=" . count((array)$keyword_id) . ")";
 
               $keyword_filter ='';
           }
@@ -3557,7 +3557,7 @@ class testcase extends tlObjectWithAttachments {
     $adt = array('on' => self::AUDIT_ON, 'version' => null);
     $adt = array_merge($adt, (array)$audit);
 
-    if( count($kw_ids) == 0 ) {
+    if( count((array)$kw_ids) == 0 ) {
       return true;
     }
 
@@ -3588,7 +3588,7 @@ class testcase extends tlObjectWithAttachments {
       }
     }
 
-    if( count($dummy) <= 0 ) {
+    if( count((array)$dummy) <= 0 ) {
       return;
     }
 
@@ -3895,7 +3895,7 @@ class testcase extends tlObjectWithAttachments {
 
         if( is_array($my['options']['exec_to_exclude']))
         {
-            if(count($my['options']['exec_to_exclude']) > 0 )
+            if(count((array)$my['options']['exec_to_exclude']) > 0 )
             {
               $exec_id_list = implode(",",$my['options']['exec_to_exclude']);
                 $where_clause  .= " AND e.id NOT IN ({$exec_id_list}) ";
@@ -4076,10 +4076,10 @@ class testcase extends tlObjectWithAttachments {
 
     $recordset = $this->db->fetchColumnsIntoMap($sql,'execution_id','tcversion_id');
     $and_exec_id='';
-    if( !is_null($recordset) && count($recordset) > 0) {
+    if( !is_null($recordset) && count((array)$recordset) > 0) {
       $the_list = implode(",", array_keys($recordset));
       if($the_list != '') {
-        if( count($recordset) > 1 ) {
+        if( count((array)$recordset) > 1 ) {
           $and_exec_id = " AND e.id IN ($the_list) ";
         } else {
           $and_exec_id = " AND e.id = $the_list ";
@@ -4269,7 +4269,7 @@ class testcase extends tlObjectWithAttachments {
       // each UPPER CASE word in this map KEY, MUST HAVE AN OCCURENCE on $elemTpl
       // value is a key inside $tc_data[0]
       //
-      if( !is_null($cfMap) && count($cfMap) > 0 ) {
+      if( !is_null($cfMap) && count((array)$cfMap) > 0 ) {
         $tc_data[0]['xmlcustomfields'] = $cfieldMgr->exportValueAsXML($cfMap);
       }
     }
@@ -4291,7 +4291,7 @@ class testcase extends tlObjectWithAttachments {
       
       $req4version = $reqMgr->getGoodForTCVersion($testCaseVersionID);
 
-      if( !is_null($req4version) && count($req4version) > 0 ) {
+      if( !is_null($req4version) && count((array)$req4version) > 0 ) {
         $tc_data[0]['xmlrequirements'] = 
           exportDataToXML($req4version,$this->XMLCfg->req->root,
                           $this->XMLCfg->req->elemTPL,$this->XMLCfg->req->decode,true);
@@ -4322,7 +4322,7 @@ class testcase extends tlObjectWithAttachments {
   			}
   	  }
 	  
-		  if( !is_null($attachments) && count($attachments) > 0 ) {
+		  if( !is_null($attachments) && count((array)$attachments) > 0 ) {
         $tc_data[0]['xmlattachments'] = 
           exportDataToXML($attachments,$this->XMLCfg->att->root,
                           $this->XMLCfg->att->elemTPL,$this->XMLCfg->att->decode,true);
@@ -4794,7 +4794,7 @@ class testcase extends tlObjectWithAttachments {
 
     $itemSet=$req_mgr->get_all_for_tcase($from);
     if( !is_null($itemSet) ) {
-      $loop2do=count($itemSet);
+      $loop2do=count((array)$itemSet);
       for($idx=0; $idx < $loop2do; $idx++) {
         if( isset($mappings[$itemSet[$idx]['id']]) ) {
           $items[$idx]=$mappings[$itemSet[$idx]['id']];
@@ -4976,7 +4976,7 @@ class testcase extends tlObjectWithAttachments {
   function getTestProjectFromTestCase($id,$parent_id=null)
   {
     $the_path = $this->tree_manager->get_path( (!is_null($id) && $id > 0) ? $id : $parent_id);
-    $path_len = count($the_path);
+    $path_len = count((array)$the_path);
     $tproject_id = ($path_len > 0)? $the_path[0]['parent_id'] : $parent_id;
 
     return $tproject_id;
@@ -5536,14 +5536,14 @@ class testcase extends tlObjectWithAttachments {
 
         // First get root -> test project name and leaf => test case name
       $parts = explode($pathSeparator,$pathName);
-      $partsQty = count($parts);
+      $partsQty = count((array)$parts);
       $tprojectName = $parts[0];
       $tsuiteName = $parts[$partsQty-2];
       $tcaseName = end($parts);
 
       // get all testcases on test project with this name and parent test suite
         $recordset = $this->get_by_name($tcaseName, $tsuiteName ,$tprojectName);
-        if( !is_null($recordset) && count($recordset) > 0 )
+        if( !is_null($recordset) && count((array)$recordset) > 0 )
         {
           foreach($recordset as $value)
           {
@@ -5751,7 +5751,7 @@ class testcase extends tlObjectWithAttachments {
     if(!is_null($result) && $my['options']['renderImageInline']) {
       // for attachments we need the Test Case Version ID
       // (time ago we used the Test Case ID)
-      $k2l = count($result);
+      $k2l = count((array)$result);
       $gaga = array('actions','expected_results');
       for($idx=0; $idx < $k2l; $idx++) {
         $this->renderImageAttachments($tcversion_id,$result[$idx],$gaga);
@@ -6051,7 +6051,7 @@ class testcase extends tlObjectWithAttachments {
 
       if( !is_null($my['filters']['cfields']) ) {
         $cf_hash = &$my['filters']['cfields'];
-        $cfQty = count($cf_hash);
+        $cfQty = count((array)$cf_hash);
         $countmain = 1;
 
         // Build custom fields filter
@@ -6103,7 +6103,7 @@ class testcase extends tlObjectWithAttachments {
         $key2loop = array_keys($recordset);
         if($cfQty > 0) {
           foreach($key2loop as $key) {
-            if( count($recordset[$key]) < $cfQty) {
+            if( count((array)$recordset[$key]) < $cfQty) {
               unset($recordset[$key]);
             }
             else {
@@ -6119,7 +6119,7 @@ class testcase extends tlObjectWithAttachments {
           }
         }
 
-        if( count($recordset) <= 0 ) {
+        if( count((array)$recordset) <= 0 ) {
           $recordset = null;
         }
       }
@@ -6210,13 +6210,13 @@ class testcase extends tlObjectWithAttachments {
 
     $stepSet = (array)$this->get_steps($tcversion_id,0,
                                         array('fields2get' => 'id', 'accessKey' => 'id'));
-    if( count($stepSet) > 0 )
+    if( count((array)$stepSet) > 0 )
     {
       $this->delete_step_by_id(array_keys($stepSet));
     }
 
     // Now insert steps
-    $loop2do = count($steps);
+    $loop2do = count((array)$steps);
     for($idx=0; $idx < $loop2do; $idx++)
     {
       $this->create_step($tcversion_id,$steps[$idx]['step_number'],
@@ -6269,7 +6269,7 @@ class testcase extends tlObjectWithAttachments {
 
     $or_clause = '';
     $cf_query = '';
-    $cf_qty = count($cf_hash);
+    $cf_qty = count((array)$cf_hash);
 
     // do not worry!! it seems that filter criteria is OR, but really is an AND,
     // OR is needed to do a simple query.
@@ -6300,12 +6300,12 @@ class testcase extends tlObjectWithAttachments {
       $key2loop = array_keys($recordset);
       foreach($key2loop as $key)
       {
-        if( count($recordset[$key]) < $cf_qty)
+        if( count((array)$recordset[$key]) < $cf_qty)
         {
           unset($recordset[$key]);
         }
       }
-      if( count($recordset) <= 0 )
+      if( count((array)$recordset) <= 0 )
       {
         $recordset = null;
       }
@@ -6514,7 +6514,7 @@ class testcase extends tlObjectWithAttachments {
    */
   function renderGhostSteps(&$steps2render, $scan = null) {
     $warningRenderException = lang_get('unable_to_render_ghost');
-    $loop2do = count($steps2render);
+    $loop2do = count((array)$steps2render);
 
     $tlBeginMark = self::GHOSTBEGIN;
     $tlEndMark = self::GHOSTEND;
@@ -6542,7 +6542,7 @@ class testcase extends tlObjectWithAttachments {
 
         if($start !== FALSE) {
           $xx = explode($tlBeginMark,$rse[$gdx][$item_key]);
-          $xx2do = count($xx);
+          $xx2do = count((array)$xx);
           $ghost = '';
           $deghosted = false;
           for($xdx=0; $xdx < $xx2do; $xdx++) {
@@ -7243,7 +7243,7 @@ class testcase extends tlObjectWithAttachments {
     $goo->display_testcase_path = !is_null($goo->path_info);
     $goo->show_match_count = $viewer_defaults['show_match_count'];
     if($goo->show_match_count && $goo->display_testcase_path ) {
-      $goo->pageTitle .= '-' . lang_get('match_count') . ':' . ($goo->match_count = count($goo->path_info));
+      $goo->pageTitle .= '-' . lang_get('match_count') . ':' . ($goo->match_count = count((array)$goo->path_info));
     }
 
     $goo->refreshTree = isset($goo->refreshTree) ? $goo->refreshTree : $viewer_defaults['refreshTree'];
@@ -7296,13 +7296,13 @@ class testcase extends tlObjectWithAttachments {
     }
 
     if( $goo->display_parent_testsuite ) {
-      $parent = count($path2root)-2;
+      $parent = count((array)$path2root)-2;
       $goo->parentTestSuiteName = $path2root[$parent]['name'];
     }
 
 
     $testplans = $this->tproject_mgr->get_all_testplans($goo->tproject_id,array('plan_status' =>1) );
-    $goo->has_testplans = !is_null($testplans) && count($testplans) > 0 ? 1 : 0;
+    $goo->has_testplans = !is_null($testplans) && count((array)$testplans) > 0 ? 1 : 0;
 
 
     $platformMgr = new tlPlatform($this->db,$goo->tproject_id);
@@ -7405,7 +7405,7 @@ class testcase extends tlObjectWithAttachments {
         $xx = explode($tlBeginMark,$rse[$item_key]);
 
         // How many requests to replace ?
-        $xx2do = count($xx);
+        $xx2do = count((array)$xx);
         $ghost = '';
         for($xdx=0; $xdx < $xx2do; $xdx++) {
           $isTestCaseGhost = true;
@@ -7419,7 +7419,7 @@ class testcase extends tlObjectWithAttachments {
             // is user had not messed things.
             $yy = explode($tlEndMark,$xx[$xdx]);
 
-            if( ($elc = count($yy)) > 0)
+            if( ($elc = count((array)$yy)) > 0)
             {
               $dx = $yy[0];
 
@@ -7713,7 +7713,7 @@ class testcase extends tlObjectWithAttachments {
 
     $relSet['relations']= $this->db->get_recordset($sql);
 
-    if( !is_null($relSet['relations']) && count($relSet['relations']) > 0 ) {
+    if( !is_null($relSet['relations']) && count((array)$relSet['relations']) > 0 ) {
       $labels = $this->getRelationLabels();
       $label_keys = array_keys($labels);
       foreach($relSet['relations'] as $key => $rel)
@@ -7751,7 +7751,7 @@ class testcase extends tlObjectWithAttachments {
 
         } // end foreach
 
-        $relSet['num_relations'] = count($relSet['relations']);
+        $relSet['num_relations'] = count((array)$relSet['relations']);
     }
 
     return $relSet;
@@ -7794,7 +7794,7 @@ class testcase extends tlObjectWithAttachments {
 
     $relSet['relations']= $this->db->get_recordset($sql);
 
-    if( !is_null($relSet['relations']) && count($relSet['relations']) > 0 ) {
+    if( !is_null($relSet['relations']) && count((array)$relSet['relations']) > 0 ) {
       $labels = $this->getRelationLabels();
       $label_keys = array_keys($labels);
 
@@ -7836,7 +7836,7 @@ class testcase extends tlObjectWithAttachments {
 
         } // end foreach
 
-        $relSet['num_relations'] = count($relSet['relations']);
+        $relSet['num_relations'] = count((array)$relSet['relations']);
     }
 
     return $relSet;
@@ -8212,7 +8212,7 @@ class testcase extends tlObjectWithAttachments {
         $xx = explode($beginTag,$rse[$item_key]);
 
         // How many requests to replace ?
-        $xx2do = count($xx);
+        $xx2do = count((array)$xx);
         $ghost = '';
         for($xdx=0; $xdx < $xx2do; $xdx++) {
           // Hope was not a false request.
@@ -8221,7 +8221,7 @@ class testcase extends tlObjectWithAttachments {
             // Theorically can be just ONE, but it depends
             // is user had not messed things.
             $yy = explode($endTag,$xx[$xdx]);
-            if( ($elc = count($yy)) > 0) {
+            if( ($elc = count((array)$yy)) > 0) {
 
               $atx = $yy[0];
               if( intval($atx) == 0 ) {
@@ -8427,7 +8427,7 @@ class testcase extends tlObjectWithAttachments {
         $xx = explode($tlBeginTag,$play);
 
         // How many requests to replace ?
-        $xx2do = count($xx);
+        $xx2do = count((array)$xx);
         for($xdx=0; $xdx < $xx2do; $xdx++) {
 
           // Hope was not a false request.
@@ -8437,7 +8437,7 @@ class testcase extends tlObjectWithAttachments {
             // Theorically can be just ONE, but it depends
             // is user had not messed things.
             $yy = explode($tlEndTag,$xx[$xdx]);
-            if( ($elc = count($yy)) > 0) {
+            if( ($elc = count((array)$yy)) > 0) {
               $markAsIS = $tlBeginTag . $yy[0] . $tlEndTag;
               $variableName = trim($yy[0]);
 
@@ -8527,7 +8527,7 @@ class testcase extends tlObjectWithAttachments {
       }
     }
 
-    if(count($script_list) === 0)
+    if(count((array)$script_list) === 0)
     {
       $script_list = null;
     }
@@ -8599,7 +8599,7 @@ class testcase extends tlObjectWithAttachments {
       $name = $whoami['l'] . self::NAME_PHOPEN; 
 
       $juice = $this->orangeJuice($text2scan);
-      $name .=  ( count($dm) > 0 ) ? $dm[0] : $meat;
+      $name .=  ( count((array)$dm) > 0 ) ? $dm[0] : $meat;
       $name .= self::NAME_DIVIDE . $juice . self::NAME_PHCLOSE . $whoami['r']; 
     }
     return $name;
@@ -8643,7 +8643,7 @@ class testcase extends tlObjectWithAttachments {
       }    
       
       $dm = explode(self::NAME_DIVIDE, $needle);
-      $target = $side['l'] . ((count($dm) > 0) ? $dm[0] : $needle);
+      $target = $side['l'] . ((count((array)$dm) > 0) ? $dm[0] : $needle);
 
       $juice = $this->orangeJuice($scan4values);
       $target .= self::NAME_DIVIDE . $juice . $side['r']; 
@@ -8701,7 +8701,7 @@ class testcase extends tlObjectWithAttachments {
 
     $xx = $this->db->fetchRowsIntoMap( $sql, 'tcversion_id' );
 
-    if( null != $xx && count($xx) > 0 ) {
+    if( null != $xx && count((array)$xx) > 0 ) {
       return array_keys($xx);
     } 
 
@@ -8768,7 +8768,7 @@ class testcase extends tlObjectWithAttachments {
            " link_status,author_id) ";
 
     $values = array();
-    if( null != $relSource && count($relSource) > 0) {
+    if( null != $relSource && count((array)$relSource) > 0) {
       foreach ($relSource as $key => $elem) {
         $stm = "($dest_id,{$elem['destination_id']}," .
                "{$elem['relation_type']},{$elem['link_status']}," .
@@ -8777,7 +8777,7 @@ class testcase extends tlObjectWithAttachments {
       } 
     }
 
-    if( null != $relDest && count($relDest) > 0) {
+    if( null != $relDest && count((array)$relDest) > 0) {
       foreach ($relDest as $key => $elem) {
         $stm = "({$elem['source_id']},$dest_id," .
                "{$elem['relation_type']},{$elem['link_status']}," .
@@ -8786,7 +8786,7 @@ class testcase extends tlObjectWithAttachments {
       } 
     }
 
-    if( count($values) > 0 ) {
+    if( count((array)$values) > 0 ) {
       $sql = 'INSERT INTO ' . $this->tables['testcase_relations'] .
              $ins . ' VALUES ' . implode(',',$values);
 
@@ -8943,7 +8943,7 @@ class testcase extends tlObjectWithAttachments {
       $reqSet = null;
       $reqVerSet = null; 
 
-      $loop2do=count($itemSet);
+      $loop2do=count((array)$itemSet);
       for($idx=0; $idx < $loop2do; $idx++) {
 
         $reqID = $itemSet[$idx]['req_id'];
@@ -9067,7 +9067,7 @@ class testcase extends tlObjectWithAttachments {
         $xx = explode($tlBeginTag,$play);
 
         // How many requests to replace ?
-        $xx2do = count($xx);
+        $xx2do = count((array)$xx);
         $ghost = '';
         for($xdx=0; $xdx < $xx2do; $xdx++) {
 
@@ -9077,7 +9077,7 @@ class testcase extends tlObjectWithAttachments {
             // Theorically can be just ONE, but it depends
             // is user had not messed things.
             $yy = explode($tlEndTag,$xx[$xdx]);
-            if( ($elc = count($yy)) > 0) {
+            if( ($elc = count((array)$yy)) > 0) {
               $cfname = trim($yy[0]);
               try {
                 // look for the custom field
@@ -9341,7 +9341,7 @@ class testcase extends tlObjectWithAttachments {
 
     $tcvSet = $this->db->fetchRowsIntoMap($sqlA,'id');
 
-    if( count($linkSet) > 0 ) {
+    if( count((array)$linkSet) > 0 ) {
 
       $safeTP = intval($tplanID);
       $linkItems = array_keys($linkSet);
@@ -9466,7 +9466,7 @@ class testcase extends tlObjectWithAttachments {
   */
   public function saveStepsPartialExec($partialExec,$context) 
   {
-    if (!is_null($partialExec) && count($partialExec) > 0) {
+    if (!is_null($partialExec) && count((array)$partialExec) > 0) {
       $stepsIDSet = array_keys($partialExec['notes']);
       $this->deleteStepsPartialExec($stepsIDSet,$context);
         
@@ -9527,7 +9527,7 @@ class testcase extends tlObjectWithAttachments {
 
     $rs = (array)$this->db->get_recordset($sql);
 
-    return (count($rs) > 0);
+    return (count((array)$rs) > 0);
   }
 
 
@@ -9540,7 +9540,7 @@ class testcase extends tlObjectWithAttachments {
    */
   public function getStepsPartialExec($stepsIds,$context) {
     $rs = null;  
-    if (!is_null($stepsIds) && count($stepsIds) > 0) {
+    if (!is_null($stepsIds) && count((array)$stepsIds) > 0) {
 
       $fields2get = "tcstep_id,testplan_id,platform_id,build_id,
                      tester_id,notes,status,creation_ts";
@@ -9563,7 +9563,7 @@ class testcase extends tlObjectWithAttachments {
    * 
    */
   public function deleteStepsPartialExec($stepsIds,$context) {
-    if( count($stepsIds) > 0 ) {
+    if( count((array)$stepsIds) > 0 ) {
       // https://github.com/TestLinkOpenSourceTRMS/testlink-code/pull/327
       // Security
       $inClause = $this->db->prepare_string(implode(",",$stepsIds));
@@ -9817,7 +9817,7 @@ class testcase extends tlObjectWithAttachments {
     $adt = array('on' => self::AUDIT_ON, 'version' => null);
     $adt = array_merge($adt, (array)$audit);
 
-    if( count($idSet) == 0 ) {
+    if( count((array)$idSet) == 0 ) {
       return true;
     }
 
@@ -9849,7 +9849,7 @@ class testcase extends tlObjectWithAttachments {
       }
     }
 
-    if( count($dummy) <= 0 ) {
+    if( count((array)$dummy) <= 0 ) {
       return;
     }
 

--- a/lib/functions/testcase.class.php
+++ b/lib/functions/testcase.class.php
@@ -572,7 +572,7 @@ class testcase extends tlObjectWithAttachments {
 
                 case 'counterSuffix':
                   $mask =  !is_null($algo_cfg->text) ? $algo_cfg->text : '#%s';
-                  $nameSet = array_flip(array_keys($itemSet));
+                  $nameSet = array_flip(array_keys((array)$itemSet));
 
                   // 20110109 - franciscom
                   // does not understand why I've choosen time ago
@@ -1210,7 +1210,7 @@ class testcase extends tlObjectWithAttachments {
 
     // Removing duplicate and NULL id's
     unset($userIDSet['']);
-    $gui->users = tlUser::getByIDs($this->db,array_keys($userIDSet));
+    $gui->users = tlUser::getByIDs($this->db,array_keys((array)$userIDSet));
     $gui->cf = null;
 
     $this->initShowGuiActions($gui);
@@ -1449,12 +1449,12 @@ class testcase extends tlObjectWithAttachments {
     $auditContext = array('on' => self::AUDIT_ON, 'version' => $version);
     
     if(!is_null($items['todelete']) && count((array)$items['todelete'])) {
-      $this->deleteKeywords($id,$version_id,array_keys($items['todelete']),$auditContext);
+      $this->deleteKeywords($id,$version_id,array_keys((array)$items['todelete']),$auditContext);
     }
 
     if(!is_null($items['new']) && count((array)$items['new']))
     {
-      $this->addKeywords($id,$version_id,array_keys($items['new']),$auditContext);
+      $this->addKeywords($id,$version_id,array_keys((array)$items['new']),$auditContext);
     }
   }
 
@@ -1698,13 +1698,13 @@ class testcase extends tlObjectWithAttachments {
 
     // Multiple Test Case Steps
     if( !is_null($recordset) && ($my['options']['output'] == 'full') ) {
-      $version2loop = array_keys($recordset);
+      $version2loop = array_keys((array)$recordset);
       foreach( $version2loop as $accessKey) {
         // no options => will renderd Ghost Steps
         $step_set = $this->get_steps($accessKey);
-        $tplan2loop = array_keys($recordset[$accessKey]);
+        $tplan2loop = array_keys((array)$recordset[$accessKey]);
         foreach( $tplan2loop as $tplanKey) {
-          $elem2loop = array_keys($recordset[$accessKey][$tplanKey]);
+          $elem2loop = array_keys((array)$recordset[$accessKey][$tplanKey]);
           foreach( $elem2loop as $elemKey) {
             $recordset[$accessKey][$tplanKey][$elemKey]['steps'] = $step_set;
           }
@@ -2364,7 +2364,7 @@ class testcase extends tlObjectWithAttachments {
         $freezeTCVRelationsOnNewTCVersion ) {
       $oldVerRel = $this->getTCVRelationsRaw($source['version_id']);
       if( null != $oldVerRel && count((array)$oldVerRel) > 0 ) {
-        $i2c = array_keys($oldVerRel);
+        $i2c = array_keys((array)$oldVerRel);
         $this->closeOpenTCVRelation($i2c,LINK_TC_RELATION_CLOSED_BY_NEW_TCVERSION);
       }
     }
@@ -2817,7 +2817,7 @@ class testcase extends tlObjectWithAttachments {
     $canProcess = !is_null($recordset);
 
     if( $canProcess && $render['variables'] ) {
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $accessKey) {
         try {
           $this->renderVariables($recordset[$accessKey],$my['options']['tproject_id']);
@@ -2829,7 +2829,7 @@ class testcase extends tlObjectWithAttachments {
     }
 
     if( $canProcess && $render['specialKW'] ) {
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $accessKey) {
         $this->renderSpecialTSuiteKeywords($recordset[$accessKey]);
       }
@@ -2839,7 +2839,7 @@ class testcase extends tlObjectWithAttachments {
 
     // ghost on preconditions and summary
     if( $canProcess && $my['options']['renderGhost'] ) {
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $accessKey) {
         $this->renderGhost($recordset[$accessKey]);
       }
@@ -2847,7 +2847,7 @@ class testcase extends tlObjectWithAttachments {
     }
 
     if( $canProcess && $render['imageInline']) {
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $accessKey) {
         $pVersion = $recordset[$accessKey]['id'];
         $this->renderImageAttachments($pVersion,$recordset[$accessKey]);
@@ -2860,7 +2860,7 @@ class testcase extends tlObjectWithAttachments {
     if( $canProcess && $my['options']['output'] == 'full') {
       $gsOpt['renderGhostSteps'] = $my['options']['renderGhost'];
 
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $accessKey) {
         $step_set = $this->get_steps($recordset[$accessKey]['id'],0,$gsOpt);
         if($my['options']['withGhostString']) {
@@ -2882,7 +2882,7 @@ class testcase extends tlObjectWithAttachments {
     }
 
     if( $canProcess && $my['options']['getPrefix'] ) {
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach( $key2loop as $accessKey) {
         $pfx = $this->getPrefix($recordset[$accessKey]['testcase_id']);
         $recordset[$accessKey]['fullExternalID'] =  $pfx[0] . $this->cfg->testcase->glue_character .
@@ -3217,7 +3217,7 @@ class testcase extends tlObjectWithAttachments {
       break;
 
       default:
-        $target = array_keys($rs);
+        $target = array_keys((array)$rs);
       break;
     }
 
@@ -3667,7 +3667,7 @@ class testcase extends tlObjectWithAttachments {
     if( !is_null($sourceKW) ) {
       
       // build item id list
-      $keySet = array_keys($sourceKW);
+      $keySet = array_keys((array)$sourceKW);
       if( null != $kwMappings ) {
         foreach($keySet as $itemPos => $itemID) {
           if( isset($mappings[$itemID]) ) {
@@ -4077,7 +4077,7 @@ class testcase extends tlObjectWithAttachments {
     $recordset = $this->db->fetchColumnsIntoMap($sql,'execution_id','tcversion_id');
     $and_exec_id='';
     if( !is_null($recordset) && count((array)$recordset) > 0) {
-      $the_list = implode(",", array_keys($recordset));
+      $the_list = implode(",", array_keys((array)$recordset));
       if($the_list != '') {
         if( count((array)$recordset) > 1 ) {
           $and_exec_id = " AND e.id IN ($the_list) ";
@@ -4156,12 +4156,12 @@ class testcase extends tlObjectWithAttachments {
         $xx = $this->getStepsExecInfo($tg['execution_id']);
       }
 
-      $itemSet = array_keys($recordset);
+      $itemSet = array_keys((array)$recordset);
       foreach( $itemSet as $sdx) {
         $step_set = $this->get_steps($recordset[$sdx]['id']);
         if($localOptions['getStepsExecInfo']) {
           if(!is_null($step_set)) {
-            $key_set = array_keys($step_set);
+            $key_set = array_keys((array)$step_set);
             foreach($key_set as $kyx) {
               $step_set[$kyx]['execution_notes'] = '';
               $step_set[$kyx]['execution_status'] = '';
@@ -4188,7 +4188,7 @@ class testcase extends tlObjectWithAttachments {
     // ghost Test Case processing in summary & preconditions
     if( !is_array($id) ) {
       if(!is_null($recordset)) {
-        $key2loop = array_keys($recordset);
+        $key2loop = array_keys((array)$recordset);
 
         // get test project from test plan
         $tplanInfo  = $this->tree_manager->get_node_hierarchy_info($tplan_id);
@@ -4656,11 +4656,11 @@ class testcase extends tlObjectWithAttachments {
             if($my['opt']['access_keys'] == 'testplan_testcase')
             {
               $tcaseSet=null;
-              $main_keys = array_keys($rs);
+              $main_keys = array_keys((array)$rs);
 
               foreach($main_keys as $maccess_key)
               {
-                $sec_keys = array_keys($rs[$maccess_key]);
+                $sec_keys = array_keys((array)$rs[$maccess_key]);
                 foreach($sec_keys as $saccess_key)
                 {
                   // is enough I process first element
@@ -4683,14 +4683,14 @@ class testcase extends tlObjectWithAttachments {
                 // to remove it from test suite name in "tc assigned to user" tables
                 $flat_path[$tcase_id]=implode('/',$pieces);
               }
-              $main_keys = array_keys($rs);
+              $main_keys = array_keys((array)$rs);
 
               foreach($main_keys as $idx)
               {
-                $sec_keys = array_keys($rs[$idx]);
+                $sec_keys = array_keys((array)$rs[$idx]);
                 foreach($sec_keys as $jdx)
                 {
-                  $third_keys = array_keys($rs[$idx][$jdx]);
+                  $third_keys = array_keys((array)$rs[$idx][$jdx]);
                   foreach($third_keys as $tdx)
                   {
                     $fdx = $rs[$idx][$jdx][$tdx]['testcase_id'];
@@ -5484,7 +5484,7 @@ class testcase extends tlObjectWithAttachments {
       }
 
       if( null != $xtree && $options['getTSuiteKeywords'] ) {
-        $tsSet = array_keys($xtree);
+        $tsSet = array_keys((array)$xtree);
         $opkw = array('output' => 'kwname');
         $fkw = array('keywordsLikeStart' => '@#');
         $iset = (array) $tsuiteMgr->getTSuitesFilteredByKWSet($tsSet,$opkw,$fkw);
@@ -6084,7 +6084,7 @@ class testcase extends tlObjectWithAttachments {
         $cfQuery = " AND ({$cfQuery}) ";
       }
 
-      $keySet = implode(',',array_keys($recordset));
+      $keySet = implode(',',array_keys((array)$recordset));
       $sql = "/* $debugMsg */ " .
              " {$selectClause}, NH_TCVERSION.parent_id AS testcase_id, " .
              " TCV.version,TCV.execution_type,TCV.importance,TCV.status {$cfSelect} " .
@@ -6100,7 +6100,7 @@ class testcase extends tlObjectWithAttachments {
       // (not doing this has produced in part TICKET 4704,4708)
       // entries whose count() < number of custom fields has to be removed
       if( !is_null($recordset) ) {
-        $key2loop = array_keys($recordset);
+        $key2loop = array_keys((array)$recordset);
         if($cfQty > 0) {
           foreach($key2loop as $key) {
             if( count((array)$recordset[$key]) < $cfQty) {
@@ -6212,7 +6212,7 @@ class testcase extends tlObjectWithAttachments {
                                         array('fields2get' => 'id', 'accessKey' => 'id'));
     if( count((array)$stepSet) > 0 )
     {
-      $this->delete_step_by_id(array_keys($stepSet));
+      $this->delete_step_by_id(array_keys((array)$stepSet));
     }
 
     // Now insert steps
@@ -6297,7 +6297,7 @@ class testcase extends tlObjectWithAttachments {
     // now loop over result, entries whose count() < number of custom fields has to be removed
     if( !is_null($recordset) )
     {
-      $key2loop = array_keys($recordset);
+      $key2loop = array_keys((array)$recordset);
       foreach($key2loop as $key)
       {
         if( count((array)$recordset[$key]) < $cf_qty)
@@ -6697,10 +6697,10 @@ class testcase extends tlObjectWithAttachments {
       (is_null($options->access_keys) || $options->access_keys='testplan_testcase') )
       {
         $tcaseSet=null;
-        $main_keys = array_keys($rs);
+        $main_keys = array_keys((array)$rs);
         foreach($main_keys as $maccess_key)
         {
-          $sec_keys = array_keys($rs[$maccess_key]);
+          $sec_keys = array_keys((array)$rs[$maccess_key]);
           foreach($sec_keys as $saccess_key)
           {
             // is enough I process first element
@@ -6721,14 +6721,14 @@ class testcase extends tlObjectWithAttachments {
           unset($pieces[0]);
           $flat_path[$tcase_id]=implode('/',$pieces);
         }
-        $main_keys = array_keys($rs);
+        $main_keys = array_keys((array)$rs);
 
         foreach($main_keys as $idx)
         {
-          $sec_keys = array_keys($rs[$idx]);
+          $sec_keys = array_keys((array)$rs[$idx]);
           foreach($sec_keys as $jdx)
           {
-            $third_keys = array_keys($rs[$idx][$jdx]);
+            $third_keys = array_keys((array)$rs[$idx][$jdx]);
             foreach($third_keys as $tdx)
             {
               $fdx = $rs[$idx][$jdx][$tdx]['testcase_id'];
@@ -7715,7 +7715,7 @@ class testcase extends tlObjectWithAttachments {
 
     if( !is_null($relSet['relations']) && count((array)$relSet['relations']) > 0 ) {
       $labels = $this->getRelationLabels();
-      $label_keys = array_keys($labels);
+      $label_keys = array_keys((array)$labels);
       foreach($relSet['relations'] as $key => $rel)
       {
         // is this relation type is configured?
@@ -7796,7 +7796,7 @@ class testcase extends tlObjectWithAttachments {
 
     if( !is_null($relSet['relations']) && count((array)$relSet['relations']) > 0 ) {
       $labels = $this->getRelationLabels();
-      $label_keys = array_keys($labels);
+      $label_keys = array_keys((array)$labels);
 
       foreach($relSet['relations'] as $key => $rel) {
         // is this relation type is configured?
@@ -8077,7 +8077,7 @@ class testcase extends tlObjectWithAttachments {
     else
     {
       // "related to" is not configured, so take last element as selected one
-      $keys = array_keys($htmlSelect['items']);
+      $keys = array_keys((array)$htmlSelect['items']);
       $selected_key = end($keys);
     }
     $htmlSelect['selected'] = $selected_key;
@@ -8702,7 +8702,7 @@ class testcase extends tlObjectWithAttachments {
     $xx = $this->db->fetchRowsIntoMap( $sql, 'tcversion_id' );
 
     if( null != $xx && count((array)$xx) > 0 ) {
-      return array_keys($xx);
+      return array_keys((array)$xx);
     } 
 
     return null;      
@@ -9344,7 +9344,7 @@ class testcase extends tlObjectWithAttachments {
     if( count((array)$linkSet) > 0 ) {
 
       $safeTP = intval($tplanID);
-      $linkItems = array_keys($linkSet);
+      $linkItems = array_keys((array)$linkSet);
       $inClause = implode(',',$linkItems);
 
        
@@ -9359,7 +9359,7 @@ class testcase extends tlObjectWithAttachments {
       $this->db->exec_query($sql);
 
       // Access by test case version id
-      $tcvItems = array_keys($tcvSet);
+      $tcvItems = array_keys((array)$tcvSet);
       $inClause = implode(',',$tcvItems);
 
       // Execution results
@@ -9467,7 +9467,7 @@ class testcase extends tlObjectWithAttachments {
   public function saveStepsPartialExec($partialExec,$context) 
   {
     if (!is_null($partialExec) && count((array)$partialExec) > 0) {
-      $stepsIDSet = array_keys($partialExec['notes']);
+      $stepsIDSet = array_keys((array)$partialExec['notes']);
       $this->deleteStepsPartialExec($stepsIDSet,$context);
         
       $prop = get_object_vars($context);
@@ -9973,7 +9973,7 @@ class testcase extends tlObjectWithAttachments {
     if( !is_null($sourceIT) ) {
       
       // build item id list
-      $itSet = array_keys($sourceIT);
+      $itSet = array_keys((array)$sourceIT);
       if( null != $platMap ) {
         foreach($itSet as $itemPos => $itemID) {
           if( isset($mappings[$itemID]) ) {

--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -835,7 +835,7 @@ class testplan extends tlObjectWithAttachments
     $items = $this->db->fetchRowsIntoMap($sql,'tsuite_id',database::CUMULATIVE);           
       $xsql = " SELECT COALESCE(parent_id,0) AS parent_id,id,name" . 
           " FROM {$this->tables['nodes_hierarchy']} " . 
-          " WHERE id IN (" . implode(',',array_keys($items)) . ") AND parent_id IS NOT NULL";
+          " WHERE id IN (" . implode(',',array_keys((array)$items)) . ") AND parent_id IS NOT NULL";
 
     unset($items);
     $xmen = $this->db->fetchMapRowsIntoMap($xsql,'parent_id','id');
@@ -864,7 +864,7 @@ class testplan extends tlObjectWithAttachments
     // Now with node list get order
       $xsql = " SELECT id,name,node_order " . 
           " FROM {$this->tables['nodes_hierarchy']} " . 
-          " WHERE id IN (" . implode(',',array_keys($tlnodes)) . ")" .
+          " WHERE id IN (" . implode(',',array_keys((array)$tlnodes)) . ")" .
           " ORDER BY node_order,name ";
     $xmen = $this->db->fetchRowsIntoMap($xsql,'id');
     switch($my['opt']['output'])
@@ -1197,7 +1197,7 @@ class testplan extends tlObjectWithAttachments
     
     if( !is_null($exec_ids) and count((array)$exec_ids) > 0 ) {
       // has executions
-      $exec_ids = array_keys($exec_ids);
+      $exec_ids = array_keys((array)$exec_ids);
       $exec_id_list = implode(",",$exec_ids);
       $exec_id_where= " WHERE execution_id IN ($exec_id_list)";
 
@@ -1259,7 +1259,7 @@ class testplan extends tlObjectWithAttachments
     $sql=" SELECT id AS link_id FROM {$this->tables['testplan_tcversions']} " .
        " WHERE testplan_id={$id} AND {$where_clause} ";
     $link_ids = $this->db->fetchRowsIntoMap($sql,'link_id');
-    $features = array_keys($link_ids);
+    $features = array_keys((array)$link_ids);
     if( count((array)$features) == 1) {
       $features=$features[0];
     }
@@ -1341,7 +1341,7 @@ class testplan extends tlObjectWithAttachments
       }
       
       
-      $tc_id_list = implode(",",array_keys($linked_items));
+      $tc_id_list = implode(",",array_keys((array)$linked_items));
       
       // 20081116 - franciscom -
       // Does DISTINCT is needed ? Humm now I think no.
@@ -2920,7 +2920,7 @@ class testplan extends tlObjectWithAttachments
             $linkedItems = $this->get_linked_tcvid($id,$platfID);  
             if( (!is_null($linkedItems)) )
             {
-              $tcVersionIDSet[$platfID]= array_keys($linkedItems);
+              $tcVersionIDSet[$platfID]= array_keys((array)$linkedItems);
             }
           }  
         }
@@ -3040,10 +3040,10 @@ class testplan extends tlObjectWithAttachments
 
       if( ($status_ok = !is_null($executed)) )
       {
-        $tc2loop = array_keys($executed);
+        $tc2loop = array_keys((array)$executed);
         foreach($tc2loop as $tcase_id)
         {
-          $p2loop = array_keys($executed[$tcase_id]);
+          $p2loop = array_keys((array)$executed[$tcase_id]);
           foreach($p2loop as $platf_id)
           {
             $targetSet[$platf_id][]=array('id' => $executed[$tcase_id][$platf_id]['exec_id'],
@@ -3140,10 +3140,10 @@ class testplan extends tlObjectWithAttachments
         $executed = $this->getLTCVNewGeneration($id,$filters,$options); 
         if( ($status_ok = !is_null($executed)) )
         {
-          $tc2loop = array_keys($executed);
+          $tc2loop = array_keys((array)$executed);
           foreach($tc2loop as $tcase_id)
           {
-            $p2loop = array_keys($executed[$tcase_id]);
+            $p2loop = array_keys((array)$executed[$tcase_id]);
             foreach($p2loop as $platf_id)
             {
               $targetSet[$platf_id][]=$executed[$tcase_id][$platf_id]['exec_id'];
@@ -3362,7 +3362,7 @@ class testplan extends tlObjectWithAttachments
       $sourceLinks = $this->platform_mgr->getLinkedToTestplanAsMap($source_id);
       if( !is_null($sourceLinks) )
       {
-        $sourceLinks = array_keys($sourceLinks);
+        $sourceLinks = array_keys((array)$sourceLinks);
         if( !is_null($mappings) )
         {
           foreach($sourceLinks as $key => $value)
@@ -3618,7 +3618,7 @@ class testplan extends tlObjectWithAttachments
         $sib = $this->getTestCaseSiblings($id,$tcversion_id,$platform_id,$my['opt']);
       break;
     }
-    $tcversionSet = array_keys($sib);
+    $tcversionSet = array_keys((array)$sib);
     $elemQty = count((array)$tcversionSet);
     $dummy = array_flip($tcversionSet);
 
@@ -3723,7 +3723,7 @@ class testplan extends tlObjectWithAttachments
     $loop2do = count((array)$mm);
     if( $loop2do > 0 )
     { 
-      $items2loop = array_keys($mm);
+      $items2loop = array_keys((array)$mm);
       foreach($items2loop as $itemkey)
       {
         $mm[$itemkey] = array('platform_name' => $mm[$itemkey], 'id' => $itemkey);
@@ -5007,11 +5007,11 @@ class testplan extends tlObjectWithAttachments
     $hitsFoundOn['otherStatus'] = count((array)$hits['otherStatus']) > 0;
 
     if($hitsFoundOn['notRun'] && $hitsFoundOn['otherStatus']) {
-      $items = array_merge(array_keys($hits['notRun']), array_keys($hits['otherStatus']));
+      $items = array_merge(array_keys((array)$hits['notRun']), array_keys((array)$hits['otherStatus']));
     } else if($hitsFoundOn['notRun']) {
-      $items = array_keys($hits['notRun']);
+      $items = array_keys((array)$hits['notRun']);
     } else if($hitsFoundOn['otherStatus']) {
-      $items = array_keys($hits['otherStatus']);
+      $items = array_keys((array)$hits['otherStatus']);
     }
 
         
@@ -5055,7 +5055,7 @@ class testplan extends tlObjectWithAttachments
         " AND E.status IS NULL ";
 
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
-    return is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
+    return is_null($recordset) ? $recordset : array_flip(array_keys((array)$recordset));
   }
 
 
@@ -5092,7 +5092,7 @@ class testplan extends tlObjectWithAttachments
         " AND E.status IS NULL ";
 
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
-    return is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
+    return is_null($recordset) ? $recordset : array_flip(array_keys((array)$recordset));
   }
 
 
@@ -5156,7 +5156,7 @@ class testplan extends tlObjectWithAttachments
         " AND E.status IN('{$statusInClause}')";
         
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
-    $hits = is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
+    $hits = is_null($recordset) ? $recordset : array_flip(array_keys((array)$recordset));
     
     $items = (array)$hits + (array)$notRunHits; 
     return count((array)$items) > 0 ? $items : null;
@@ -5221,7 +5221,7 @@ class testplan extends tlObjectWithAttachments
         " AND E.status IN('{$statusInClause}')";
     
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
-    $hits = is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
+    $hits = is_null($recordset) ? $recordset : array_flip(array_keys((array)$recordset));
     
     $items = (array)$hits + (array)$notRunHits; 
     return count((array)$items) > 0 ? $items : null;
@@ -5297,7 +5297,7 @@ class testplan extends tlObjectWithAttachments
 
     unset($safe_id,$buildsCfg,$sqlLEX);
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
-    return is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
+    return is_null($recordset) ? $recordset : array_flip(array_keys((array)$recordset));
   }
 
 
@@ -5375,7 +5375,7 @@ class testplan extends tlObjectWithAttachments
 
     unset($safe_id,$buildsCfg,$sqlLEBP);
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
-    return is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
+    return is_null($recordset) ? $recordset : array_flip(array_keys((array)$recordset));
   }
 
 
@@ -5453,16 +5453,16 @@ class testplan extends tlObjectWithAttachments
     {
       if( $hitsFoundOn['notRun'] && $hitsFoundOn['otherStatus'] )
       {
-        $items = array_keys($hits['notRun']) + array_keys($hits['otherStatus']);
+        $items = array_keys((array)$hits['notRun']) + array_keys((array)$hits['otherStatus']);
       }
     } 
     else if($get['notRun'] && $hitsFoundOn['notRun'])
     {
-      $items = array_keys($hits['notRun']);
+      $items = array_keys((array)$hits['notRun']);
     }
     else if($get['otherStatus'] && $hitsFoundOn['otherStatus'])
     {
-      $items = array_keys($hits['otherStatus']);
+      $items = array_keys((array)$hits['otherStatus']);
     }
     
     return is_null($items) ? $items : array_flip($items);
@@ -5671,8 +5671,8 @@ class testplan extends tlObjectWithAttachments
     if($hitsFoundOn['notRun'] && $hitsFoundOn['otherStatus'])
     {
             // THIS DOES NOT WORK with numeric keys  
-            // $items = array_merge(array_keys($hits['notRun']),array_keys($hits['otherStatus']));
-            //$items = array_keys($hits['notRun']) + array_keys($hits['otherStatus']);
+            // $items = array_merge(array_keys((array)$hits['notRun']),array_keys((array)$hits['otherStatus']));
+            //$items = array_keys((array)$hits['notRun']) + array_keys((array)$hits['otherStatus']);
 
             // 20120919 - asimon - TICKET 5226: Filtering by test result did not always show the correct matches
             // 
@@ -5692,15 +5692,15 @@ class testplan extends tlObjectWithAttachments
             // the first 5 testcases from $hits['otherStatus']) were not in the result set because of the + operator.
             // 
             // After using array_keys() we have numeric keys => we HAVE TO USE array_merge().
-            $items = array_merge(array_keys($hits['notRun']), array_keys($hits['otherStatus']));
+            $items = array_merge(array_keys((array)$hits['notRun']), array_keys((array)$hits['otherStatus']));
     } 
     else if($hitsFoundOn['notRun'])
     {
-      $items = array_keys($hits['notRun']);
+      $items = array_keys((array)$hits['notRun']);
     }
     else if($hitsFoundOn['otherStatus'])
     {
-      $items = array_keys($hits['otherStatus']);
+      $items = array_keys((array)$hits['otherStatus']);
     }
         
     return is_null($items) ? $items : array_flip($items);

--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -1878,7 +1878,7 @@ class testplan extends tlObjectWithAttachments
     $status = tl::ERROR;
     $sql = " /* $debugMsg */ DELETE FROM {$this->tables['user_testplan_roles']} " .
            " WHERE testplan_id = " . intval($id);
-    if(!is_null($users))
+    if(!is_null($users) && !empty($users))
     {
       $sql .= " AND user_id IN(" . implode(',',$users) . ")";
     } 

--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -173,11 +173,11 @@ class testplan extends tlObjectWithAttachments
         $pinfo = $this->tproject_mgr->get_by_id(intval($item->testProjectID));
       }
       
-      if( null == $pinfo || count($pinfo) == 0 ) {
+      if( null == $pinfo || count((array)$pinfo) == 0 ) {
         $pinfo = $this->tproject_mgr->get_by_prefix($item->testProjectID);            
       }
       
-      if( is_null($pinfo) || count($pinfo) == 0 ) {
+      if( is_null($pinfo) || count((array)$pinfo) == 0 ) {
         throw new Exception('Test project ID does not exist');      
       }  
 
@@ -529,7 +529,7 @@ class testplan extends tlObjectWithAttachments
     $debugMsg = 'Class:' . __CLASS__ . ' - Method: ' . __FUNCTION__;
 
     // protect yourself :) - 20140607
-    if( is_null($id) || (is_int($id) && intval($id) <= 0 ) || (is_array($id) && count($id) == 0) )
+    if( is_null($id) || (is_int($id) && intval($id) <= 0 ) || (is_array($id) && count((array)$id) == 0) )
     {
       return 0;  // >>>----> Bye
     } 
@@ -900,7 +900,7 @@ class testplan extends tlObjectWithAttachments
         array_shift($filter);
       }
       
-      if(count($filter)) {
+      if(count((array)$filter)) {
         $sql['filter'] = " AND TK.keyword_id IN (" . implode(',',$filter) . ")"; 
       }  
     }
@@ -1008,7 +1008,7 @@ class testplan extends tlObjectWithAttachments
       unset($filter[$this->notRunStatusCode]);  
     }
     
-    if(count($filter) > 0)
+    if(count((array)$filter) > 0)
     {
       $dummy = " E.status IN ('" . implode("','",$filter) . "') ";
       $execFilter = " ( {$dummy} {$lastExecSql} ) ";  
@@ -1195,7 +1195,7 @@ class testplan extends tlObjectWithAttachments
 
     $exec_ids = $this->db->fetchRowsIntoMap($sql,'execution_id');
     
-    if( !is_null($exec_ids) and count($exec_ids) > 0 ) {
+    if( !is_null($exec_ids) and count((array)$exec_ids) > 0 ) {
       // has executions
       $exec_ids = array_keys($exec_ids);
       $exec_id_list = implode(",",$exec_ids);
@@ -1260,7 +1260,7 @@ class testplan extends tlObjectWithAttachments
        " WHERE testplan_id={$id} AND {$where_clause} ";
     $link_ids = $this->db->fetchRowsIntoMap($sql,'link_id');
     $features = array_keys($link_ids);
-    if( count($features) == 1) {
+    if( count((array)$features) == 1) {
       $features=$features[0];
     }
     $this->assignment_mgr->delete_by_feature_id($features);
@@ -2179,7 +2179,7 @@ class testplan extends tlObjectWithAttachments
         
       $recordset = (array)$this->db->get_recordset($sql);
       $myarray = array();
-      if (count($recordset) > 0) {        
+      if (count((array)$recordset) > 0) {        
         $myarray = array($recordset[0]);
         $myarray = array_merge($myarray, $this->get_parenttestsuites($recordset[0]['parent_id'])); 
       }
@@ -2476,7 +2476,7 @@ class testplan extends tlObjectWithAttachments
       // Need to get testplan parent (testproject id) in order to get custom fields
       // 20081122 - franciscom - need to check when we can call this with ID=NULL
       $the_path = $this->tree_manager->get_path(!is_null($id) ? $id : $parent_id);
-      $path_len = count($the_path);
+      $path_len = count((array)$the_path);
     }
     $tproject_id = ($path_len > 0)? $the_path[$path_len-1]['parent_id'] : $parent_id; 
     
@@ -2508,7 +2508,7 @@ class testplan extends tlObjectWithAttachments
       // Need to get testplan parent (testproject id) in order to get custom fields
       // 20081122 - franciscom - need to check when we can call this with ID=NULL
       $the_path = $this->tree_manager->get_path(!is_null($id) ? $id : $parent_id);
-      $path_len = count($the_path);
+      $path_len = count((array)$the_path);
     }
     $tproject_id = ($path_len > 0)? $the_path[$path_len-1]['parent_id'] : $parent_id; 
     
@@ -2731,7 +2731,7 @@ class testplan extends tlObjectWithAttachments
         $doFilter = true;
       }  
     }
-    $cf_qty = count($cf_hash) - $ignored;                                      
+    $cf_qty = count((array)$cf_hash) - $ignored;                                      
     $doIt = !$doFilter;
     foreach ($tp_tcs as $tc_id => $tc_value)
     {
@@ -2749,7 +2749,7 @@ class testplan extends tlObjectWithAttachments
         // TO CHECK - 20140126 - Give a look to treeMenu.inc.php - filter_by_cf_values()  
         // to understand if both logics are coerent.
         //
-        $doIt = (count($rows) == $cf_qty);
+        $doIt = (count((array)$rows) == $cf_qty);
       }  
       if( $doIt ) 
       {
@@ -2858,7 +2858,7 @@ class testplan extends tlObjectWithAttachments
     foreach($tcVersionIDSet as $platfID => $items)
     {  
       $estimated['platform'][$platfID]['minutes'] = 0;
-      $estimated['platform'][$platfID]['tcase_qty'] = count($items);
+      $estimated['platform'][$platfID]['tcase_qty'] = count((array)$items);
       foreach($items as $dx)
       {
         if(!is_null($dx['estimated_exec_duration']))
@@ -2961,7 +2961,7 @@ class testplan extends tlObjectWithAttachments
         $sql2exec = $sql . " AND node_id IN (" . implode(',',$items) . ")";
         $dummy = $this->db->fetchOneValue($sql2exec);
         $estimated['platform'][$platfID]['minutes'] = is_null($dummy) ? 0 : $dummy;
-        $estimated['platform'][$platfID]['tcase_qty'] = count($items);
+        $estimated['platform'][$platfID]['tcase_qty'] = count((array)$items);
         
         $estimated['totalMinutes'] += $estimated['platform'][$platfID]['minutes'];
         $estimated['totalTestCases'] += $estimated['platform'][$platfID]['tcase_qty'];
@@ -3071,7 +3071,7 @@ class testplan extends tlObjectWithAttachments
     foreach($targetSet as $platfID => $itemSet)
     {  
       $total_time['platform'][$platfID]['minutes'] = 0;
-      $total_time['platform'][$platfID]['tcase_qty'] = count($itemSet);
+      $total_time['platform'][$platfID]['tcase_qty'] = count((array)$itemSet);
       foreach($itemSet as $dx)
       {
         if(!is_null($dx['duration']))
@@ -3181,7 +3181,7 @@ class testplan extends tlObjectWithAttachments
 
         $dummy = $this->db->fetchOneValue($sql2exec);
         $total_time['platform'][$platfID]['minutes'] = is_null($dummy) ? 0 : $dummy;
-        $total_time['platform'][$platfID]['tcase_qty'] = count($items);
+        $total_time['platform'][$platfID]['tcase_qty'] = count((array)$items);
 
         $total_time['totalMinutes'] += $total_time['platform'][$platfID]['minutes'];
         $total_time['totalTestCases'] += $total_time['platform'][$platfID]['tcase_qty'];
@@ -3245,7 +3245,7 @@ class testplan extends tlObjectWithAttachments
     $debugMsg = 'Class:' . __CLASS__ . ' - Method: ' . __FUNCTION__;
 
     $node_types = $this->tree_manager->get_available_node_types();
-    $num_exec = count($buildSet);
+    $num_exec = count((array)$buildSet);
     $build_in = implode(",", $buildSet);
     $status_in = implode("',", (array)$status);
     
@@ -3285,7 +3285,7 @@ class testplan extends tlObjectWithAttachments
     
     $recordset = $this->db->fetchRowsIntoMap($sql,'tcase_id');
     
-    if (count($first_results)) {
+    if (count((array)$first_results)) {
       foreach ($first_results as $key => $value) {
         $recordset[$key] = $value;
       }
@@ -3619,7 +3619,7 @@ class testplan extends tlObjectWithAttachments
       break;
     }
     $tcversionSet = array_keys($sib);
-    $elemQty = count($tcversionSet);
+    $elemQty = count((array)$tcversionSet);
     $dummy = array_flip($tcversionSet);
 
     $pos = $dummy[$tcversion_id];  
@@ -3720,7 +3720,7 @@ class testplan extends tlObjectWithAttachments
     $xml_mapping = array("||PLATFORMNAME||" => "platform_name", "||PLATFORMID||" => 'id');
 
     $mm = (array)$this->platform_mgr->getLinkedToTestplanAsMap($id);
-    $loop2do = count($mm);
+    $loop2do = count((array)$mm);
     if( $loop2do > 0 )
     { 
       $items2loop = array_keys($mm);
@@ -3913,7 +3913,7 @@ class testplan extends tlObjectWithAttachments
     // -----------------------------------------------------------------------------------------------------
     // get test plan contents (test suites and test cases)
     $item_info['testsuites'] = null;
-    if( !is_null($tplan_spec) && isset($tplan_spec['childNodes']) && ($loop2do = count($tplan_spec['childNodes'])) > 0)
+    if( !is_null($tplan_spec) && isset($tplan_spec['childNodes']) && ($loop2do = count((array)$tplan_spec['childNodes'])) > 0)
     {
       $item_info['testsuites'] = '<testsuites>' . 
                                  $this->exportTestSuiteDataToXML($tplan_spec,$context['tproject_id'],$id,
@@ -3970,7 +3970,7 @@ class testplan extends tlObjectWithAttachments
       }  
 
       $cfMap = (array)$tsuiteMgr->get_linked_cfields_at_design($container['id'],null,null,$tproject_id);
-      if( count($cfMap) > 0 )
+      if( count((array)$cfMap) > 0 )
       {
         $cfXML = $this->cfield_mgr->exportValueAsXML($cfMap);
       } 
@@ -3984,7 +3984,7 @@ class testplan extends tlObjectWithAttachments
     $childNodes = isset($container['childNodes']) ? $container['childNodes'] : null ;
     if( !is_null($childNodes) )
     {
-      $loop_qty=sizeof($childNodes); 
+      $loop_qty=sizeof((array)$childNodes); 
       for($idx = 0;$idx < $loop_qty;$idx++)
       {
         $cNode = $childNodes[$idx];
@@ -4030,7 +4030,7 @@ class testplan extends tlObjectWithAttachments
           }
         }
       }
-      (count($userList) > 0) ? $tcaseExportOptions['ASSIGNED_USER'] = $userList : $tcaseExportOptions['ASSIGNED_USER'] = null;
+      (count((array)$userList) > 0) ? $tcaseExportOptions['ASSIGNED_USER'] = $userList : $tcaseExportOptions['ASSIGNED_USER'] = null;
       
       $xmlTC .= $tcaseMgr->exportTestCaseDataToXML($cNode['id'],$cNode['tcversion_id'],
                                                          $tproject_id,testcase::NOXMLHEADER,
@@ -4275,7 +4275,7 @@ class testplan extends tlObjectWithAttachments
     $sql .= " ORDER BY node_order,id";
     
     $rs = $this->db->fetchRowsIntoMap($sql,'id');
-    if( null == $rs || count($rs) == 0 ) {
+    if( null == $rs || count((array)$rs) == 0 ) {
       return $qnum;
     }
   
@@ -4643,7 +4643,7 @@ class testplan extends tlObjectWithAttachments
     // Maybe copy/paste-error on refactoring? 
     // Example: With 3 builds and filtering for FAILED or BLOCKED on ALL builds
     // we have to get 3 hits for each test case to be shown, not six hits.
-    // $countTarget = intval($buildsCfg['count']) * count($dummy);
+    // $countTarget = intval($buildsCfg['count']) * count((array)$dummy);
     $countTarget = intval($buildsCfg['count']);
 
     $groupBy = ' GROUP BY ' . ((DB_TYPE == 'mssql') ? 'parent_id ':'tcase_id');
@@ -4947,7 +4947,7 @@ class testplan extends tlObjectWithAttachments
       unset($statusSet[$flippedStatusSet[$this->notRunStatusCode]]);
     }
         
-    $get['otherStatus'] = count($statusSet) > 0;
+    $get['otherStatus'] = count((array)$statusSet) > 0;
     if($get['otherStatus']) {
       $statusSet = $this->sanitizeExecStatus($statusSet);
       $statusInClause = implode("','",$statusSet);
@@ -4960,7 +4960,7 @@ class testplan extends tlObjectWithAttachments
       // Maybe copy/paste-error on refactoring? 
       // Example: With 3 builds and filtering for FAILED or BLOCKED on ALL builds
       // we have to get 3 hits for each test case to be shown, not six hits.
-      // $countTarget = intval($buildsCfg['count']) * count($statusSet);
+      // $countTarget = intval($buildsCfg['count']) * count((array)$statusSet);
       $countTarget = intval($buildsCfg['count']);
             
       $otherStatusSQL = " /* $debugMsg */ " .
@@ -5003,8 +5003,8 @@ class testplan extends tlObjectWithAttachments
         
     // build results record set
     $hitsFoundOn = array();
-    $hitsFoundOn['notRun'] = count($hits['notRun']) > 0;
-    $hitsFoundOn['otherStatus'] = count($hits['otherStatus']) > 0;
+    $hitsFoundOn['notRun'] = count((array)$hits['notRun']) > 0;
+    $hitsFoundOn['otherStatus'] = count((array)$hits['otherStatus']) > 0;
 
     if($hitsFoundOn['notRun'] && $hitsFoundOn['otherStatus']) {
       $items = array_merge(array_keys($hits['notRun']), array_keys($hits['otherStatus']));
@@ -5159,7 +5159,7 @@ class testplan extends tlObjectWithAttachments
     $hits = is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
     
     $items = (array)$hits + (array)$notRunHits; 
-    return count($items) > 0 ? $items : null;
+    return count((array)$items) > 0 ? $items : null;
   }
 
 
@@ -5224,7 +5224,7 @@ class testplan extends tlObjectWithAttachments
     $hits = is_null($recordset) ? $recordset : array_flip(array_keys($recordset));
     
     $items = (array)$hits + (array)$notRunHits; 
-    return count($items) > 0 ? $items : null;
+    return count((array)$items) > 0 ? $items : null;
   }
 
 
@@ -5437,7 +5437,7 @@ class testplan extends tlObjectWithAttachments
       unset($statusSetLocal[$dummy[$this->notRunStatusCode]]);
     }
     
-    if( ($get['otherStatus']=(count($statusSetLocal) > 0)) )
+    if( ($get['otherStatus']=(count((array)$statusSetLocal) > 0)) )
     {
       tLog(__METHOD__ . ":: \$tplan_mgr->$getHitsStatusSetMethod", 'DEBUG');
       $hits['otherStatus'] = (array)$this->$getHitsStatusSetMethod($id,$statusSetLocal,$buildSet);  
@@ -5445,8 +5445,8 @@ class testplan extends tlObjectWithAttachments
 
     // build results recordset
     $hitsFoundOn = array();
-    $hitsFoundOn['notRun'] = count($hits['notRun']) > 0;
-    $hitsFoundOn['otherStatus'] = count($hits['otherStatus']) > 0;
+    $hitsFoundOn['notRun'] = count((array)$hits['notRun']) > 0;
+    $hitsFoundOn['otherStatus'] = count((array)$hits['otherStatus']) > 0;
     
     
     if($get['notRun'] && $get['otherStatus'])
@@ -5650,15 +5650,15 @@ class testplan extends tlObjectWithAttachments
       $hits['notRun'] = (array)$this->$getHitsNotRunMethod($id,$platformID,$buildSet);  
       unset($statusSetLocal[$dummy[$this->notRunStatusCode]]);
     }
-    if( ($get['otherStatus']=(count($statusSetLocal) > 0)) )
+    if( ($get['otherStatus']=(count((array)$statusSetLocal) > 0)) )
     {
       $hits['otherStatus'] = (array)$this->$getHitsStatusSetMethod($id,$platformID,$statusSetLocal,$buildSet);  
     }
 
     // build results recordset
     $hitsFoundOn = array();
-    $hitsFoundOn['notRun'] = count($hits['notRun']) > 0;
-    $hitsFoundOn['otherStatus'] = count($hits['otherStatus']) > 0;
+    $hitsFoundOn['notRun'] = count((array)$hits['notRun']) > 0;
+    $hitsFoundOn['otherStatus'] = count((array)$hits['otherStatus']) > 0;
 
         //20120919 - asimon - TICKET 5226: Filtering by test result did not always show the correct matches
         //if($get['notRun'] && $get['otherStatus'])
@@ -5730,7 +5730,7 @@ class testplan extends tlObjectWithAttachments
         $buildSet = array_keys($this->get_builds($id, self::ACTIVE_BUILDS));
         $buildsCfg['statusClause'] = " AND B.active = 1 ";
       }
-      $buildsCfg['count'] = count($buildSet);
+      $buildsCfg['count'] = count((array)$buildSet);
       $buildsCfg['inClause'] = implode(",",$buildSet);
     } else {
       $buildsCfg['inClause'] = intval($my['options']['buildID']);
@@ -6428,7 +6428,7 @@ class testplan extends tlObjectWithAttachments
           {
             case 'multiselection list':
               // 
-              if( count($cf_value) > 1)
+              if( count((array)$cf_value) > 1)
               {
                 $combo = implode('|',$cf_value);
                 $cf_sql .= "( CFTPD.value = '{$combo}' AND CFTPD.field_id = {$cf_id} )";
@@ -7327,12 +7327,12 @@ class testplan extends tlObjectWithAttachments
     $mm = $this->getLinkedStaticView($id,$my['filters'],array('output' => 'array','detail' => '4results'));
     
 
-    if(!is_null($mm) && ($tcaseQty=count($mm)) > 0)
+    if(!is_null($mm) && ($tcaseQty=count((array)$mm)) > 0)
     {
 
       // Custom fields processing
       $xcf = $this->cfield_mgr->get_linked_cfields_at_execution($item['tproject_id'],1,'testcase');
-      if(!is_null($xcf) && ($cfQty=count($xcf)) > 0)
+      if(!is_null($xcf) && ($cfQty=count((array)$xcf)) > 0)
       {
         for($gdx=0; $gdx < $tcaseQty; $gdx++)
         {
@@ -7355,7 +7355,7 @@ class testplan extends tlObjectWithAttachments
         $mm[$gdx]['steps'] = $this->tcase_mgr->getStepsSimple($mm[$gdx]['tcversion_id'],0,$gso);
         if(!is_null($mm[$gdx]['steps']))
         {
-          $qs = count($mm[$gdx]['steps']);
+          $qs = count((array)$mm[$gdx]['steps']);
           for($scx=0; $scx < $qs; $scx++)
           {
             $mm[$gdx]['steps'][$scx]['notes'] = 'your step exec notes';

--- a/lib/functions/testplan.class.php
+++ b/lib/functions/testplan.class.php
@@ -2814,7 +2814,7 @@ class testplan extends tlObjectWithAttachments
 
     $tcVersionIDSet = array();
     $getOpt = array('outputFormat' => 'mapAccessByID' , 'addIfNull' => true);
-    $platformSet = array_keys($this->getPlatforms($id,$getOpt));
+    $platformSet = array_keys((array)$this->getPlatforms($id,$getOpt));
 
     if( is_null($itemSet) )
     {
@@ -2893,7 +2893,7 @@ class testplan extends tlObjectWithAttachments
     {
       $tcVersionIDSet = array();
       $getOpt = array('outputFormat' => 'mapAccessByID' , 'addIfNull' => true);
-      $platformSet = array_keys($this->getPlatforms($id,$getOpt));
+      $platformSet = array_keys((array)$this->getPlatforms($id,$getOpt));
       
       $sql = " /* $debugMsg */ ";
       if( DB_TYPE == 'mysql')
@@ -3017,7 +3017,7 @@ class testplan extends tlObjectWithAttachments
     $targetSet = array();
 
     $getOpt = array('outputFormat' => 'mapAccessByID' , 'addIfNull' => true);
-    $platformSet = array_keys($this->getPlatforms($context->tplan_id,$getOpt));
+    $platformSet = array_keys((array)$this->getPlatforms($context->tplan_id,$getOpt));
 
     if( is_null($execIDSet) )
     {
@@ -3107,7 +3107,7 @@ class testplan extends tlObjectWithAttachments
     if( $status_ok)
     {
       $getOpt = array('outputFormat' => 'mapAccessByID' , 'addIfNull' => true);
-      $platformSet = array_keys($this->getPlatforms($id,$getOpt));
+      $platformSet = array_keys((array)$this->getPlatforms($id,$getOpt));
 
       // ----------------------------------------------------------------------------
       $sql="SELECT SUM(CAST(value AS NUMERIC)) ";
@@ -5727,7 +5727,7 @@ class testplan extends tlObjectWithAttachments
 
     if($my['options']['buildID'] <= 0) {
       if( is_null($buildSet) ) {
-        $buildSet = array_keys($this->get_builds($id, self::ACTIVE_BUILDS));
+        $buildSet = array_keys((array)$this->get_builds($id, self::ACTIVE_BUILDS));
         $buildsCfg['statusClause'] = " AND B.active = 1 ";
       }
       $buildsCfg['count'] = count((array)$buildSet);
@@ -5991,7 +5991,7 @@ class testplan extends tlObjectWithAttachments
       {
         $activeStatus = intval($domain[$options['build_active_status']]);
       }
-      $dummy = array_keys($this->get_builds($safe_id,$activeStatus));
+      $dummy = array_keys((array)$this->get_builds($safe_id,$activeStatus));
     }
     
     return implode(",",$dummy);

--- a/lib/functions/testproject.class.php
+++ b/lib/functions/testproject.class.php
@@ -299,7 +299,7 @@ public function setSessionProject($projectId)
  * @param array $recorset produced by getTestProject() 
  */
 protected function parseTestProjectRecordset(&$recordset) {
-  if (null != $recordset && count($recordset) > 0) {
+  if (null != $recordset && count((array)$recordset) > 0) {
     foreach ($recordset as $number => $row) {
       $recordset[$number]['opt'] = unserialize($row['options']);
     }
@@ -488,7 +488,7 @@ function get_all($filters=null,$options=null)
     $this->parseTestProjectRecordset($recordset);
   } else {
     $recordset = $this->db->fetchRowsIntoMap($sql,$my['options']['access_key']);
-    if (null != $recordset && count($recordset) > 0) {
+    if (null != $recordset && count((array)$recordset) > 0) {
       foreach ($recordset as $number => $row) {
         $recordset[$number]['opt'] = unserialize($row['options']);
       }
@@ -684,7 +684,7 @@ function get_accessible_for_user($user_id,$opt = null,$filters = null) {
     case 'map_with_inactive_mark':
     default:
       $arrTemp = (array)$this->db->fetchRowsIntoMap($sql,'id');
-      $do_post_process = (count($arrTemp) > 0);
+      $do_post_process = (count((array)$arrTemp) > 0);
     break;
   }
     
@@ -834,7 +834,7 @@ function count_testcases($id)
 {
   $tcIDs = array();
   $this->get_all_testcases_id($id,$tcIDs);
-  $qty = sizeof($tcIDs);
+  $qty = sizeof((array)$tcIDs);
   return $qty;
 }
 
@@ -899,7 +899,7 @@ function count_testcases($id)
                     array('recursive' => !self::RECURSIVE_MODE,
                           'exclude_testcases' => self::EXCLUDE_TESTCASES));
 
-    if(count($test_spec))
+    if(count((array)$test_spec))
     {
       $ret = $this->_createHierarchyMap($test_spec,$mode);
     }
@@ -1264,7 +1264,7 @@ function setPublicStatus($id,$status)
     $opt = array('checkBeforeDelete' => false,
                  'context' => $tproject_name);
 
-    $loop2do = sizeof($kwIDs);
+    $loop2do = sizeof((array)$kwIDs);
     for($idx = 0;$idx < $loop2do; $idx++) {
       $opt['nameForAudit'] = $itemSet[$kwIDs[$idx]]['keyword'];
 
@@ -1332,7 +1332,7 @@ function setPublicStatus($id,$status)
       $xmlCode .= TL_XMLEXPORT_HEADER."\n";
     }
     $xmlCode .= "<keywords>";
-    for($idx = 0;$idx < sizeof($kwIDs);$idx++)
+    for($idx = 0;$idx < sizeof((array)$kwIDs);$idx++)
     {
       $keyword = new tlKeyword($kwIDs[$idx]);
       $keyword->readFromDb($this->db);
@@ -1351,7 +1351,7 @@ function setPublicStatus($id,$status)
   function exportKeywordsToCSV($testproject_id,$delim = ';') {
     $kwIDs = $this->getKeywordIDsFor($testproject_id);
     $csv = null;
-    for($idx = 0;$idx < sizeof($kwIDs);$idx++) {
+    for($idx = 0;$idx < sizeof((array)$kwIDs);$idx++) {
       $keyword = new tlKeyword($kwIDs[$idx]);
       $keyword->readFromDb($this->db);
       $keyword->writeToCSV($csv,$delim);
@@ -1540,7 +1540,7 @@ function setPublicStatus($id,$status)
     
     $my['options'] = array('order_cfg' => array('type' => 'rspec'), 'output' => 'rspec');
       $subtree = $this->tree_manager->get_subtree($id,$my['filters'],$my['options']);
-      if(count($subtree))
+      if(count((array)$subtree))
     {
       $ret = $this->_createHierarchyMap($subtree,$mode,$dot,'doc_id');
         }
@@ -1982,14 +1982,14 @@ function setPublicStatus($id,$status)
     $this->deleteAttachments($id);
     
     $reqSpecSet=$reqspec_mgr->get_all_id_in_testproject($id);
-    if( !is_null($reqSpecSet) && count($reqSpecSet) > 0 ) {
+    if( !is_null($reqSpecSet) && count((array)$reqSpecSet) > 0 ) {
       foreach($reqSpecSet as $reqSpec) {
         $reqspec_mgr->delete_deep($reqSpec['id']);
       }      
     }
     
     $tplanSet = $this->get_all_testplans($id);
-    if( !is_null($tplanSet) && count($tplanSet) > 0 ) {
+    if( !is_null($tplanSet) && count((array)$tplanSet) > 0 ) {
       $tplan_mgr = new testplan($this->db);
       $items=array_keys($tplanSet);     
       foreach($items as $key) {
@@ -2168,7 +2168,7 @@ function setPublicStatus($id,$status)
           $suiteIDs[] = $row['id'];
         }
       }
-      if (sizeof($suiteIDs))
+      if (sizeof((array)$suiteIDs))
       {
         $suiteIDs  = implode(",",$suiteIDs);
         $this->get_all_testcases_id($suiteIDs,$tcIDs,$options);
@@ -2223,7 +2223,7 @@ function DEPRECATED_get_keywords_tcases($testproject_id, $keyword_id=0, $keyword
                             AND testproject_id = {$testproject_id}
                             {$keyword_filter}
                             GROUP BY testcase_id ) AS FOXDOG " .
-                        " WHERE FOXDOG.HITS=" . count($keyword_id) . ")";
+                        " WHERE FOXDOG.HITS=" . count((array)$keyword_id) . ")";
                      
             $keyword_filter ='';
         }    
@@ -2277,7 +2277,7 @@ function getKeywordsLatestTCV($tproject_id, $keyword_id=0, $kwFilterType='Or') {
         $subquery = " AND tcversion_id IN (" .
                     " SELECT FOXDOG.tcversion_id FROM
                           ( $sqlCount ) AS FOXDOG " .
-                        " WHERE FOXDOG.HITS=" . count($keyword_id) . ")";
+                        " WHERE FOXDOG.HITS=" . count((array)$keyword_id) . ")";
         $kwFilter ='';
       }    
     }
@@ -2334,7 +2334,7 @@ function XXXgetPlatformsLatestTCV($tproject_id, $platform_id=0, $filterType='Or'
         $subquery = " AND tcversion_id IN (" .
                     " SELECT FOXDOG.tcversion_id FROM
                           ( $sqlCount ) AS FOXDOG " .
-                        " WHERE FOXDOG.HITS=" . count($platform_id) . ")";
+                        " WHERE FOXDOG.HITS=" . count((array)$platform_id) . ")";
         $platFilter ='';
       }    
     }
@@ -2497,7 +2497,7 @@ function get_first_level_test_suites($tproject_id,$mode='simple',$opt=null)
     break;
 
     case 'smarty_html_options':
-    if( !is_null($fl) && count($fl) > 0)
+    if( !is_null($fl) && count((array)$fl) > 0)
     {
       foreach($fl as $idx => $map)
       {
@@ -2568,7 +2568,7 @@ function getFreeTestCases($id,$options=null)
         $free=$retval['allfree'] ? $all : array_diff_key($all,$linked);
     }
     
-    if( !is_null($free) && count($free) > 0)
+    if( !is_null($free) && count((array)$free) > 0)
     {
         $in_clause=implode(',',array_keys($free));
          $sql = " /* $debugMsg */ " .
@@ -3195,7 +3195,7 @@ function _get_subtree_rec($node_id,&$pnode,$filters = null, $options = null) {
   
   // Approach Change - get all 
   $rs = (array)$this->db->fetchRowsIntoMap($sql,'id');
-  if( count($rs) == 0 ) {
+  if( count((array)$rs) == 0 ) {
     return $qnum;
   }
 
@@ -3284,7 +3284,7 @@ function _get_subtree_rec($node_id,&$pnode,$filters = null, $options = null) {
     $highlander = $this->db->fetchRowsIntoMap($ssx,'tc_id');
     if( $filterOnTC ) {
       $ky = !is_null($highlander) ? array_diff_key($tclist,$highlander) : $tclist;
-      if( count($ky) > 0 ) {
+      if( count((array)$ky) > 0 ) {
         foreach($ky as $tcase) {
           unset($rs[$tcase]);            
         }
@@ -3350,7 +3350,7 @@ function getTCLatestVersionFilteredByKeywords($tproject_id, $keyword_id=0, $keyw
   if( $getWithOutKeywords || $keyword_filter_type == 'NotLinked') {  
 
     $this->get_all_testcases_id($tproject_id,$tcaseSet);
-    if( ($hasTCases = count($tcaseSet) > 0) ) {
+    if( ($hasTCases = count((array)$tcaseSet) > 0) ) {
       $delTT = true;
       $tt = 'temp_tcset_' . $tproject_id . md5(microtime());
       $sql = "CREATE TEMPORARY TABLE IF NOT EXISTS $tt AS 
@@ -3411,7 +3411,7 @@ function getTCLatestVersionFilteredByKeywords($tproject_id, $keyword_id=0, $keyw
         $sql = "/* Filter Type = AND */
                 SELECT FOXDOG.testcase_id 
                 FROM ( $sqlCount ) AS FOXDOG 
-                WHERE FOXDOG.HITS=" . count($keyword_id);
+                WHERE FOXDOG.HITS=" . count((array)$keyword_id);
       break;
 
 
@@ -3624,7 +3624,7 @@ function getPublicAttr($id)
     // 
     $target = array();
     $this->get_all_testcases_id($id,$target);
-    $itemQty = count($target);
+    $itemQty = count((array)$target);
    
     $rs = null;
     if($itemQty > 0)
@@ -4130,7 +4130,7 @@ function getTCLatestVersionFilteredByPlatforms($tproject_id, $platform_id=0) {
   $getWithOutPlatforms = in_array(-1,$platSet); 
   if( $getWithOutPlatforms ) {  
     $this->get_all_testcases_id($tproject_id,$tcaseSet);
-    if( ($hasTCases = count($tcaseSet) > 0) ) {
+    if( ($hasTCases = count((array)$tcaseSet) > 0) ) {
       $delTT = true;
       $tt = 'temp_tcset_' . $tproject_id . md5(microtime());
       $sql = "CREATE TEMPORARY TABLE IF NOT EXISTS $tt AS 
@@ -4192,7 +4192,7 @@ function getTCLatestVersionFilteredByPlatforms($tproject_id, $platform_id=0) {
         $sql = "/* Filter Type = AND */
                 SELECT PLTFOXDOG.testcase_id 
                 FROM ( $sqlCount ) AS PLTFOXDOG 
-                WHERE PLTFOXDOG.HITS=" . count($platform_id);
+                WHERE PLTFOXDOG.HITS=" . count((array)$platform_id);
       break;
 
 

--- a/lib/functions/testproject.class.php
+++ b/lib/functions/testproject.class.php
@@ -1259,7 +1259,7 @@ function setPublicStatus($id,$status)
     $result = tl::OK;
 
     $itemSet = (array)$this->getKeywordSet($tproject_id);
-    $kwIDs = array_keys($itemSet);
+    $kwIDs = array_keys((array)$itemSet);
 
     $opt = array('checkBeforeDelete' => false,
                  'context' => $tproject_name);
@@ -1991,7 +1991,7 @@ function setPublicStatus($id,$status)
     $tplanSet = $this->get_all_testplans($id);
     if( !is_null($tplanSet) && count((array)$tplanSet) > 0 ) {
       $tplan_mgr = new testplan($this->db);
-      $items=array_keys($tplanSet);     
+      $items=array_keys((array)$tplanSet);     
       foreach($items as $key) {
         $tplan_mgr->delete($key);
       }
@@ -2570,7 +2570,7 @@ function getFreeTestCases($id,$options=null)
     
     if( !is_null($free) && count((array)$free) > 0)
     {
-        $in_clause=implode(',',array_keys($free));
+        $in_clause=implode(',',array_keys((array)$free));
          $sql = " /* $debugMsg */ " .
               " SELECT MAX(TCV.version) AS version, TCV.tc_external_id, " .
                 " TCV.importance AS importance, NHTCV.parent_id AS id, NHTC.name " .
@@ -2933,7 +2933,7 @@ private function copy_cfields_assignments($source_id, $target_id)
     $row_set = $this->db->fetchRowsIntoMap($sql,'field_id');   
   if( !is_null($row_set) )
   {
-    $cfield_set = array_keys($row_set);
+    $cfield_set = array_keys((array)$row_set);
     $this->cfield_mgr->link_to_testproject($target_id,$cfield_set);
   }
 }
@@ -2950,7 +2950,7 @@ private function copy_testplans($source_id,$target_id,$user_id,$mappings)
   $tplanSet = $this->get_all_testplans($source_id);
   if( !is_null($tplanSet) )
   {
-    $keySet = array_keys($tplanSet);
+    $keySet = array_keys((array)$tplanSet);
     if( is_null($tplanMgr) )
     {
       $tplanMgr = new testplan($this->db);
@@ -3201,7 +3201,7 @@ function _get_subtree_rec($node_id,&$pnode,$filters = null, $options = null) {
 
     // create list with test cases nodes
   $tclist = null;
-  $ks = array_keys($rs);
+  $ks = array_keys((array)$rs);
   foreach($ks as $ikey) {
     if( $rs[$ikey]['node_type_id'] == $this->tree_manager->node_descr_id['testcase'] ) {
       $tclist[$rs[$ikey]['id']] = $rs[$ikey]['id'];
@@ -3657,11 +3657,11 @@ function getPublicAttr($id)
       $rs = $this->db->fetchRowsIntoMap($sql,'tcase_id',database::CUMULATIVE);
       if( !is_null($rs) )
       {
-        $k2g = array_keys($rs);
+        $k2g = array_keys((array)$rs);
         $path_info = $this->tree_manager->get_full_path_verbose($k2g,array('output_format' => 'path_as_string'));
         foreach($k2g as $tgx)
         {
-          $rx = array_keys($rs[$tgx]);
+          $rx = array_keys((array)$rs[$tgx]);
           foreach($rx as $ex)
           {
             $rs[$tgx][$ex]['path'] = $path_info[$tgx];

--- a/lib/functions/testsuite.class.php
+++ b/lib/functions/testsuite.class.php
@@ -413,7 +413,7 @@ class testsuite extends tlObjectWithAttachments
     $rs = $this->db->fetchRowsIntoMap($sql,'id');
     if( !is_null($rs) )
     {
-      $rs = count($rs) == 1 ? current($rs) : $rs;
+      $rs = count((array)$rs) == 1 ? current($rs) : $rs;
     }
    
     // now inline image processing (if needed)
@@ -868,7 +868,7 @@ class testsuite extends tlObjectWithAttachments
           } 
         }
       }
-      $doit = count($testcases) > 0;
+      $doit = count((array)$testcases) > 0;
     }
     
     if($doit && $details=='full')
@@ -931,7 +931,7 @@ class testsuite extends tlObjectWithAttachments
           $testcases[]= $elem;
         } 
       }
-      $doit = count($testcases) > 0;
+      $doit = count((array)$testcases) > 0;
     }
       
     if($doit && $details=='full')
@@ -1102,7 +1102,7 @@ class testsuite extends tlObjectWithAttachments
     $debugMsg = 'Class:' . __CLASS__ . ' - Method: ' . __FUNCTION__;
     $status = 1;
     $kw = $this->getKeywords($id,$kw_id);
-    if( ($doLink = !sizeof($kw)) )
+    if( ($doLink = !sizeof((array)$kw)) )
     {
       $sql = "/* $debugMsg */ INSERT INTO {$this->tables['object_keywords']} " .
              " (fk_id,fk_table,keyword_id) VALUES ($id,'nodes_hierarchy',$kw_id)";
@@ -1122,7 +1122,7 @@ class testsuite extends tlObjectWithAttachments
   */
   function addKeywords($id,$kw_ids) {
     $status = 1;
-    $num_kws = sizeof($kw_ids);
+    $num_kws = sizeof((array)$kw_ids);
     for($idx = 0; $idx < $num_kws; $idx++) {
       $status = $status && $this->addKeyword($id,$kw_ids[$idx]);
     }
@@ -1185,7 +1185,7 @@ class testsuite extends tlObjectWithAttachments
         }
         if (isset($optExport['CFIELDS']) && $optExport['CFIELDS']) {
           $cfMap = (array)$this->get_linked_cfields_at_design($container_id,null,null,$tproject_id);
-          if( count($cfMap) > 0 ) {
+          if( count((array)$cfMap) > 0 ) {
             $cfXML = $this->cfield_mgr->exportValueAsXML($cfMap);
           } 
         }
@@ -1214,7 +1214,7 @@ class testsuite extends tlObjectWithAttachments
             }
           }
       
-          if( !is_null($attach) && count($attach) > 0 ) {
+          if( !is_null($attach) && count((array)$attach) > 0 ) {
             $attchRootElem = "<attachments>\n{{XMLCODE}}</attachments>\n";
             $attchElemTemplate = "\t<attachment>\n" .
                       "\t\t<id><![CDATA[||ATTACHMENT_ID||]]></id>\n" .
@@ -1255,7 +1255,7 @@ class testsuite extends tlObjectWithAttachments
     $tcase_mgr=null;
     $relXmlData = '';
     if( !is_null($childNodes) ) {
-      $loop_qty=sizeof($childNodes); 
+      $loop_qty=sizeof((array)$childNodes); 
       for($idx = 0;$idx < $loop_qty;$idx++) {
         $cNode = $childNodes[$idx];
         $nTable = $cNode['node_table'];
@@ -1351,7 +1351,7 @@ class testsuite extends tlObjectWithAttachments
     if (!$tproject_id)
     {
       $the_path=$this->tree_manager->get_path(!is_null($id) ? $id : $parent_id);
-      $path_len=count($the_path);
+      $path_len=count((array)$the_path);
       $tproject_id=($path_len > 0)? $the_path[$path_len-1]['parent_id'] : $parent_id;
     }
   
@@ -1533,7 +1533,7 @@ class testsuite extends tlObjectWithAttachments
       $my['options'] = array_merge($my['options'], (array)$options);
       
       $subtree = $this->tree_manager->get_children($id, array('testcase' => 'exclude_me'));
-      if(!is_null($subtree) && count($subtree) > 0)
+      if(!is_null($subtree) && count((array)$subtree) > 0)
       {
       foreach( $subtree as $the_key => $elem)
       {
@@ -1720,7 +1720,7 @@ class testsuite extends tlObjectWithAttachments
         $xx = explode($beginTag,$rse[$item_key]);
 
         // How many requests to replace ?
-        $xx2do = count($xx);
+        $xx2do = count((array)$xx);
         $ghost = '';
         for($xdx=0; $xdx < $xx2do; $xdx++)
         {
@@ -1731,7 +1731,7 @@ class testsuite extends tlObjectWithAttachments
             // Theorically can be just ONE, but it depends
             // is user had not messed things.
             $yy = explode($endTag,$xx[$xdx]);
-            if( ($elc = count($yy)) > 0)
+            if( ($elc = count((array)$yy)) > 0)
             {
               $atx = $yy[0];
               try
@@ -1839,7 +1839,7 @@ class testsuite extends tlObjectWithAttachments
       foreach ($subtree as $the_key => $elem) {
         $testcases[] = $elem['id'];
       }
-      $doit = count($testcases) > 0;
+      $doit = count((array)$testcases) > 0;
     }
     
     if( $doit ) {
@@ -2023,7 +2023,7 @@ class testsuite extends tlObjectWithAttachments
       // the new ones.
       foreach($kwForTS as $tsk => $kwVenn) {
         $kw2add = array_diff($kwSet,$kwVenn);
-        if( count($kw2add) > 0 ) {
+        if( count((array)$kw2add) > 0 ) {
           foreach($kw2add as $kaboom) {
             $vv[] = "($tsk,'nodes_hierarchy',$kaboom)";
           }
@@ -2031,7 +2031,7 @@ class testsuite extends tlObjectWithAttachments
       }      
     }
 
-    if( count($vv) > 0 ) {
+    if( count((array)$vv) > 0 ) {
       $sql = "/* $debugMsg */
               INSERT INTO {$this->tables['object_keywords']} 
               (fk_id,fk_table,keyword_id) 
@@ -2082,7 +2082,7 @@ class testsuite extends tlObjectWithAttachments
              AND KW.keyword = {$safeKW}";
     $rs = (array)$this->db->get_recordset($sql);
 
-    return (count($rs) == 1);
+    return (count((array)$rs) == 1);
   } 
 
 

--- a/lib/functions/testsuite.class.php
+++ b/lib/functions/testsuite.class.php
@@ -1487,7 +1487,7 @@ class testsuite extends tlObjectWithAttachments
     if( !is_null($sourceItems) )
     {
       // build item id list
-      $keySet = array_keys($sourceItems);
+      $keySet = array_keys((array)$sourceItems);
       foreach($keySet as $itemPos => $itemID)
       {
         if( isset($mappings[$itemID]) )

--- a/lib/functions/tlAttachmentRepository.class.php
+++ b/lib/functions/tlAttachmentRepository.class.php
@@ -166,7 +166,7 @@ class tlAttachmentRepository extends tlObjectWithDB
       $op->statusOK = $this->storeFileInFSRepository($fTmpName,$destFPath);
     } else {
       $fContents = $this->getFileContentsForDBRepository($fTmpName,$destFName);
-      $op->statusOK = sizeof($fContents);
+      $op->statusOK = sizeof((array)$fContents);
       if($op->statusOK) {
         @unlink($fTmpName); 
       } 
@@ -486,7 +486,7 @@ class tlAttachmentRepository extends tlObjectWithDB
     $statusOK = true;
     $attachmentIDs = (array)$this->getAttachmentIDsFor($fkid,$stdTableUsedAsFolder);
     
-    for($i = 0;$i < sizeof($attachmentIDs);$i++) {
+    for($i = 0;$i < sizeof((array)$attachmentIDs);$i++) {
       $id = $attachmentIDs[$i];
       $statusOK = ($this->deleteAttachment($id) && $statusOK);
     }
@@ -531,7 +531,7 @@ class tlAttachmentRepository extends tlObjectWithDB
     $stdTableUsedAsFolder = str_replace(DB_TABLE_PREFIX,'',$fkTableName);
 
     $idSet = (array)$this->getAttachmentIDsFor($fkid,$stdTableUsedAsFolder);
-    $loop2do = sizeof($idSet);
+    $loop2do = sizeof((array)$idSet);
     for($idx = 0;$idx < $loop2do; $idx++) {
       $attachmentInfo = $this->getAttachmentInfo($idSet[$idx]);
       if (null != $attachmentInfo) {
@@ -587,18 +587,18 @@ class tlAttachmentRepository extends tlObjectWithDB
     $stdTableUsedAsFolder = str_replace(DB_TABLE_PREFIX,'',$fkTableName);
 
     $attachments = $this->getAttachmentInfosFor($source_id,$stdTableUsedAsFolder);
-    if( null != $attachments && count($attachments) > 0) {
+    if( null != $attachments && count((array)$attachments) > 0) {
       foreach($attachments as $key => $value) {
         $file_contents = null;
         $f_parts = explode(DIRECTORY_SEPARATOR,$value['file_path']);
-        $mangled_fname = $f_parts[count($f_parts)-1];
+        $mangled_fname = $f_parts[count((array)$f_parts)-1];
         
         if ($this->repositoryType == TL_REPOSITORY_TYPE_FS) {
           $destFPath = $this->buildRepositoryFilePath($mangled_fname,$stdTableUsedAsFolder,$target_id);
           $status_ok = copy($this->repositoryPath . $value['file_path'],$destFPath);
         } else {
           $file_contents = $this->getAttachmentContentFromDB($value['id']);
-          $status_ok = sizeof($file_contents);
+          $status_ok = sizeof((array)$file_contents);
         }
         
         if($status_ok) {

--- a/lib/functions/tlFilterControl.class.php
+++ b/lib/functions/tlFilterControl.class.php
@@ -446,7 +446,7 @@ abstract class tlFilterControl extends tlObjectWithDB
 
       // show/hide CF
       $this->filters[$key] = array('items' => $cf_html_code,'btn_label' => $btn_label,'collapsed' => $collapsed);
-      $this->active_filters[$key] = count($selection) ? $selection : null;
+      $this->active_filters[$key] = count((array)$selection) ? $selection : null;
     }
   } // end of method
 

--- a/lib/functions/tlKeyword.class.php
+++ b/lib/functions/tlKeyword.class.php
@@ -484,7 +484,7 @@ class tlKeyword extends tlDBObject implements iSerialization,iSerializationToXML
     $this->name = isset($data[0]) ? $data[0] : null;
     $this->notes = isset($data[1]) ? $data[1] : null;
     
-    return sizeof($data) ? tl::OK : tl::ERROR;
+    return sizeof((array)$data) ? tl::OK : tl::ERROR;
   }
   //END interface iSerializationToCSV
 

--- a/lib/functions/tlPlatform.class.php
+++ b/lib/functions/tlPlatform.class.php
@@ -319,7 +319,7 @@ class tlPlatform extends tlObjectWithDB
                 GROUP BY PLAT.id ";
       $figures = $this->db->fetchRowsIntoMap($sql,'id');   
       
-      $loop2do = count($rs);
+      $loop2do = count((array)$rs);
       for ($idx=0; $idx < $loop2do; $idx++) {
         $rs[$idx]['linked_count'] = 
           $figures[$rs[$idx]['id']]['linked_count'];        

--- a/lib/functions/tlRole.class.php
+++ b/lib/functions/tlRole.class.php
@@ -221,7 +221,7 @@ class tlRole extends tlDBObject
     $this->description = trim($this->description);
     
     $result = tl::OK;
-    if (!sizeof($this->rights)) {
+    if (!sizeof((array)$this->rights)) {
       $result = self::E_EMPTYROLE;
     }
 
@@ -485,7 +485,7 @@ class tlRole extends tlDBObject
   protected function buildRightsArray($rightInfo)
   {
     $rights = null;
-    for($i = 0;$i < sizeof($rightInfo);$i++)
+    for($i = 0;$i < sizeof((array)$rightInfo);$i++)
     {
       $id = $rightInfo[$i];
       $right = new tlRight($id['right_id']);

--- a/lib/functions/tlTestCaseFilterByRequirementControl.class.php
+++ b/lib/functions/tlTestCaseFilterByRequirementControl.class.php
@@ -873,7 +873,7 @@ class tlTestCaseFilterByRequirementControl extends tlFilterControl {
       if(!$add_plan) 
       {
         $builds = $this->testplan_mgr->get_builds($plan['id'],testplan::GET_ACTIVE_BUILD,testplan::GET_OPEN_BUILD);
-        $add_plan =  (is_array($builds) && count($builds));
+        $add_plan =  (is_array($builds) && count((array)$builds));
       }
       
       if ($add_plan) 
@@ -1058,7 +1058,7 @@ class tlTestCaseFilterByRequirementControl extends tlFilterControl {
     $type_selection = $this->args->{$type};
     
     // are there any keywords?
-    if (!is_null($keywords) && count($keywords)) 
+    if (!is_null($keywords) && count((array)$keywords)) 
     {
       $this->filters[$key] = array();
 
@@ -1076,7 +1076,7 @@ class tlTestCaseFilterByRequirementControl extends tlFilterControl {
       // data for the keywords themselves     
       $this->filters[$key]['items'] = $special['domain'] + $keywords;
       $this->filters[$key]['selected'] = $selection;
-      $this->filters[$key]['size'] = min(count($this->filters[$key]['items']),
+      $this->filters[$key]['size'] = min(count((array)$this->filters[$key]['items']),
                                          self::ADVANCED_FILTER_ITEM_QUANTITY);
 
       // additional data for the filter type (logical and/or)
@@ -1166,7 +1166,7 @@ class tlTestCaseFilterByRequirementControl extends tlFilterControl {
                                             MEDIUM => lang_get('medium_importance'), 
                                             LOW => lang_get('low_importance'));
     
-      $this->filters[$key]['size'] = sizeof($this->filters[$key]['items']);
+      $this->filters[$key]['size'] = sizeof((array)$this->filters[$key]['items']);
       $this->active_filters[$key] = $selection;
     }
   }
@@ -1484,7 +1484,7 @@ class tlTestCaseFilterByRequirementControl extends tlFilterControl {
       {
         $selection = null;
       }  
-      else if( count($cfx) > 0)
+      else if( count((array)$cfx) > 0)
       {
         $selection = $cfx;
         $this->do_filtering = true;
@@ -1506,7 +1506,7 @@ class tlTestCaseFilterByRequirementControl extends tlFilterControl {
     $this->filters[$key]['items'] = array(0 => $this->option_strings['any']) +
                                           $this->tc_mgr->getWorkFlowStatusDomain();
 
-    $this->filters[$key]['size'] = min(count($this->filters[$key]['items']),
+    $this->filters[$key]['size'] = min(count((array)$this->filters[$key]['items']),
                                        self::ADVANCED_FILTER_ITEM_QUANTITY);
     
     $this->active_filters[$key] = $selection;

--- a/lib/functions/tlTestCaseFilterControl.class.php
+++ b/lib/functions/tlTestCaseFilterControl.class.php
@@ -2012,7 +2012,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     if(count((array)$cf) > 0)
     {
       $cfTypes = array_flip($this->cfield_mgr->get_available_types());
-      $key2loop = array_keys($cf);
+      $key2loop = array_keys((array)$cf);
       foreach($key2loop as $cfID)
       {
         // we will use these CF as filter => required property has to be

--- a/lib/functions/tlTestCaseFilterControl.class.php
+++ b/lib/functions/tlTestCaseFilterControl.class.php
@@ -1217,7 +1217,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
                                         $this->args->$key : $newest_build_id;
 
     // still no build selected? take first one from selection.
-    if (!$this->settings[$key]['selected'] && sizeof($this->settings[$key]['items'])) 
+    if (!$this->settings[$key]['selected'] && sizeof((array)$this->settings[$key]['items'])) 
     {
       $this->settings[$key]['selected'] = end($tplan_builds);
     }
@@ -1274,7 +1274,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
       if(!$add_plan) 
       {
         $builds = $this->testplan_mgr->get_builds($plan['id'],testplan::GET_ACTIVE_BUILD,testplan::GET_OPEN_BUILD);
-        $add_plan =  (is_array($builds) && count($builds));
+        $add_plan =  (is_array($builds) && count((array)$builds));
       }
       
       if ($add_plan) 
@@ -1309,7 +1309,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     }
     
     $platformSet = $this->platform_mgr->getLinkedToTestplanAsMap($testplan_id);
-    if( is_null($platformSet) || count($platformSet) == 0) {
+    if( is_null($platformSet) || count((array)$platformSet) == 0) {
       // Brute force bye, bye !! >>--->
       $this->settings[$key] = [
         'items' => null, 
@@ -1515,7 +1515,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     $type_selection = $this->args->{$type};
     
     // are there any keywords?
-    $atLeastOneKW = !is_null($keywords) && count($keywords);
+    $atLeastOneKW = !is_null($keywords) && count((array)$keywords);
     if ($atLeastOneKW) {
       $this->filters[$key] = array();
 
@@ -1530,7 +1530,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
       // data for the keywords themselves     
       $this->filters[$key]['items'] = $special['domain'] + $keywords;
       $this->filters[$key]['selected'] = $selection;
-      $this->filters[$key]['size'] = min(count($this->filters[$key]['items']),
+      $this->filters[$key]['size'] = min(count((array)$this->filters[$key]['items']),
                                          self::ADVANCED_FILTER_ITEM_QUANTITY);
 
       // additional data for the filter type (logical and/or)
@@ -1549,7 +1549,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
       // !!Regardless of filter mode!!
       //
       if (is_array($this->filters[$key]['selected']) && 
-          count($this->filters[$key]['selected']) > 1 &&  
+          count((array)$this->filters[$key]['selected']) > 1 &&  
           in_array(0, $this->filters[$key]['selected'])) {
         $this->active_filters[$key] = null;
       } else {
@@ -1626,7 +1626,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
                                             MEDIUM => lang_get('medium_importance'), 
                                             LOW => lang_get('low_importance'));
     
-      $this->filters[$key]['size'] = sizeof($this->filters[$key]['items']);
+      $this->filters[$key]['size'] = sizeof((array)$this->filters[$key]['items']);
       $this->active_filters[$key] = $selection;
     }
   }
@@ -1942,7 +1942,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     if (!$selection || $this->args->reset_filters)  {
       if( !is_null($this->args->caller) && !$selection) {
         $selection = null;
-      } else if( count($cfx) > 0) {
+      } else if( count((array)$cfx) > 0) {
         $selection = $cfx;
         $this->do_filtering = true;
       } else {
@@ -1959,7 +1959,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     $this->filters[$key]['items'] = array(0 => $this->option_strings['any']) +
                                           $this->tc_mgr->getWorkFlowStatusDomain();
 
-    $this->filters[$key]['size'] = min(count($this->filters[$key]['items']),
+    $this->filters[$key]['size'] = min(count((array)$this->filters[$key]['items']),
                                        self::ADVANCED_FILTER_ITEM_QUANTITY);
     
     $this->active_filters[$key] = $selection;
@@ -2009,7 +2009,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     // for CF types that present a domain like LIST, then if the blank option is
     // not present will be added as FIRST OPTION
 
-    if(count($cf) > 0)
+    if(count((array)$cf) > 0)
     {
       $cfTypes = array_flip($this->cfield_mgr->get_available_types());
       $key2loop = array_keys($cf);
@@ -2184,7 +2184,7 @@ class tlTestCaseFilterControl extends tlFilterControl {
     $platformSet = (array)$this->platform_mgr->getAllAsMap($opxy);
     $this->filters[$key] = array('items' => $platformSet,
                                  'selected' => $selection);
-    $this->filters[$key]['size'] = min(count($this->filters[$key]['items']),
+    $this->filters[$key]['size'] = min(count((array)$this->filters[$key]['items']),
                                        self::ADVANCED_FILTER_ITEM_QUANTITY);
                              
     // set the active value to filter

--- a/lib/functions/tlTestPlanMetrics.class.php
+++ b/lib/functions/tlTestPlanMetrics.class.php
@@ -912,7 +912,7 @@ class tlTestPlanMetrics extends testplan
     $totals = array();
     $priorityCfg = config_get('urgencyImportance');
     if( !is_null($rs) ) {
-      $loop2do = count($rs);
+      $loop2do = count((array)$rs);
       if( $my['opt']['groupByPlatform'] ) {
         // loop2do => platform Qty
         foreach( $rs as $platID => $elem ) {
@@ -1023,7 +1023,7 @@ class tlTestPlanMetrics extends testplan
     $safe_id = intval($id);  
     list($my,$builds,$sqlStm,$union,$platformSet) = $this->helperBuildSQLExecCounters($id, $filters, $opt);
 
-    if(is_null($builds) || count($builds) <= 0) {
+    if(is_null($builds) || count((array)$builds) <= 0) {
       return null;  // >>---> Bye!
     }  
 
@@ -1394,7 +1394,7 @@ class tlTestPlanMetrics extends testplan
         // only element contains Root node, is useless for this algorithm
         // 
         
-        if( count($staircase[$tsuite_id]) > 1) {
+        if( count((array)$staircase[$tsuite_id]) > 1) {
           // element at position 1 is a TOP LEVEL SUITE
           //$topSuiteID = &$staircase[$tsuite_id][1];
           $topSuiteID = $staircase[$tsuite_id][1];
@@ -1459,7 +1459,7 @@ class tlTestPlanMetrics extends testplan
         // only element contains Root node, is useless for this algorithm
         // 
         
-        if( count($staircase[$tsuite_id]) > 1) {
+        if( count((array)$staircase[$tsuite_id]) > 1) {
           // element at position 1 is a TOP LEVEL SUITE
           $topSuiteID = &$staircase[$tsuite_id][1];
           $initName = false;
@@ -1627,7 +1627,7 @@ class tlTestPlanMetrics extends testplan
   
     // Build item set
     $exec['tsuites_full'] = $this->get_testsuites($safe_id);
-    $loop2do = count($exec['tsuites_full']);
+    $loop2do = count((array)$exec['tsuites_full']);
     for($idx=0; $idx < $loop2do; $idx++) {
       $keySet[] = $exec['tsuites_full'][$idx]['id'];
 
@@ -2408,8 +2408,8 @@ class tlTestPlanMetrics extends testplan
 
         $dx = (array)$this->db->get_recordset($sql); 
 
-        $l2do = count($dx);
-        $loop2do = count($dummy);
+        $l2do = count((array)$dx);
+        $loop2do = count((array)$dummy);
         for($vdx=0; $vdx < $l2do; $vdx++)
         { 
           for($fdx=0; $fdx < $loop2do; $fdx++)
@@ -2789,7 +2789,7 @@ class tlTestPlanMetrics extends testplan
       $priorityCfg = config_get('urgencyImportance');
       $cache = array('tsuite' => null, 'tcase' => null);
 
-      $loop2do = count($rs);
+      $loop2do = count((array)$rs);
       $gnOpt = array('fields' => 'name');
 
       for($adx=0; $adx < $loop2do; $adx++)
@@ -3018,7 +3018,7 @@ class tlTestPlanMetrics extends testplan
     $buildSet = $this->get_builds($safeID,testplan::ACTIVE_BUILDS,
                                   testplan::OPEN_BUILDS);
 
-    $sql .= " HAVING COUNT(0) = " . count($buildSet);
+    $sql .= " HAVING COUNT(0) = " . count((array)$buildSet);
     $sql .= " ORDER BY platform_name,full_external_id ";
     
     return $this->db->get_recordset($sql);      
@@ -3156,7 +3156,7 @@ class tlTestPlanMetrics extends testplan
     $buildSet = $this->get_builds($safeID,testplan::ACTIVE_BUILDS,
                                   testplan::OPEN_BUILDS);
 
-    $sql .= " HAVING COUNT(0) = " . count($buildSet);
+    $sql .= " HAVING COUNT(0) = " . count((array)$buildSet);
     
     // echo $sql;
     return $this->db->get_recordset($sql);      
@@ -3232,7 +3232,7 @@ class tlTestPlanMetrics extends testplan
     $buildSet = $this->get_builds($safeID,testplan::ACTIVE_BUILDS,
                                   testplan::OPEN_BUILDS);
 
-    $sql .= " HAVING COUNT(0) = " . count($buildSet);
+    $sql .= " HAVING COUNT(0) = " . count((array)$buildSet);
     // $sql .= " ORDER BY platform_name,full_external_id ";
     
     // echo $sql;
@@ -3406,7 +3406,7 @@ class tlTestPlanMetrics extends testplan
            }
         */
 
-        $tsuiteDepth = count($staircase[$tsuite_id]);
+        $tsuiteDepth = count((array)$staircase[$tsuite_id]);
 
         $l2id = -1;
         if ($tsuiteDepth > 1) {
@@ -3636,7 +3636,7 @@ class tlTestPlanMetrics extends testplan
             WHERE testplan_id = $id 
             GROUP BY {$fieldList}";
    
-    $levels = count($context);
+    $levels = count((array)$context);
     switch ($levels) {
       case 1:
         $rs = $this->db->fetchRowsIntoMap($sql,'testplan_id');

--- a/lib/functions/tlTestPlanMetrics.class.php
+++ b/lib/functions/tlTestPlanMetrics.class.php
@@ -65,7 +65,7 @@ class tlTestPlanMetrics extends testplan
     }
     // $this->notRunStatusCode = $this->tc_status_for_statistics['not_run'];
       
-    $this->statusCode = array_flip(array_keys($this->resultsCfg['status_label_for_exec_ui']));
+    $this->statusCode = array_flip(array_keys((array)$this->resultsCfg['status_label_for_exec_ui']));
     foreach($this->statusCode as $key => $dummy)
     {
       $this->statusCode[$key] = $this->resultsCfg['status_code'][$key];  
@@ -373,9 +373,9 @@ class tlTestPlanMetrics extends testplan
       //   Hmm, think about Need to check is this way is better that request DBMS to do it.
       // - Execution status that have not happened
       foreach($exec as $dum => &$elem) {                            
-        $platSet = array_keys($elem);
+        $platSet = array_keys((array)$elem);
         foreach($platSet as $platId ) {
-          $itemSet = array_keys($elem[$platId]);
+          $itemSet = array_keys((array)$elem[$platId]);
           foreach($itemSet as $itemID) {
             foreach($this->statusCode as $verbose => $code) {
               if(!isset($elem[$platId][$itemID][$code])) {
@@ -394,7 +394,7 @@ class tlTestPlanMetrics extends testplan
       //   Hmm, think about Need to check is this way is better that request DBMS to do it.
       // - Execution status that have not happened
       foreach($exec as &$elem) {                             
-        $itemSet = array_keys($elem);
+        $itemSet = array_keys((array)$elem);
         foreach($itemSet as $itemID) {
           foreach($this->statusCode as $verbose => $code) {
             if(!isset($elem[$itemID][$code])) {
@@ -468,11 +468,11 @@ class tlTestPlanMetrics extends testplan
 
       // Creating item list this way will generate a row also for
       // ACTIVE BUILDS were ALL TEST CASES HAVE NO TESTER ASSIGNMENT
-      // $buildList = array_keys($metrics['active_builds']);
+      // $buildList = array_keys((array)$metrics['active_builds']);
       
       // Creating item list this way will generate a row ONLY FOR
       // ACTIVE BUILDS were TEST CASES HAVE TESTER ASSIGNMENT
-      $buildList = array_keys($metrics['with_tester']);
+      $buildList = array_keys((array)$metrics['with_tester']);
       $renderObj->info = array();  
       foreach($buildList as $buildID)
       {
@@ -1122,10 +1122,10 @@ class tlTestPlanMetrics extends testplan
     $totals = array();
     foreach($exec as &$topLevelElem)
     {                             
-      $topLevelItemSet = array_keys($topLevelElem);
+      $topLevelItemSet = array_keys((array)$topLevelElem);
       foreach($topLevelItemSet as $topLevelItemID)
       {
-        $itemSet = array_keys($topLevelElem[$topLevelItemID]);
+        $itemSet = array_keys((array)$topLevelElem[$topLevelItemID]);
         foreach($itemSet as $itemID)
         {
           $elem = &$topLevelElem[$topLevelItemID];
@@ -1174,14 +1174,14 @@ class tlTestPlanMetrics extends testplan
     if( !is_null($metrics) )
     {
       $renderObj = new stdClass();
-      $topItemSet = array_keys($metrics['with_tester']);
+      $topItemSet = array_keys((array)$metrics['with_tester']);
       $renderObj->info = array();  
       $out = &$renderObj->info;
 
       $topElem = &$metrics['with_tester'];
       foreach($topItemSet as $topItemID)
       {
-        $itemSet = array_keys($topElem[$topItemID]);
+        $itemSet = array_keys((array)$topElem[$topItemID]);
         foreach($itemSet as $itemID)
         {
           $elem = &$topElem[$topItemID][$itemID];
@@ -1259,7 +1259,7 @@ class tlTestPlanMetrics extends testplan
       $renderObj->info = array(); 
 
       if( $byPlatform == false ) { 
-        $itemList = array_keys($metrics[$setKey]);      
+        $itemList = array_keys((array)$metrics[$setKey]);      
         foreach($itemList as $itemID) {
           if( isset($metrics['with_tester'][$itemID]) ) {
             $totalRun = 0;
@@ -1290,10 +1290,10 @@ class tlTestPlanMetrics extends testplan
         }
       } else {
         // mainKey is Platform ID
-        $platList = array_keys($metrics['with_tester']); 
+        $platList = array_keys((array)$metrics['with_tester']); 
         $mex = &$metrics['with_tester']; 
         foreach($platList as $platID) {
-          $itemList = array_keys($mex[$platID]);
+          $itemList = array_keys((array)$mex[$platID]);
           foreach($itemList as $itemID) {
             if( isset($mex[$platID]) ) {
               $totalRun = 0;
@@ -1369,7 +1369,7 @@ class tlTestPlanMetrics extends testplan
 
     list($rx,$staircase) = $this->getStatusTotalsByItemForRender($id,'tsuite',$filters,$opt);
 
-    // ??? $key2loop = array_keys($rx->info);
+    // ??? $key2loop = array_keys((array)$rx->info);
     $template = array('type' => 'tsuite', 'name' => '','total_tc' => 0,
               'percentage_completed' => 0, 'details' => array());  
 
@@ -1384,11 +1384,11 @@ class tlTestPlanMetrics extends testplan
     $topNameCache = null;
     $execQty = null;
 
-    $key2loop = array_keys($staircase);
+    $key2loop = array_keys((array)$staircase);
     $wp = isset($opt['groupByPlatform']) && $opt['groupByPlatform'];
 
     if( $wp ) {
-      $plat2loop = array_keys($rx->info);
+      $plat2loop = array_keys((array)$rx->info);
       foreach($key2loop as $tsuite_id) {
         // (count() == 1) => is a TOP LEVEL SUITE, 
         // only element contains Root node, is useless for this algorithm
@@ -1683,7 +1683,7 @@ class tlTestPlanMetrics extends testplan
     // now is time do some decoding
     // Key is a tuple (PARENT tsuite_id, test case id, platform id)
     //
-    $item2loop = array_keys($dummy);
+    $item2loop = array_keys((array)$dummy);
     $stairway2heaven = null;
     $pathway = null;
     $latestExec = null;
@@ -1695,9 +1695,9 @@ class tlTestPlanMetrics extends testplan
       unset($stairway2heaven);
 
       // go inside test case
-      $tcase2loop = array_keys($dummy[$item_id]);
+      $tcase2loop = array_keys((array)$dummy[$item_id]);
       foreach($tcase2loop as $tcase_id) {
-        $platform2loop = array_keys($dummy[$item_id][$tcase_id]);
+        $platform2loop = array_keys((array)$dummy[$item_id][$tcase_id]);
         foreach($platform2loop as $platform_id) {
           $latestExec[$platform_id][$tcase_id] = 
             array('id' => -1, 'status' => $this->notRunStatusCode);
@@ -1778,7 +1778,7 @@ class tlTestPlanMetrics extends testplan
       $bi->infoSet = $this->get_builds($id,testplan::ACTIVE_BUILDS,
                                        $openStatus);
       if (!is_null($bi->infoSet)) {
-       $bi->idSet = array_keys($bi->infoSet);
+       $bi->idSet = array_keys((array)$bi->infoSet);
       }
     }
     
@@ -1894,7 +1894,7 @@ class tlTestPlanMetrics extends testplan
     
     // refence is critic  
     foreach($out as &$elem) {                             
-      $itemSet = array_keys($elem);
+      $itemSet = array_keys((array)$elem);
       foreach($itemSet as $itemID) {             
         $totalByItemID[$itemID]['qty'] = 0;
         foreach($this->statusCode as $verbose => $code) {
@@ -2851,10 +2851,10 @@ class tlTestPlanMetrics extends testplan
 
     foreach($out as &$elem) {   
 
-      $rowSet = array_keys($elem);
+      $rowSet = array_keys((array)$elem);
       foreach($rowSet as $rowID) {
 
-        $colSet = array_keys($elem[$rowID]);
+        $colSet = array_keys((array)$elem[$rowID]);
         foreach($colSet as $colID) {             
           $totalByMatrix[$rowID][$colID]['qty'] = 0;
           foreach($this->statusCode as $verbose => $code) {
@@ -2887,7 +2887,7 @@ class tlTestPlanMetrics extends testplan
 
     // Creating item list this way will generate a row also for
     // ACTIVE BUILDS were ALL TEST CASES HAVE NO TESTER ASSIGNMENT
-    // $buildList = array_keys($metrics['active_builds']);
+    // $buildList = array_keys((array)$metrics['active_builds']);
     
     // Creating item list this way will generate a row ONLY FOR
     // ACTIVE BUILDS were TEST CASES HAVE TESTER ASSIGNMENT
@@ -2895,7 +2895,7 @@ class tlTestPlanMetrics extends testplan
       $renObj = new stdClass();
       $renObj->info = array();  
 
-      $platList = array_keys($metrics['with_tester']);
+      $platList = array_keys((array)$metrics['with_tester']);
       $mwt = &$metrics['with_tester'];
       foreach( $mwt as $platID => $buildMetrics ) {
         foreach($buildMetrics as $buildID => $met ) {
@@ -2929,10 +2929,10 @@ class tlTestPlanMetrics extends testplan
       }
   
       // Last step: get completness percentages
-      $platList = array_keys($renObj->info); 
+      $platList = array_keys((array)$renObj->info); 
       $tk = 'total_assigned';
       foreach($platList as $platID) {
-        $itemList = array_keys($renObj->info[$platID]);
+        $itemList = array_keys((array)$renObj->info[$platID]);
         foreach($itemList as $itemID) {
           if( isset($renObj->info[$platID]) ) {
             $totalRun = 0;
@@ -3061,7 +3061,7 @@ class tlTestPlanMetrics extends testplan
     // now is time do some decoding
     // Key is a tuple (PARENT tsuite_id, test case id, platform id)
     //
-    $item2loop = array_keys($dummy);
+    $item2loop = array_keys((array)$dummy);
     $stairway2heaven = null;
     $pathway = null;
     $latestExec = null;
@@ -3073,9 +3073,9 @@ class tlTestPlanMetrics extends testplan
       unset($stairway2heaven);
 
       // go inside test case
-      $tcase2loop = array_keys($dummy[$item_id]);
+      $tcase2loop = array_keys((array)$dummy[$item_id]);
       foreach($tcase2loop as $tcase_id) {
-        $platform2loop = array_keys($dummy[$item_id][$tcase_id]);
+        $platform2loop = array_keys((array)$dummy[$item_id][$tcase_id]);
         foreach($platform2loop as $platform_id) {
           $rf = &$dummy[$item_id][$tcase_id][$platform_id][0];
           $rf['suiteName'] = $pathway[$item_id];
@@ -3355,7 +3355,7 @@ class tlTestPlanMetrics extends testplan
     list($rx,$staircase) = 
       $this->getStatusTotalsByItemForRender($id,'tsuite',$filters,$opt);
 
-    // ??? $key2loop = array_keys($rx->info);
+    // ??? $key2loop = array_keys((array)$rx->info);
     $template = array('type' => 'tsuite', 
                       'name' => '',
                       'parent_id' => 0,
@@ -3377,12 +3377,12 @@ class tlTestPlanMetrics extends testplan
     $execQty = null;
     $execQtyL2 = null;
 
-    $key2loop = array_keys($staircase);
+    $key2loop = array_keys((array)$staircase);
     $wp = isset($opt['groupByPlatform']) && $opt['groupByPlatform'];
 
     if( $wp ) {
       $tsNameCache = array();
-      $plat2loop = array_keys($rx->info);
+      $plat2loop = array_keys((array)$rx->info);
 
       // In order to get SUM() for each Top (Level 1) Test Suite
       // using the specific test suite we get the Level 1

--- a/lib/functions/tlUser.class.php
+++ b/lib/functions/tlUser.class.php
@@ -850,7 +850,7 @@ class tlUser extends tlDBObject {
         }
 
         // subtract global rights    
-        $testProjectRights = array_diff($testProjectRights,array_keys($g_propRights_global));
+        $testProjectRights = array_diff($testProjectRights,array_keys((array)$g_propRights_global));
         propagateRights($globalRights,$g_propRights_global,$testProjectRights);
         $allRights = $testProjectRights;
       } else {
@@ -871,7 +871,7 @@ class tlUser extends tlDBObject {
         }
         
         //subtract test projects rights    
-        $testPlanRights = array_diff($testPlanRights,array_keys($g_propRights_product));
+        $testPlanRights = array_diff($testPlanRights,array_keys((array)$g_propRights_product));
         
         propagateRights($allRights,$g_propRights_product,$testPlanRights);
         $allRights = $testPlanRights;

--- a/lib/functions/tlUser.class.php
+++ b/lib/functions/tlUser.class.php
@@ -336,7 +336,7 @@ class tlUser extends tlDBObject {
     }
     $allRoles = $db->fetchColumnsIntoMap($sql,'testproject_id','role_id');
     $this->tprojectRoles = null;
-    if (null != $allRoles && sizeof($allRoles)) {
+    if (null != $allRoles && sizeof((array)$allRoles)) {
       $roleCache = null;
       foreach($allRoles as $tprojectID => $roleID) {
         if (!isset($roleCache[$roleID])) {
@@ -373,7 +373,7 @@ class tlUser extends tlDBObject {
         
     $allRoles = $db->fetchColumnsIntoMap($sql,'testplan_id','role_id');
     $this->tplanRoles = null;
-    if (null != $allRoles  && sizeof($allRoles)) {
+    if (null != $allRoles  && sizeof((array)$allRoles)) {
       $roleCache = null;
       foreach($allRoles as $tplanID => $roleID) {
         if (!isset($roleCache[$roleID])) {
@@ -838,7 +838,7 @@ class tlUser extends tlDBObject {
 
       // Special situation => just one right
       $doMoreAnalysis = true;
-      if( count($userTestProjectRights) == 1) {
+      if( count((array)$userTestProjectRights) == 1) {
         $doMoreAnalysis = !is_null($userTestProjectRights[0]->dbID);
       }  
 
@@ -1037,7 +1037,7 @@ class tlUser extends tlDBObject {
     // Admin exception
     $doReindex = false;
     if( $this->globalRoleID != TL_ROLES_ADMIN && null != $testPlanSet 
-        && count($testPlanSet) > 0 ) {
+        && count((array)$testPlanSet) > 0 ) {
       foreach($testPlanSet as $idx => $item) {
         if( $item['is_public'] == 0 && $item['has_role'] == 0 ) {
           unset($testPlanSet[$idx]);
@@ -1136,7 +1136,7 @@ class tlUser extends tlDBObject {
       return null;
     }
 
-    for($idx = 0;$idx < sizeof($ids);$idx++) {
+    for($idx = 0;$idx < sizeof((array)$ids);$idx++) {
       $id = $ids[$idx];
       $user = tlDBObject::createObjectFromDB($db,$id,__CLASS__,self::TLOBJ_O_SEARCH_BY_ID,$detailLevel);
       if ($user) {  

--- a/lib/functions/tlsmarty.inc.php
+++ b/lib/functions/tlsmarty.inc.php
@@ -445,7 +445,7 @@ class TLSmarty extends Smarty {
                    'keyword_add' => $imgLoc . 'tag_blue_add.png');
 
     $imi = config_get('images');
-    if(count($imi) >0) {
+    if(count((array)$imi) >0) {
       foreach($imi as $key => $img) {
 
         // You need to configure in your custom config something like this

--- a/lib/functions/tree.class.php
+++ b/lib/functions/tree.class.php
@@ -669,7 +669,7 @@ class tree extends tlObject
       $node_type_filter='';
       if( !is_null($exclude_node_types) )
       {
-         $types=implode("','",array_keys($exclude_node_types));  
+         $types=implode("','",array_keys((array)$exclude_node_types));  
          $node_type_filter=" AND NT.description NOT IN ('{$types}') ";
       }
       
@@ -1224,7 +1224,7 @@ class tree extends tlObject
         $xitems = array_flip((array)$items);
         $xsql = " SELECT parent_id,id " . 
                 " FROM {$this->tables['nodes_hierarchy']} " . 
-                " WHERE id IN (" . implode(',',array_keys($xitems)) . ")";
+                " WHERE id IN (" . implode(',',array_keys((array)$xitems)) . ")";
 
         $xmen = $this->db->fetchRowsIntoMap($xsql,'parent_id',database::CUMULATIVE);
         $all_nodes = array();      
@@ -1307,7 +1307,7 @@ class tree extends tlObject
             
             case 'simple':  
             default:
-            $keySet = array_keys($path_to);
+            $keySet = array_keys((array)$path_to);
             foreach($keySet as $key)
             {
               $path_to[$key] = $path_to[$key]['name'];

--- a/lib/functions/tree.class.php
+++ b/lib/functions/tree.class.php
@@ -408,7 +408,7 @@ class tree extends tlObject
   function get_path($node_id,$to_node_id = null,$format = 'full')  {
     $the_path = array();
     $this->_get_path($node_id,$the_path,$to_node_id,$format); 
-    if( !is_null($the_path) && count($the_path) > 0 ) {
+    if( !is_null($the_path) && count((array)$the_path) > 0 ) {
       $the_path = array_reverse($the_path);  
     }
     return $the_path;
@@ -423,7 +423,7 @@ class tree extends tlObject
     $matrioska = array();
     $this->_get_path($node_id,$the_path,$to_node_id,$format); 
     
-    if( !is_null($the_path) && ($loop2do=count($the_path)) > 0 ) {
+    if( !is_null($the_path) && ($loop2do=count((array)$the_path)) > 0 ) {
       $the_path=array_reverse($the_path);  
       $matrioska = $the_path[0];
       $matrioska['childNodes']=array();
@@ -730,7 +730,7 @@ class tree extends tlObject
     $sql .= " GROUP BY parent_id ";
     $rs = (array)$this->db->get_recordset($sql);
       
-    return (count($rs) > 0 ? $rs[0]['max_order']: 0);     
+    return (count((array)$rs) > 0 ? $rs[0]['max_order']: 0);     
   }
   
   
@@ -1218,7 +1218,7 @@ class tree extends tlObject
         $output_format = isset($options['output_format']) ? $options['output_format'] : $output_format;
       }
       
-      // according to count($items) we will try to optimize, sorry for magic number
+      // according to count((array)$items) we will try to optimize, sorry for magic number
       if( count((array)$items) > 200)
       {
         $xitems = array_flip((array)$items);
@@ -1252,7 +1252,7 @@ class tree extends tlObject
         }
       }
       
-      $status_ok = (!is_null($all_nodes) && count($all_nodes) > 0);
+      $status_ok = (!is_null($all_nodes) && count((array)$all_nodes) > 0);
       if( $status_ok )
       { 
         // get only different items, to get descriptions
@@ -1399,7 +1399,7 @@ class tree extends tlObject
    */
   function getTreeRoot($node_id) {
     $path = (array)$this->get_path($node_id);
-    $path_len = count($path);
+    $path_len = count((array)$path);
     $root_node_id = ($path_len > 0)? $path[0]['parent_id'] : $node_id;
     return $root_node_id;
   }
@@ -1477,7 +1477,7 @@ class tree extends tlObject
     if( !is_null($root_id) && ($node_id != $root_id) )
     {
       $children = (array)$this->db->get_recordset($sql);
-      if( count($children) == 0 )
+      if( count((array)$children) == 0 )
       {
         $sql2 = "/* $debugMsg */ SELECT NH.* FROM {$this->object_table} NH " .
                 " WHERE NH.id = " . $this->db->prepare_int($node_id);
@@ -1625,7 +1625,7 @@ class tree extends tlObject
             $containerSet[] = $row['id'];
         }
       }
-      if (sizeof($containerSet))
+      if (sizeof((array)$containerSet))
       {
         $containerSet  = implode(",",$containerSet);
         $this->getAllItemsID($containerSet,$itemSet,$coupleTypes);

--- a/lib/functions/treeMenu.inc.php
+++ b/lib/functions/treeMenu.inc.php
@@ -1243,7 +1243,7 @@ function filter_by_cf_values(&$db, &$tcase_tree, &$cf_hash, $node_types)
 function filterStatusSetAtLeastOneOfActiveBuilds(&$tplan_mgr,&$tcase_set,$tplan_id,$filters) 
 {
   $safe_platform = intval($filters->setting_platform);
-  $buildSet = array_keys($tplan_mgr->get_builds($tplan_id, testplan::ACTIVE_BUILDS));
+  $buildSet = array_keys((array)$tplan_mgr->get_builds($tplan_id, testplan::ACTIVE_BUILDS));
   if( !is_null($buildSet) ) 
   {
     if( $safe_platform > 0 )
@@ -1295,7 +1295,7 @@ function filterStatusSetAtLeastOneOfActiveBuilds(&$tplan_mgr,&$tcase_set,$tplan_
  * @return array new tcase_set
  */
 function filterStatusSetAllActiveBuilds(&$tplan_mgr,&$tcase_set,$tplan_id,$filters) {
-  $buildSet = array_keys($tplan_mgr->get_builds($tplan_id, testplan::ACTIVE_BUILDS));
+  $buildSet = array_keys((array)$tplan_mgr->get_builds($tplan_id, testplan::ACTIVE_BUILDS));
   if( !is_null($buildSet) ) {
 
     $safe_platform = intval($filters->setting_platform);

--- a/lib/functions/treeMenu.inc.php
+++ b/lib/functions/treeMenu.inc.php
@@ -70,7 +70,7 @@ function generateTestSpecTree(&$db,$tproject_id, $tproject_name,$linkto,$filters
 
     // Special processing for keywords
     if ($filters['filter_keywords'] != null && 
-    	count($filters['filter_keywords']) == 1 &&
+    	count((array)$filters['filter_keywords']) == 1 &&
         $filters['filter_keywords'][0] == 0
        ) {
        // Get all available keywords on test project and apply these set
@@ -386,13 +386,13 @@ function prepareNode(&$db,&$node,&$map_node_tccount,$attr_map = null,
     $enabledFiltersOn['keywords'] = 
       (null != $attr_map && isset($attr_map['keywords']) 
        && null != $attr_map['keywords']
-       && count($attr_map['keywords']) > 0);
+       && count((array)$attr_map['keywords']) > 0);
 
     $enabledFiltersOn['platforms'] = 
       (null != $attr_map 
        && isset($attr_map['platforms'])
        && null != $attr_map['platforms']
-       && count($attr_map['platforms']) > 0);
+       && count((array)$attr_map['platforms']) > 0);
 
 
     $filterOnTCVersionAttribute = $enabledFiltersOn['executionType'] || $enabledFiltersOn['importance'];
@@ -411,7 +411,7 @@ function prepareNode(&$db,&$node,&$map_node_tccount,$attr_map = null,
                           $my['filters']['filter_result_result'] : null;
     
 
-    $testPlanIsNotEmpty = (!is_null($tplan_tcases) && count($tplan_tcases) > 0); 
+    $testPlanIsNotEmpty = (!is_null($tplan_tcases) && count((array)$tplan_tcases) > 0); 
   }
     
   $tcase_counters = array_fill_keys($status_descr_list, 0);
@@ -662,7 +662,7 @@ function prepareNode(&$db,&$node,&$map_node_tccount,$attr_map = null,
   {
     // node has to be a Test Suite ?
     $childNodes = &$node['childNodes'];
-    $childNodesQty = count($childNodes);
+    $childNodesQty = count((array)$childNodes);
 
     for($idx = 0;$idx < $childNodesQty ;$idx++)
     {
@@ -813,7 +813,7 @@ function renderTreeNode($level,&$node,$hash_id_descr,$linkto,$testCasePrefix,$op
     // in order to change it's values using reference .
     // Can not assign anymore to intermediate variables.
     //
-    $nChildren = sizeof($node['childNodes']);
+    $nChildren = sizeof((array)$node['childNodes']);
     for($idx = 0;$idx < $nChildren;$idx++)
     {
       // asimon - replaced is_null by !isset because of warnings in event log
@@ -996,7 +996,7 @@ function renderExecTreeNode($level,&$node,&$tcase_node,$hash_id_descr,$linkto,$t
   {
     // need to work always original object in order to change it's values using reference .
     // Can not assign anymore to intermediate variables.
-    $nodes_qty = sizeof($node['childNodes']);
+    $nodes_qty = sizeof((array)$node['childNodes']);
     for($idx = 0;$idx <$nodes_qty ;$idx++)
     {
       if(is_null($node['childNodes'][$idx]) || $node['childNodes'][$idx]==REMOVEME)
@@ -1107,7 +1107,7 @@ function filter_by_cf_values(&$db, &$tcase_tree, &$cf_hash, $node_types)
                                                               $cf_hash,$node_types); 
         
         // now remove testsuite node if it is empty after coming back from recursion
-        if (!count($tcase_tree[$key]['childNodes'])) 
+        if (!count((array)$tcase_tree[$key]['childNodes'])) 
         {
           $delete_suite = true;
         }
@@ -1201,7 +1201,7 @@ function filter_by_cf_values(&$db, &$tcase_tree, &$cf_hash, $node_types)
        * TC Version 4: cfield "color" has value "red", cfield "status" has value "ready".
        * 
        * Filter by color GREEN and status READY, then $rows looks like this: Array ( [0] => red, [1] => red )
-       * => count($rows) returns 2, which matches the number of custom fields we want to filter by.
+       * => count((array)$rows) returns 2, which matches the number of custom fields we want to filter by.
        * So TC lands in the result set instead of being filtered out.
        * That is wrong, because TC matches only one of the fields we were filtering by!
        * 
@@ -1209,7 +1209,7 @@ function filter_by_cf_values(&$db, &$tcase_tree, &$cf_hash, $node_types)
        * so that each custom field only is contained ONCE in the result set.
        */
             
-      $passed = (count($rows) == count($cf_hash)) ? true : false;
+      $passed = (count((array)$rows) == count((array)$cf_hash)) ? true : false;
       // now delete node if no match was found
       if (!$passed) 
       {
@@ -2677,7 +2677,7 @@ function prepareTestSpecNode(&$db, &$tprojectMgr,$tprojectID,&$node,&$map_node_t
   
     // node has to be a Test Suite ?
     $childNodes = &$node['childNodes'];
-    $childNodesQty = count($childNodes);
+    $childNodesQty = count((array)$childNodes);
     
     //$pos2unset = array();
     for($idx = 0;$idx < $childNodesQty ;$idx++) {

--- a/lib/functions/treeMenu.inc.php
+++ b/lib/functions/treeMenu.inc.php
@@ -78,7 +78,7 @@ function generateTestSpecTree(&$db,$tproject_id, $tproject_name,$linkto,$filters
        // TODOD
        $tproject_mgr = new testproject($db);
        $usedKeywordsByKeyID = $tproject_mgr->getUsedKeywordsMap($tproject_id);
-       $filters['filter_keywords'] = array_keys($usedKeywordsByKeyID);
+       $filters['filter_keywords'] = array_keys((array)$usedKeywordsByKeyID);
     }
 
     $rr = generateTestSpecTreeNew($db,$tproject_id,$tproject_name,$linkto,$filters,$options);
@@ -351,7 +351,7 @@ function prepareNode(&$db,&$node,&$map_node_tccount,$attr_map = null,
     $nodesCodeType = array_flip($nodesTypeCode);
 
     $resultsCfg = config_get('results');
-    $status_descr_list = array_keys($resultsCfg['status_code']);
+    $status_descr_list = array_keys((array)$resultsCfg['status_code']);
     $status_descr_list[] = 'testcase_count';
     
     $my = array();
@@ -2295,7 +2295,7 @@ function update_status_for_colors(&$dbHandler,&$items,$context,$statusCfg)
 {
   $tables = tlObject::getDBTables(array('executions','nodes_hierarchy'));
   $dummy = current($items);
-  $key2scan = array_keys($items);
+  $key2scan = array_keys((array)$items);
   $keySet = null;
   foreach($key2scan as $fx)
   {

--- a/lib/functions/users.inc.php
+++ b/lib/functions/users.inc.php
@@ -58,7 +58,7 @@ function setUserSession(&$db,$user, $id, $roleID, $email, $locale = null, $activ
   }
   if (!$_SESSION['testprojectID']) {
       $tpID = null;
-      if (sizeof($arrProducts))
+      if (sizeof((array)$arrProducts))
       {
         $tpID = key($arrProducts);
       } 
@@ -136,7 +136,7 @@ function buildUserMap($users,$add_options = false, $additional_options=null, $op
       }
     }
     $userSet = array_keys($users);
-    $loops2do = count($userSet);
+    $loops2do = count((array)$userSet);
     
     for( $idx=0; $idx < $loops2do ; $idx++)
     {
@@ -309,7 +309,7 @@ function getAllUsersRoles(&$db,$order_by = null)
 
   $users = tlDBObject::createObjectsFromDBbySQL($db,$sql,"id","tlUser",false,tlUser::TLOBJ_O_GET_DETAIL_MINIMUM);
   
-  $loop2do = count($users);
+  $loop2do = count((array)$users);
   $specialK = array_flip((array)config_get('demoSpecialUsers'));
   $demoModeEnabled = config_get('demoMode');
   for($idx=0; $idx < $loop2do; $idx++)

--- a/lib/functions/users.inc.php
+++ b/lib/functions/users.inc.php
@@ -135,7 +135,7 @@ function buildUserMap($users,$add_options = false, $additional_options=null, $op
           $usersMap[$code] = $verbose_code;
       }
     }
-    $userSet = array_keys($users);
+    $userSet = array_keys((array)$users);
     $loops2do = count((array)$userSet);
     
     for( $idx=0; $idx < $loops2do ; $idx++)

--- a/lib/functions/xml.inc.php
+++ b/lib/functions/xml.inc.php
@@ -136,7 +136,7 @@ function getItemsFromSimpleXMLObj($simpleXMLItems,$itemStructure)
   if($simpleXMLItems)
   {
     $items_counter=0;
-    $loop_qty = count($simpleXMLItems);
+    $loop_qty = count((array)$simpleXMLItems);
 
     // new dBug($loop_qty);
     for($idx=0; $idx < $loop_qty; $idx++)

--- a/lib/general/frmWorkArea.php
+++ b/lib/general/frmWorkArea.php
@@ -202,7 +202,7 @@ function validateBuildAvailability(&$db,&$tplanMgr,$context,$attrFilter)
     }  
     
     $mzx = '';
-    if(count($msx) > 0)
+    if(count((array)$msx) > 0)
     {
       $mzx = "(" . implode(' & ',$msx) . ")";
     }  

--- a/lib/general/mainPage.php
+++ b/lib/general/mainPage.php
@@ -268,7 +268,7 @@ function getGrants($dbHandler,$user,$tproject_id,$forceToNo=false)
           'testproject_delete_executed_testcases' => 'testproject_delete_executed_testcases',
           'exec_ro_access' => 'exec_ro_access');
  if ($forceToNo) {
-    $grants = array_fill_keys(array_keys($right2check), 'no');
+    $grants = array_fill_keys(array_keys((array)$right2check), 'no');
     return $grants;      
  }  
   

--- a/lib/general/mainPage.php
+++ b/lib/general/mainPage.php
@@ -37,7 +37,7 @@ $testplanID = intval($testplanID);
 
 $accessibleItems = $tproject_mgr->get_accessible_for_user($user->dbID,array('output' => 'map_name_with_inactive_mark'));
 $tprojectQty = $tproject_mgr->getItemCount();
-$userIsBlindFolded = (is_null($accessibleItems) || count($accessibleItems) == 0) && $tprojectQty > 0;
+$userIsBlindFolded = (is_null($accessibleItems) || count((array)$accessibleItems) == 0) && $tprojectQty > 0;
 
 if($userIsBlindFolded) {
   $testprojectID = $testplanID = 0;
@@ -88,7 +88,7 @@ if($testplanID > 0) {
 	//
 	$index=0;
 	$found=0;
-	$loop2do=count($arrPlans);
+	$loop2do=count((array)$arrPlans);
 	for($idx=0; $idx < $loop2do; $idx++) {
   	if( $arrPlans[$idx]['id'] == $testplanID ) {
      	$found = 1;
@@ -154,7 +154,7 @@ $gui->url = array('metrics_dashboard' => 'lib/results/metricsDashboard.php',
                   'testcase_assignments' => 'lib/testcases/tcAssignedToUser.php');
 $gui->launcher = 'lib/general/frmWorkArea.php';
 $gui->arrPlans = $arrPlans;                   
-$gui->countPlans = count($gui->arrPlans);
+$gui->countPlans = count((array)$gui->arrPlans);
 
 
 $gui->testprojectID = $testprojectID;

--- a/lib/general/navBar.php
+++ b/lib/general/navBar.php
@@ -69,7 +69,7 @@ function init_args(&$dbH)
              ON TPRJ.id = NH.id ";
     $rs = (array)$dbH->get_recordset($sql);
 
-    if(count($rs) == 0) {
+    if(count((array)$rs) == 0) {
       $args->newInstallation = true;
     }  
   }  
@@ -93,7 +93,7 @@ function initializeGui(&$db,&$args) {
   $gui->TestProjects = 
     $tproject_mgr->get_accessible_for_user($args->user->dbID,$opx);
 
-  $gui->TestProjectCount = sizeof($gui->TestProjects);
+  $gui->TestProjectCount = sizeof((array)$gui->TestProjects);
   if($gui->TestProjectCount == 0) {
     $gui->TestProjects = null;
   } 
@@ -150,7 +150,7 @@ function initializeGui(&$db,&$args) {
   if($gui->tproject_id) {
     $testPlanSet = 
       (array)$args->user->getAccessibleTestPlans($db,$gui->tproject_id);
-    $gui->TestPlanCount = sizeof($testPlanSet);
+    $gui->TestPlanCount = sizeof((array)$testPlanSet);
 
     $tplanID = isset($_SESSION['testplanID']) ? intval($_SESSION['testplanID']) : null;
     if( !is_null($tplanID) ) {
@@ -163,7 +163,7 @@ function initializeGui(&$db,&$args) {
       //
       $index=0;
       $testPlanFound=0;
-      $loop2do=count($testPlanSet);
+      $loop2do=count((array)$testPlanSet);
       for($idx=0; $idx < $loop2do; $idx++) {
         if( $testPlanSet[$idx]['id'] == $tplanID ) {
           $testPlanFound = 1;
@@ -172,7 +172,7 @@ function initializeGui(&$db,&$args) {
         }
       }
 
-      if( $testPlanFound == 0 && is_array($testPlanSet) &&  count($testPlanSet) > 0) {
+      if( $testPlanFound == 0 && is_array($testPlanSet) &&  count((array)$testPlanSet) > 0) {
         $tplanID = $testPlanSet[0]['id'];
         setSessionTestPlan($testPlanSet[0]);      
       } 

--- a/lib/general/navBar.php
+++ b/lib/general/navBar.php
@@ -126,7 +126,7 @@ function initializeGui(&$db,&$args) {
     if( 0 == $gui->TestProjectCount ) {
       throw new Exception("Can't work without Test Project ID", 1);
     }
-    $theOne = current(array_keys($gui->TestProjects));
+    $theOne = current(array_keys((array)$gui->TestProjects));
     $gui->tproject_id = $gui->tprojectID = $theOne;
   }  
 

--- a/lib/issuetrackerintegration/bugzillaxmlrpcInterface.class.php
+++ b/lib/issuetrackerintegration/bugzillaxmlrpcInterface.class.php
@@ -173,7 +173,7 @@ class bugzillaxmlrpcInterface extends issueTrackerInterface
     $resp = array_merge($resp,(array)$op['response']);
 
 
-		if(count($resp['Bug.get']['faults']) == 0)
+		if(count((array)$resp['Bug.get']['faults']) == 0)
 		{
 			$issue = new stdClass();
       $issue->id = $issueID;

--- a/lib/issuetrackerintegration/code_testing/redmine/test.redmine.rest.php
+++ b/lib/issuetrackerintegration/code_testing/redmine/test.redmine.rest.php
@@ -32,7 +32,7 @@ var_dump($x);
 
 //$issues = $issueMgr->find(d);
 //echo '<pre>' . var_dump($issues) . '</pre>';
-//$issuesQty = count($issues);
+//$issuesQty = count((array)$issues);
 //for ($idx=0; $idx < $issuesQty; $idx++) 
 //{
 //    echo $issues[$idx]->subject;

--- a/lib/issuetrackerintegration/gforgesoapInterface.class.php
+++ b/lib/issuetrackerintegration/gforgesoapInterface.class.php
@@ -135,7 +135,7 @@ class gforgesoapInterface extends issueTrackerInterface
             $issue = $this->APIClient->getTrackerItemFull($this->authToken, $issueID);
             new dBug($issue);
             
-            echo 'QTY extra_field_data:' . count($issue->extra_field_data) . '<br>';
+            echo 'QTY extra_field_data:' . count((array)$issue->extra_field_data) . '<br>';
             $target = array();
             $dataID = array();
             foreach($issue->extra_field_data as $efd)

--- a/lib/issuetrackerintegration/githubrestInterface.class.php
+++ b/lib/issuetrackerintegration/githubrestInterface.class.php
@@ -153,7 +153,7 @@ class githubrestInterface extends issueTrackerInterface
       try
       {
         $items = $this->APIClient->getRepo();
-        $this->connected = count($items) > 0 ? true : false;
+        $this->connected = count((array)$items) > 0 ? true : false;
         unset($items);
       }
       catch(Exception $e)
@@ -227,7 +227,7 @@ class githubrestInterface extends issueTrackerInterface
         $issue->summaryHTMLString = (string)$jsonObj->title.":</br>".(string)$jsonObj->body; 
         $issue->summary =  (string)$jsonObj->title.":\n".(string)$jsonObj->body;
         $Notes = $this->APIClient->getNotes((int)$issueID);
-        if(is_array($Notes) && count($Notes)>0){
+        if(is_array($Notes) && count((array)$Notes)>0){
           foreach($Notes as $key => $note){
             $issue->summaryHTMLString .= "</br>[Note $key]:$note->body";
             $issue->summary .= "\n[Note $key]: $note->body";

--- a/lib/issuetrackerintegration/gitlabrestInterface.class.php
+++ b/lib/issuetrackerintegration/gitlabrestInterface.class.php
@@ -155,7 +155,7 @@ class gitlabrestInterface extends issueTrackerInterface
       try
       {
         $items = $this->APIClient->getProjects();
-        $this->connected = count($items) > 0 ? true : false;
+        $this->connected = count((array)$items) > 0 ? true : false;
         unset($items);
       }
       catch(Exception $e)

--- a/lib/issuetrackerintegration/jirarestInterface.class.php
+++ b/lib/issuetrackerintegration/jirarestInterface.class.php
@@ -408,7 +408,7 @@ class jirarestInterface extends issueTrackerInterface
         /*
         $matches = preg_grep("/(?:\/.*\/{1,})(.*) - Execution/", 
                              (array)$summary);
-        if (count($matches) > 0 && isset($matches[1])) {
+        if (count((array)$matches) > 0 && isset($matches[1])) {
           $issue['fields']['customfield_10311'] = $matches[1];
         }
         */
@@ -618,7 +618,7 @@ class jirarestInterface extends issueTrackerInterface
     $ret = null;
     if(!is_null($attrSet))
     {
-      $ic = count($attrSet);
+      $ic = count((array)$attrSet);
       for($idx=0; $idx < $ic; $idx++)
       {
         $ret[$attrSet[$idx]->id] = $attrSet[$idx]->name; 
@@ -789,7 +789,7 @@ class jirarestInterface extends issueTrackerInterface
       $cf = (array)$cf;    
       $cfJIRAID = $cf['customfieldId']; 
       $valueSet = (array)$cf['values'];        
-      $loop2do = count($valueSet);
+      $loop2do = count((array)$valueSet);
 
       $dummy = null;
       $cfType = strtolower((string)$cf['type']);

--- a/lib/issuetrackerintegration/kaitenrestInterface.class.php
+++ b/lib/issuetrackerintegration/kaitenrestInterface.class.php
@@ -114,7 +114,7 @@ class kaitenrestInterface extends issueTrackerInterface {
       // to undestand if connection is OK, I will ask for users.
       try {
         $items = $this->APIClient->getUsers();
-        $this->connected = count($items) > 0 ? true : false;
+        $this->connected = count((array)$items) > 0 ? true : false;
         unset($items);
       }
       catch(Exception $e) {
@@ -251,7 +251,7 @@ class kaitenrestInterface extends issueTrackerInterface {
 
     foreach($pik as $ky => $vy ) {
       preg_match('/^' . $vy . '(.+)$/imu', $info, $matches[$ky]);    
-      if( count($matches[$ky]) > 1 ) {
+      if( count((array)$matches[$ky]) > 1 ) {
         $result['links'][] = [
           'descr' => $vy,
           'url' => $matches[$ky][1]
@@ -276,7 +276,7 @@ class kaitenrestInterface extends issueTrackerInterface {
         throw new Exception("Error creating issue", 1);
       }
 
-      if (count($more['links']) > 0) {
+      if (count((array)$more['links']) > 0) {
         $this->APIClient->addExternalLinks($op->id,$more['links']);
       }
   

--- a/lib/issuetrackerintegration/mantisrestInterface.class.php
+++ b/lib/issuetrackerintegration/mantisrestInterface.class.php
@@ -320,7 +320,7 @@ class mantisrestInterface extends issueTrackerInterface {
         throw new Exception("Error creating issue", 1);
       }
 
-      if (count($more['links']) > 0) {
+      if (count((array)$more['links']) > 0) {
         $this->APIClient->addExternalLinks($op->id,$more['links']);
       }
   

--- a/lib/issuetrackerintegration/trellorestInterface.class.php
+++ b/lib/issuetrackerintegration/trellorestInterface.class.php
@@ -101,7 +101,7 @@ class trellorestInterface extends issueTrackerInterface {
   {
     $norm = $issueID;
     $pieces = explode('/',$issueID);
-    $piecesQty = count($pieces); 
+    $piecesQty = count((array)$pieces); 
     if ( $piecesQty > 1) {
       // MAGIC
       // 0 -> https:

--- a/lib/issuetrackerintegration/tuleaprestInterface.class.php
+++ b/lib/issuetrackerintegration/tuleaprestInterface.class.php
@@ -169,7 +169,7 @@ class tuleaprestInterface extends issueTrackerInterface
                 // retrieve the labels of closed status
                 $ret['status'] = $this->getClosedLabels($status, $statusValuesID);
                 // check that all labels have been found
-                if ( count($ret['status']) != (count($status->values) - count($statusValuesID)) )
+                if ( count((array)$ret['status']) != (count((array)$status->values) - count((array)$statusValuesID)) )
                     throw new Exception('Some labels was not found.');
             } else
                 throw new Exception('The tracker ' . $this->trackerID . ' was not found.');
@@ -190,7 +190,7 @@ class tuleaprestInterface extends issueTrackerInterface
      * @author Aurelien TISNE <aurelien.tisne@csgroup.eu>
      **/
     private function getField($tracker, $fieldID) {
-        $i = count($tracker->fields);
+        $i = count((array)$tracker->fields);
         $field = null;
         while ($i > 0 && ! $field) {
             if ($tracker->fields[$i - 1]->field_id == $fieldID)

--- a/lib/keywords/keywordsAssign.php
+++ b/lib/keywords/keywordsAssign.php
@@ -80,7 +80,7 @@ switch($args->edit) {
       }
     }
 
-    if( ($loop2do = sizeof($tcs)) ) {
+    if( ($loop2do = sizeof((array)$tcs)) ) {
       $gui->can_do = 1;
       
       $method = null;
@@ -134,7 +134,7 @@ switch($args->edit) {
     $gui->hasBeenExecuted = intval($statusQuo['executed']) > 0;
 
     if ($gui->canAddRemoveKWFromExecuted || !$gui->hasBeenExecuted) {      
-      $kwQty = !is_null($args->keywordArray) ? count($args->keywordArray) : 0;
+      $kwQty = !is_null($args->keywordArray) ? count((array)$args->keywordArray) : 0;
       if ($args->assignToTestCase && $kwQty >0) {
         $result = 'ok';
         $tcase_mgr->setKeywords($args->id,$latestActiveVersionID,$args->keywordArray);

--- a/lib/keywords/keywordsEdit.php
+++ b/lib/keywords/keywordsEdit.php
@@ -90,7 +90,7 @@ $tplEngine->display($tplCfg->template_dir . $tpl);
 function initEnv(&$dbHandler) {
   $args = new stdClass();
   $_REQUEST = strings_stripSlashes($_REQUEST);
-  $source = sizeof($_POST) ? "POST" : "GET";
+  $source = sizeof((array)$_POST) ? "POST" : "GET";
   
   $ipcfg = 
     array( "doAction" => array($source,tlInputParameter::STRING_N,0,50),

--- a/lib/keywords/keywordsEnv.php
+++ b/lib/keywords/keywordsEnv.php
@@ -39,7 +39,7 @@ function getKeywordsEnv(&$dbHandler,&$user,$tproject_id,$opt=null) {
 
     // Count how many times the keyword has been used
     $kwEnv->kwOnTCV = (array)$tproject->countKeywordUsageInTCVersions($tproject_id);
-    if( $more && count($kwEnv->kwOnTCV) > 0) {
+    if( $more && count((array)$kwEnv->kwOnTCV) > 0) {
       foreach($kwEnv->kwOnTCV as $kk => $dummy) {
         $kwEnv->kwOnTCV[$kk]['keyword'] = $kwNames[$kk];
         $kwEnv->kwOnTCV[$kk]['notes'] = $kwNotes[$kk];        

--- a/lib/plan/buildCopyExecTaskAssignment.php
+++ b/lib/plan/buildCopyExecTaskAssignment.php
@@ -156,7 +156,7 @@ function getBuildDomainForGUI(&$tplanMgr, &$argsObj)
   if( !is_null($htmlMenu['items']) )
   {
     $lblCount = lang_get('assignments'); 
-    $htmlMenu['build_count'] = count($htmlMenu['items']);
+    $htmlMenu['build_count'] = count((array)$htmlMenu['items']);
     foreach ($htmlMenu['items'] as $key => $name) 
     {
       $count = $tplanMgr->assignment_mgr->get_count_of_assignments_for_build_id($key);

--- a/lib/plan/buildEdit.php
+++ b/lib/plan/buildEdit.php
@@ -501,7 +501,7 @@ function doCreate(&$argsObj,&$buildMgr,&$tplanMgr,$dateFormat) {
               }
 
               if(!is_null($tcaseSet)){
-                $targetSet = array_keys($tcaseSet);
+                $targetSet = array_keys((array)$tcaseSet);
                 $features = $tplanMgr->getLinkedFeatures($argsObj->tplan_id,$glf['filters']);
                 $caOpt['feature_set'] = null;
                 foreach($targetSet as $tcase_id) {

--- a/lib/plan/buildEdit.php
+++ b/lib/plan/buildEdit.php
@@ -342,7 +342,7 @@ function renderGui(&$smartyObj,&$argsObj,&$tplanMgr,&$buildMgr,$templateCfg,$owe
         $guiObj->buildSet=$tplanMgr->get_builds($argsObj->tplan_id);
         $availableCF = (array)$buildMgr->get_linked_cfields_at_design($guiObj->build,$guiObj->tproject_id);
     
-        $hasCF = count($availableCF);
+        $hasCF = count((array)$availableCF);
         $guiObj->cfieldsColumns = null;
         $guiObj->cfieldsType = null;
 
@@ -728,7 +728,7 @@ function init_source_build_selector(&$testplan_mgr, &$argsObj)
   // get the number of existing execution assignments with each build
   if( !is_null($htmlMenu['items']) )
   {
-    $htmlMenu['build_count'] = count($htmlMenu['items']);
+    $htmlMenu['build_count'] = count((array)$htmlMenu['items']);
     foreach ($htmlMenu['items'] as $key => $name) 
     {
       $count = $testplan_mgr->assignment_mgr->get_count_of_assignments_for_build_id($key);

--- a/lib/plan/buildView.php
+++ b/lib/plan/buildView.php
@@ -58,7 +58,7 @@ function initEnv(&$dbHandler)
   if (!is_null($gui->buildSet)) {
     $availableCF = (array)$build_mgr->get_linked_cfields_at_design(current($gui->buildSet),$gui->tproject_id);
   }
-  $hasCF = count($availableCF);
+  $hasCF = count((array)$availableCF);
   $gui->cfieldsColumns = null; 
   $gui->cfieldsType = null;
   $initCFCol = true;

--- a/lib/plan/newest_tcversions.php
+++ b/lib/plan/newest_tcversions.php
@@ -43,12 +43,12 @@ $gui->tplan_id=$args->tplan_id;
 $gui->tproject_name = $args->tproject_name;
 
 $linked_tcases = $tplan_mgr->get_linked_items_id($args->tplan_id);
-$qty_linked = count($linked_tcases);
+$qty_linked = count((array)$linked_tcases);
 $gui->testcases = $tplan_mgr->get_linked_and_newest_tcversions($args->tplan_id);
 
 if($qty_linked)
 {
-    $qty_newest = count($gui->testcases);
+    $qty_newest = count((array)$gui->testcases);
     if($qty_newest)
     {
         $gui->show_details = 1;

--- a/lib/plan/newest_tcversions.php
+++ b/lib/plan/newest_tcversions.php
@@ -54,7 +54,7 @@ if($qty_linked)
         $gui->show_details = 1;
     
         // get path
-        $tcaseSet=array_keys($gui->testcases);
+        $tcaseSet=array_keys((array)$gui->testcases);
         $path_info=$tree_mgr->get_full_path_verbose($tcaseSet);
         foreach($gui->testcases as $tcase_id => $value)
         {

--- a/lib/plan/planAddTC.php
+++ b/lib/plan/planAddTC.php
@@ -120,7 +120,7 @@ if($do_display) {
       $tproject_mgr->getKeywordsLatestTCV($args->tproject_id,
         $keywordsFilter->items,$keywordsFilter->type);
 
-    if (sizeof($keywordsTestCases)) {
+    if (sizeof((array)$keywordsTestCases)) {
       $testCaseSet = array_keys($keywordsTestCases);
     }
   }
@@ -129,7 +129,7 @@ if($do_display) {
   // exists on this test project.
   $cfields = (array)$tsuite_mgr->cfield_mgr->get_linked_cfields_at_testplan_design($args->tproject_id,1,'testcase');
   $opt = array('write_button_only_if_linked' => 0, 'add_custom_fields' => 0);
-  $opt['add_custom_fields'] = count($cfields) > 0 ? 1 : 0;
+  $opt['add_custom_fields'] = count((array)$cfields) > 0 ? 1 : 0;
 
   // Add Test Cases to Test plan - Right pane does not honor custom field filter
   // filter by test case execution type
@@ -265,7 +265,7 @@ if($do_display) {
       $tproject_mgr->getKeywordsLatestTCV($args->tproject_id,
         $keywordsFilter->items,$keywordsFilter->type);
 
-		if (sizeof($keywordsTestCases)) {
+		if (sizeof((array)$keywordsTestCases)) {
 			$testCaseSet = array_keys($keywordsTestCases);
 		}
 	}
@@ -276,7 +276,7 @@ if($do_display) {
     (array)$tsuite_mgr->cfield_mgr->get_linked_cfields_at_testplan_design($args->tproject_id,1,'testcase');
 
 	$opt = array('write_button_only_if_linked' => 0, 'add_custom_fields' => 0);
-	$opt['add_custom_fields'] = count($cfields) > 0 ? 1 : 0;
+	$opt['add_custom_fields'] = count((array)$cfields) > 0 ? 1 : 0;
 
   // Add Test Cases to Test plan - Right pane does not honor custom field filter
   // filter by test case execution type
@@ -469,7 +469,7 @@ function init_args(&$tproject_mgr)
   // contains WHAT TO REMOVE
   $args->topLevelTestSuite = 0;
   if( $getFromSession && isset($pageCache['filter_toplevel_testsuite']) 
-                      && count($pageCache['filter_toplevel_testsuite']) > 0)
+                      && count((array)$pageCache['filter_toplevel_testsuite']) > 0)
   {
     // get all
     $first_level_suites = $tproject_mgr->get_first_level_test_suites($args->tproject_id,'simple',array('accessKey' => 'id'));
@@ -491,7 +491,7 @@ function init_args(&$tproject_mgr)
   $ak = 'filter_keywords';
   if (isset($pageCache[$ak])) {
     $args->keyword_id = $pageCache[$ak];
-    if (is_array($args->keyword_id) && count($args->keyword_id) == 1) {
+    if (is_array($args->keyword_id) && count((array)$args->keyword_id) == 1) {
       $args->keyword_id = $args->keyword_id[0];
     }
   }
@@ -997,7 +997,7 @@ function init_build_selector(&$testplan_mgr, &$argsObj) {
     (array)$testplan_mgr->get_builds_for_html_options($argsObj->tplan_id,
                                                       testplan::GET_ACTIVE_BUILD,
                                                       testplan::GET_OPEN_BUILD);
-  $menu['count'] = count($menu['items']);
+  $menu['count'] = count((array)$menu['items']);
   
   // if no build has been chosen yet, select the newest build by default
   $build_id = $argsObj->build_id;

--- a/lib/plan/planAddTC.php
+++ b/lib/plan/planAddTC.php
@@ -121,7 +121,7 @@ if($do_display) {
         $keywordsFilter->items,$keywordsFilter->type);
 
     if (sizeof((array)$keywordsTestCases)) {
-      $testCaseSet = array_keys($keywordsTestCases);
+      $testCaseSet = array_keys((array)$keywordsTestCases);
     }
   }
   
@@ -266,7 +266,7 @@ if($do_display) {
         $keywordsFilter->items,$keywordsFilter->type);
 
 		if (sizeof((array)$keywordsTestCases)) {
-			$testCaseSet = array_keys($keywordsTestCases);
+			$testCaseSet = array_keys((array)$keywordsTestCases);
 		}
 	}
 
@@ -555,7 +555,7 @@ function doReorder(&$argsObj,&$tplanMgr)
     // Now add info for new liked test cases if any
     if(!is_null($argsObj->testcases2add))
     {
-        $tcaseSet = array_keys($argsObj->testcases2add);
+        $tcaseSet = array_keys((array)$argsObj->testcases2add);
         foreach($tcaseSet as $tcid)
         {
           // This check is needed because, after we have added test case
@@ -895,7 +895,7 @@ function send_mail_to_testers(&$dbHandler,&$tcaseMgr,&$guiObj,&$argsObj,$feature
  */
 function initDrawSaveButtons(&$guiObj)
 {
-  $keySet = array_keys($guiObj->items);
+  $keySet = array_keys((array)$guiObj->items);
 
   // 20100225 - eloff - BUGID 3205 - check only when platforms are active
   // Logic to initialize drawSavePlatformsButton.
@@ -908,7 +908,7 @@ function initDrawSaveButtons(&$guiObj)
       $testSuite = &$guiObj->items[$key];
       if($testSuite['linked_testcase_qty'] > 0)
       {
-        $tcaseSet = array_keys($testSuite['testcases']);
+        $tcaseSet = array_keys((array)$testSuite['testcases']);
         foreach($tcaseSet as $tcaseKey)
         {
           if( isset($testSuite['testcases'][$tcaseKey]['feature_id'][0]) )
@@ -934,7 +934,7 @@ function initDrawSaveButtons(&$guiObj)
     $tcaseSet = &$guiObj->items[$key]['testcases'];
     if( !is_null($tcaseSet) )
     {
-      $tcversionSet = array_keys($tcaseSet);
+      $tcversionSet = array_keys((array)$tcaseSet);
       foreach($tcversionSet as $tcversionID)
       {
         if( isset($tcaseSet[$tcversionID]['custom_fields']) && 
@@ -1002,7 +1002,7 @@ function init_build_selector(&$testplan_mgr, &$argsObj) {
   // if no build has been chosen yet, select the newest build by default
   $build_id = $argsObj->build_id;
   if (!$build_id && $menu['count']) {
-    $keys = array_keys($menu['items']);
+    $keys = array_keys((array)$menu['items']);
     $build_id = end($keys);
   }
   $menu['selected'] = $build_id;

--- a/lib/plan/planEdit.php
+++ b/lib/plan/planEdit.php
@@ -247,7 +247,7 @@ switch($args->do_action)
       $dummy = $tplan_mgr->platform_mgr->testProjectCount();
       $gui->drawPlatformQtyColumn = $dummy[$args->tproject_id]['platform_qty'] > 0;
   
-      $tplanSet = array_keys($gui->tplans);
+      $tplanSet = array_keys((array)$gui->tplans);
       $dummy = $tplan_mgr->count_testcases($tplanSet,null,array('output' => 'groupByTestPlan'));
       $buildQty = $tplan_mgr->get_builds($tplanSet,null,null,array('getCount' => true));
 

--- a/lib/plan/planEdit.php
+++ b/lib/plan/planEdit.php
@@ -255,7 +255,7 @@ switch($args->do_action)
 
       // --------------------------------------------------------------------------------------------------
       $availableCF = (array)$tplan_mgr->get_linked_cfields_at_design(current($tplanSet),$gui->tproject_id);
-      $hasCF = count($availableCF);
+      $hasCF = count((array)$availableCF);
       $gui->cfieldsColumns = null; 
       $initCFCol = true;
       
@@ -315,7 +315,7 @@ switch($args->do_action)
         if( $gui->drawPlatformQtyColumn )
         {
           $plat = $tplan_mgr->getPlatforms($idk);
-          $gui->tplans[$idk]['platform_qty'] = is_null($plat) ? 0 : count($plat);
+          $gui->tplans[$idk]['platform_qty'] = is_null($plat) ? 0 : count((array)$plat);
         }
   
         // Get rights for each test plan
@@ -494,7 +494,7 @@ function initializeGui(&$dbHandler,&$argsObj,&$editorCfg,&$tprojectMgr)
 function getItemData(&$itemMgr,&$guiObj,&$ofObj,$itemID,$updateAttachments=false)
 {
   $dummy = $itemMgr->get_by_id($itemID);
-  if (sizeof($dummy))
+  if (sizeof((array)$dummy))
   {
     $ofObj->Value = $dummy['notes'];
     $guiObj->testplan_name = $dummy['name'];

--- a/lib/plan/planImport.php
+++ b/lib/plan/planImport.php
@@ -376,7 +376,7 @@ function importTestPlanLinksFromXML(&$dbHandler,&$tplanMgr,$targetFile,$contextO
                   // linked platforms
                   $createLink = false;
                   $updateLink = false;
-                  $plat_keys = array_keys($linkedVersions[$dummy[0]['tcversion_id']][$contextObj->tplan_id]);
+                  $plat_keys = array_keys((array)$linkedVersions[$dummy[0]['tcversion_id']][$contextObj->tplan_id]);
                   $plat_keys = array_flip($plat_keys);
 
                   if( isset($plat_keys[$platformID]) )

--- a/lib/plan/planImport.php
+++ b/lib/plan/planImport.php
@@ -252,10 +252,10 @@ function importTestPlanLinksFromXML(&$dbHandler,&$tplanMgr,$targetFile,$contextO
     {
       $tables = tlObjectWithDB::getDBTables(array('testplan_tcversions'));
       $platformSet = $tplanMgr->getPlatforms($contextObj->tplan_id,array('outputFormat' => 'mapAccessByName'));
-      $targetHasPlatforms = (count($platformSet) > 0);
+      $targetHasPlatforms = (count((array)$platformSet) > 0);
       
       $xmlLinks = $xml->executables->children();
-      $loops2do = count($xmlLinks);
+      $loops2do = count((array)$xmlLinks);
 
       // new dBug($platformSet);
       $tplanDesignCfg = config_get('tplanDesign');
@@ -341,7 +341,7 @@ function importTestPlanLinksFromXML(&$dbHandler,&$tplanMgr,$targetFile,$contextO
             $dummy = $tcaseMgr->get_basic_info($tcaseSet[$externalID],
                                                array('number' => $version));
 
-            if( count($dummy) > 0 )
+            if( count((array)$dummy) > 0 )
             {
               // Check :
               // for same test plan there is a different version already linked ?
@@ -474,7 +474,7 @@ function processPlatforms(&$platMgr,&$tplanMgr,$universe,$xmlSubset,$lbl,$tplanI
   $ret = array('status_ok' => true, 'msg' => null);
   $children = $xmlSubset->children();
   $msg_ok = array();
-  $loops2do = count($children);
+  $loops2do = count((array)$children);
   $status_ok = true;
   $idSet = null;
   for($idx = 0; $idx < $loops2do; $idx++)

--- a/lib/plan/planUpdateTC.php
+++ b/lib/plan/planUpdateTC.php
@@ -363,7 +363,7 @@ function processTestPlan(&$dbHandler,&$argsObj,&$tplanMgr)
 		if( !is_null($set2update['items']) && count((array)$set2update['items']) > 0 )
 		{
 			$set2update['msg'] = '';
-			$itemSet=array_keys($set2update['items']);
+			$itemSet=array_keys((array)$set2update['items']);
 			$path_info=$tplanMgr->tree_manager->get_full_path_verbose($itemSet);
 			foreach($set2update['items'] as $tcase_id => $value)
 			{
@@ -387,7 +387,7 @@ function tideUpForGUI(&$output)
     	$itemSet = &$output['spec_view'][$idx]['testcases'];
     	if( count((array)$itemSet) > 0)
     	{
-    		$key2loop = array_keys($itemSet);
+    		$key2loop = array_keys((array)$itemSet);
     		foreach($key2loop as $tcaseID)
     		{
     			// want to understand

--- a/lib/plan/planUpdateTC.php
+++ b/lib/plan/planUpdateTC.php
@@ -163,7 +163,7 @@ function init_args(&$tplanMgr)
 	if (isset($session_data[$fk])) 
 	{
 		$args->keyword_id = $session_data[$fk];
-		if (is_array($args->keyword_id) && count($args->keyword_id) == 1) 
+		if (is_array($args->keyword_id) && count((array)$args->keyword_id) == 1) 
 		{
 			$args->keyword_id = $args->keyword_id[0];
 		}
@@ -331,7 +331,7 @@ function processTestCase(&$dbHandler,&$argsObj,$keywordsFilter,&$tplanMgr,&$tree
 	$linked_items[$xx['tc_id']][0] = $xx; // adapt data structure to gen_spec_view() desires
 	
 	$my_path = $treeMgr->get_path($argsObj->id);
-	$idx_ts = count($my_path)-1;
+	$idx_ts = count((array)$my_path)-1;
 	$tsuite_data = $my_path[$idx_ts-1];
 
 	// Again here need to understand why we seems to consider ONLY keywords filter.
@@ -358,9 +358,9 @@ function processTestPlan(&$dbHandler,&$argsObj,&$tplanMgr)
 									   lang_get('no_newest_version_of_linked_tcversions');
 	
     $set2update['items'] = $tplanMgr->get_linked_and_newest_tcversions($argsObj->tplan_id);
-    if( count($set2update['items']) > 0 )
+    if( count((array)$set2update['items']) > 0 )
     {
-		if( !is_null($set2update['items']) && count($set2update['items']) > 0 )
+		if( !is_null($set2update['items']) && count((array)$set2update['items']) > 0 )
 		{
 			$set2update['msg'] = '';
 			$itemSet=array_keys($set2update['items']);
@@ -381,11 +381,11 @@ function processTestPlan(&$dbHandler,&$argsObj,&$tplanMgr)
 function tideUpForGUI(&$output)
 {
     // We are going to loop over test suites
-    $loop2do = count($output['spec_view']);
+    $loop2do = count((array)$output['spec_view']);
     for($idx=0; $idx < $loop2do; $idx++)
     {
     	$itemSet = &$output['spec_view'][$idx]['testcases'];
-    	if( count($itemSet) > 0)
+    	if( count((array)$itemSet) > 0)
     	{
     		$key2loop = array_keys($itemSet);
     		foreach($key2loop as $tcaseID)
@@ -397,7 +397,7 @@ function tideUpForGUI(&$output)
     			// if we have ZERO ACTIVE VERSIONS
     			//
     			$active = 0;
-    			$total = count($itemSet[$tcaseID]['tcversions_active_status']);
+    			$total = count((array)$itemSet[$tcaseID]['tcversions_active_status']);
     			foreach($itemSet[$tcaseID]['tcversions_active_status'] as $status)
     			{
     				if($status)
@@ -420,7 +420,7 @@ function tideUpForGUI(&$output)
 				if( !is_null($lnItem) && isset($itemSet[$tcaseID]['tcversions'][$lnItem]) )
 				{
 					unset($itemSet[$tcaseID]['updateTarget'][$lnItem]);
-					if(count($itemSet[$tcaseID]['updateTarget']) == 0)
+					if(count((array)$itemSet[$tcaseID]['updateTarget']) == 0)
 					{
 						$itemSet[$tcaseID]['updateTarget'] = null;
 					}

--- a/lib/plan/planView.php
+++ b/lib/plan/planView.php
@@ -22,7 +22,7 @@ if ($args->tproject_id && checkRights($db,$args->user,$args->tproject_id)) {
                                                      array('output' =>'mapfull', 'active' => null));
   $gui->drawPlatformQtyColumn = false;
   
-  if( !is_null($gui->tplans) && count($gui->tplans) > 0 )
+  if( !is_null($gui->tplans) && count((array)$gui->tplans) > 0 )
   {
     // do this test project has platform definitions ?
     $tplan_mgr = new testplan($db);
@@ -37,7 +37,7 @@ if ($args->tproject_id && checkRights($db,$args->user,$args->tproject_id)) {
 
     // To create the CF columns we need to get the linked CF
     $availableCF = (array)$tplan_mgr->get_linked_cfields_at_design(current($tplanSet),$gui->tproject_id);
-    $hasCF = count($availableCF);
+    $hasCF = count((array)$availableCF);
     $gui->cfieldsColumns = null; 
     $gui->cfieldsType = null;
     $initCFCol = true;
@@ -99,7 +99,7 @@ if ($args->tproject_id && checkRights($db,$args->user,$args->tproject_id)) {
       if( $gui->drawPlatformQtyColumn )
       {
         $plat = $tplan_mgr->getPlatforms($idk);
-        $gui->tplans[$idk]['platform_qty'] = is_null($plat) ? 0 : count($plat);
+        $gui->tplans[$idk]['platform_qty'] = is_null($plat) ? 0 : count((array)$plat);
       }
 
 

--- a/lib/plan/planView.php
+++ b/lib/plan/planView.php
@@ -30,7 +30,7 @@ if ($args->tproject_id && checkRights($db,$args->user,$args->tproject_id)) {
     $dummy = $tplan_mgr->platform_mgr->testProjectCount();
     $gui->drawPlatformQtyColumn = $dummy[$args->tproject_id]['platform_qty'] > 0;
 
-    $tplanSet = array_keys($gui->tplans);
+    $tplanSet = array_keys((array)$gui->tplans);
     $dummy = $tplan_mgr->count_testcases($tplanSet,null,array('output' => 'groupByTestPlan'));
     $buildQty = $tplan_mgr->get_builds($tplanSet,null,null,array('getCount' => true));
     $rightSet = array('testplan_user_role_assignment');

--- a/lib/plan/tc_exec_assignment.php
+++ b/lib/plan/tc_exec_assignment.php
@@ -161,7 +161,7 @@ switch($args->level) {
   case 'testcase':
     // build the data need to call gen_spec_view
     $xx = $tcase_mgr->getPathLayered(array($args->id));
-    $yy = array_keys($xx);  // done to silence warning on end()
+    $yy = array_keys((array)$xx);  // done to silence warning on end()
     $tsuite_data['id'] = end($yy);
     $tsuite_data['name'] = $xx[$tsuite_data['id']]['value']; 
         
@@ -217,7 +217,7 @@ $gui->items = $out['spec_view'];
 // useful to avoid error messages on smarty template.
 $gui->items_qty = is_null($gui->items) ? 0 : count((array)$gui->items);
 $gui->has_tc = $out['num_tc'] > 0 ? 1:0;
-$gui->support_array = array_keys($gui->items);
+$gui->support_array = array_keys((array)$gui->items);
 
 if ($_SESSION['testprojectOptions']->testPriorityEnabled) 
 {
@@ -437,7 +437,7 @@ function send_mail_to_testers(&$dbHandler,&$tcaseMgr,&$guiObj,&$argsObj,$feature
 
 
   // Do we really have platforms?
-  $pset = array_flip(array_keys($features));
+  $pset = array_flip(array_keys((array)$features));
   if ($hasPlat = !isset($pset[0])) {
     $platMgr = new tlPlatform($dbHandler,$argsObj->tproject_id);
     $platSet = $platMgr->getAllAsMap();
@@ -562,7 +562,7 @@ function doRemoveAll(&$dbH,&$argsObj,&$guiObj,$cfg,$oMgr) {
   
   // Must be done before delete
   if($argsObj->send_mail) {
-    $fSet = array_keys($features2[$op]);
+    $fSet = array_keys((array)$features2[$op]);
     $items = $oMgr['tplan']->getFeatureByID($fSet);
     $testers = $oMgr['assign']->getUsersByFeatureBuild($fSet,$argsObj->build_id,$cfg['task_test_execution']);
 
@@ -570,7 +570,7 @@ function doRemoveAll(&$dbH,&$argsObj,&$guiObj,$cfg,$oMgr) {
     foreach($items as $fid => $value)
     {
       $pid = $value['platform_id'];
-      $f4mail[$pid][$fid]['previous_user_id'] = array_keys($testers[$fid]); 
+      $f4mail[$pid][$fid]['previous_user_id'] = array_keys((array)$testers[$fid]); 
       $f4mail[$pid][$fid]['tcase_id'] = $items[$fid]['tcase_id'];
       $f4mail[$pid][$fid]['tcversion_id'] = $items[$fid]['tcversion_id'];
     } 
@@ -609,14 +609,14 @@ function doBulkUserRemove(&$dbH,&$argsObj,&$guiObj,$cfg,$oMgr) {
 
     // Must be done before delete
     if($argsObj->send_mail) {
-      $fSet = array_keys($feat);
+      $fSet = array_keys((array)$feat);
       $items = $oMgr['tplan']->getFeatureByID($fSet);
       $testers = $oMgr['assign']->getUsersByFeatureBuild($fSet,$argsObj->build_id,$cfg['task_test_execution']);
 
       $f4mail = array();
       foreach($items as $fid => $value) {
         $pid = $value['platform_id'];
-        $f4mail[$pid][$fid]['previous_user_id'] = array_keys($testers[$fid]); 
+        $f4mail[$pid][$fid]['previous_user_id'] = array_keys((array)$testers[$fid]); 
         $f4mail[$pid][$fid]['tcase_id'] = $items[$fid]['tcase_id'];
         $f4mail[$pid][$fid]['tcversion_id'] = $items[$fid]['tcversion_id'];
       } 

--- a/lib/plan/tc_exec_assignment.php
+++ b/lib/plan/tc_exec_assignment.php
@@ -84,7 +84,7 @@ switch($args->doAction)
 
       foreach($features2 as $key => $featByPlatform)
       {
-        if( count($features2[$key]) > 0 )
+        if( count((array)$features2[$key]) > 0 )
         {
           foreach($featByPlatform as $plat => $values)
           {
@@ -215,7 +215,7 @@ switch($args->level) {
 $gui->items = $out['spec_view'];
 
 // useful to avoid error messages on smarty template.
-$gui->items_qty = is_null($gui->items) ? 0 : count($gui->items);
+$gui->items_qty = is_null($gui->items) ? 0 : count((array)$gui->items);
 $gui->has_tc = $out['num_tc'] > 0 ? 1:0;
 $gui->support_array = array_keys($gui->items);
 
@@ -261,7 +261,7 @@ function init_args()
   
   $args->userSet = null;
   $target = $_REQUEST['bulk_tester_div']; 
-  if(isset($target) && count($target) > 0) {
+  if(isset($target) && count((array)$target) > 0) {
     foreach($target as $uid) {
       if($uid > 0) {
         $args->userSet[$uid] = $uid;
@@ -291,7 +291,7 @@ function init_args()
   if (isset($session_data[$fk])) 
   {
     $args->keyword_id = $session_data[$fk];
-    if (is_array($args->keyword_id) && count($args->keyword_id) == 1) 
+    if (is_array($args->keyword_id) && count((array)$args->keyword_id) == 1) 
     {
       $args->keyword_id = $args->keyword_id[0];
     }
@@ -578,7 +578,7 @@ function doRemoveAll(&$dbH,&$argsObj,&$guiObj,$cfg,$oMgr) {
 
 
   foreach($features2 as $key => $values) {
-    if( count($features2[$key]) > 0 ) {
+    if( count((array)$features2[$key]) > 0 ) {
       $oMgr['assign']->delete_by_feature_id_and_build_id($values);
     }  
   }

--- a/lib/platforms/platformsAssign.php
+++ b/lib/platforms/platformsAssign.php
@@ -72,7 +72,7 @@ if (isset($args->tplan_id)) {
   if ($args->doAction == 'doAssignPlatforms') {
     $platform_mgr->linkToTestplan($args->platformsToAdd,$args->tplan_id);
     $platform_mgr->unlinkFromTestplan($args->platformsToRemove,$args->tplan_id);
-    if( $fix_needed && count($args->platformsToAdd) == 1)
+    if( $fix_needed && count((array)$args->platformsToAdd) == 1)
     {
       reset($args->platformsToAdd);
       $tplan_mgr->changeLinkedTCVersionsPlatform($args->tplan_id,0,current($args->platformsToAdd));

--- a/lib/platforms/platformsImport.php
+++ b/lib/platforms/platformsImport.php
@@ -179,7 +179,7 @@ function doImport(&$dbHandler,$testproject_id)
 		$file_check = array('show_results' => 0, 'status_ok' => 0,'msg' => $msg);
 	}
   
-  if( count($import_msg['ko']) == 0 )
+  if( count((array)$import_msg['ko']) == 0 )
   {
     $import_msg['ko'] = null;
   }  

--- a/lib/project/fix_tplans.php
+++ b/lib/project/fix_tplans.php
@@ -37,7 +37,7 @@ if ($can_manage_tprojects)
 	}	
 	
 	$testPlans = getTestPlansWithoutProject($db);
-	$testPlansCount = count($testPlans);
+	$testPlansCount = count((array)$testPlans);
 	
 	$tpObj = new testproject($db);
 	$testProjects = $tpObj->get_all();

--- a/lib/project/projectEdit.php
+++ b/lib/project/projectEdit.php
@@ -129,7 +129,7 @@ switch($args->doAction) {
     $gui->tprojects = (array)$tproject_mgr->get_accessible_for_user($args->userID,$opt);
       
     $gui->pageTitle = lang_get('title_testproject_management');
-    $gui->itemQty = $tprojQty = count($gui->tprojects);
+    $gui->itemQty = $tprojQty = count((array)$gui->tprojects);
 
     if($gui->itemQty > 0) {
       $gui->pageTitle .= ' ' . sprintf(lang_get('available_test_projects'),$gui->itemQty);

--- a/lib/project/projectView.php
+++ b/lib/project/projectView.php
@@ -101,7 +101,7 @@ function initializeGui(&$dbHandler,&$argsObj) {
   $cfg = getWebEditorCfg('testproject');
   $guiObj->editorType = $cfg['type'];
 
-  $guiObj->itemQty = count($guiObj->tprojects);
+  $guiObj->itemQty = count((array)$guiObj->tprojects);
 
   if($guiObj->itemQty > 0) {
     $guiObj->pageTitle .= ' ' . sprintf(lang_get('available_test_projects'),$guiObj->itemQty);

--- a/lib/reqmgrsystemintegration/reqMgrSystemInterface.class.php
+++ b/lib/reqmgrsystemintegration/reqMgrSystemInterface.class.php
@@ -152,7 +152,7 @@ abstract class reqMgrSystemInterface
     $this->lastproject = null;
     $this->lastbaseline = null;
     
-    if (count($this->projects) == 0)
+    if (count((array)$this->projects) == 0)
     {
       // No projects were found.
       return false;
@@ -168,7 +168,7 @@ abstract class reqMgrSystemInterface
       return false ;
     }
     
-    if (($project != $this->lastproject) || (count($this->baselines) == 0) || $refresh)
+    if (($project != $this->lastproject) || (count((array)$this->baselines) == 0) || $refresh)
     {
       // Retrieve baselines for the specified project.
       $this->lastproject = $project;

--- a/lib/requirements/reqCommands.class.php
+++ b/lib/requirements/reqCommands.class.php
@@ -545,7 +545,7 @@ class reqCommands {
     $my['filters'] = array('exclude_node_types' => $exclude_node_types);
     $my['options']['order_cfg']['type'] = $my['options']['output'] = 'rspec';
     $subtree = $this->reqMgr->tree_mgr->get_subtree($argsObj->tproject_id,$my['filters'],$my['options']);
-    if(count($subtree))
+    if(count((array)$subtree))
     {
       $obj->containers = $this->reqMgr->tree_mgr->createHierarchyMap($subtree,'dotted',array('field' => 'doc_id','format' => '%s:'));
     }
@@ -671,7 +671,7 @@ class reqCommands {
     }
     
     $other_req = $this->reqMgr->getByDocID($argsObj->relation_destination_req_doc_id, $tproject_id);
-    if (count($other_req) < 1) {
+    if (count((array)$other_req) < 1) {
       // req doc ID was not ok
       $op['ok'] = false;
       $op['msg'] = lang_get('rel_add_error_dest_id');

--- a/lib/requirements/reqCompareVersions.php
+++ b/lib/requirements/reqCompareVersions.php
@@ -76,7 +76,7 @@ if ($args->compare_selected_versions)
       $gui->diff[$key]["right"] = explode("\n", str_replace("</p>", "</p>\n", $sbs['right_item'][$key]));
 	  $gui->diff[$key]["diff"] = $differ->inline($gui->diff[$key]["left"], $gui->leftID, 
                                                   $gui->diff[$key]["right"], $gui->rightID,$args->context);
-      $gui->diff[$key]["count"] = count($differ->changes);
+      $gui->diff[$key]["count"] = count((array)$differ->changes);
     }
     
     $gui->diff[$key]["heading"] = lang_get($key);
@@ -134,7 +134,7 @@ function getItemsToCompare($leftSideID,$rightSideID,&$itemSet)
       $ret['right_item'] = $item;
     }
     
-    if( count($ret) == 2 )
+    if( count((array)$ret) == 2 )
     {
       break;
     }
@@ -235,7 +235,7 @@ function getCFDiff($cfields,&$reqMgr)
     }  // foraeach    
   }
 
-  return (null != $cmp && count($cmp) > 0) ? $cmp : null; 
+  return (null != $cmp && count((array)$cmp) > 0) ? $cmp : null; 
 }
 
 
@@ -279,7 +279,7 @@ function initializeGui(&$dbHandler,&$argsObj,$lbl,&$reqMgr)
   // Truncate log message
   if( $reqCfg->log_message_len > 0 )
   { 
-    $loop2do = count($guiObj->items);
+    $loop2do = count((array)$guiObj->items);
     for($idx=0; $idx < $loop2do; $idx++)
     {
       if( strlen($guiObj->items[$idx]['log_message']) > $reqCfg->log_message_len )

--- a/lib/requirements/reqCompareVersions.php
+++ b/lib/requirements/reqCompareVersions.php
@@ -179,7 +179,7 @@ function getCFDiff($cfields,&$reqMgr)
 
   if( !is_null($cfieldsLeft) )
   {
-    $key2loop = array_keys($cfieldsLeft);
+    $key2loop = array_keys((array)$cfieldsLeft);
     $cmp = array();
     $type_code = $reqMgr->cfield_mgr->get_available_types();
     $key2convert = array('lvalue','rvalue');

--- a/lib/requirements/reqCreateFromIssueMantisXML.php
+++ b/lib/requirements/reqCreateFromIssueMantisXML.php
@@ -61,7 +61,7 @@ switch($args->doAction)
     $gui->items = $dummy->items;        
     $gui->file_check = $dummy->file_check;
     $gui->userFeedback = (array)$dummy->userFeedback;
-    if(array_key_exists("syntaxError", $gui->userFeedback) && count($gui->userFeedback['syntaxError']) > 0) 
+    if(array_key_exists("syntaxError", $gui->userFeedback) && count((array)$gui->userFeedback['syntaxError']) > 0) 
     {
       $gui->importResult = lang_get('import_syntax_error');
     } 
@@ -199,7 +199,7 @@ function doReqImportFromMantisXML(&$reqMgr,&$simpleXMLObj,$importContext)
 {
 
   $inputItems = getFromMantisIssueSimpleXMLObj($simpleXMLObj);
-  $loop2do = count($inputItems);
+  $loop2do = count((array)$inputItems);
   for($kdx=0; $kdx < $loop2do; $kdx++)
   {   
     $dummy = $reqMgr->createFromMap($inputItems[$kdx],$importContext->tproject_id,
@@ -227,7 +227,7 @@ function getFromMantisIssueSimpleXMLObj($xmlObj)
 
   $jdx = 0;
   $xmlIssue = $xmlObj->issue;
-  $loops2do=sizeof($xmlIssue);
+  $loops2do=sizeof((array)$xmlIssue);
  
   $XMLDef['elements'] = array('string' => array('summary' => null,'description' => null,
                                                 'additional_information' => null,

--- a/lib/requirements/reqExport.php
+++ b/lib/requirements/reqExport.php
@@ -152,7 +152,7 @@ function doExport(&$argsObj,&$req_spec_mgr)
       switch($argsObj->scope) {
         case 'tree':
           $reqSpecSet = $req_spec_mgr->getFirstLevelInTestProject($argsObj->tproject_id);
-          $reqSpecSet = array_keys($reqSpecSet);
+          $reqSpecSet = array_keys((array)$reqSpecSet);
         break;
           
         case 'branch':

--- a/lib/requirements/reqImport.php
+++ b/lib/requirements/reqImport.php
@@ -39,7 +39,7 @@ switch ($args->doAction) {
     $gui->file_check = $dummy->file_check;
     $gui->userFeedback = (array)$dummy->userFeedback;
     $gui->importResult = lang_get('import_done');
-    if(array_key_exists("syntaxError", $gui->userFeedback) && count($gui->userFeedback['syntaxError']) > 0) {
+    if(array_key_exists("syntaxError", $gui->userFeedback) && count((array)$gui->userFeedback['syntaxError']) > 0) {
       $gui->importResult = lang_get('import_syntax_error');
     }
     $gui->refreshTree = $args->refreshTree && $gui->file_check['status_ok'];  
@@ -283,7 +283,7 @@ function doReqImportFromXML(&$reqSpecMgr,&$reqMgr,&$simpleXMLObj,$importContext,
       $items = array_merge($items,$dummy);
     }
   } else {
-    $loop2do = count($simpleXMLObj->requirement);
+    $loop2do = count((array)$simpleXMLObj->requirement);
     for($kdx=0; $kdx < $loop2do; $kdx++) {   
       $dummy = $reqMgr->createFromXML($simpleXMLObj->requirement[$kdx],$importContext->tproject_id,
           $importContext->req_spec_id,$importContext->user_id,null,$importOptions);
@@ -306,7 +306,7 @@ function doReqImportOther(&$reqMgr,$fileName,$importContext,$importOptions)
   if( !is_null($impSet) )
   { 
     $reqSet = $impSet['info'];
-    if( ($loop2do=count($reqSet)) )
+    if( ($loop2do=count((array)$reqSet)) )
     {
       for($kdx=0; $kdx < $loop2do; $kdx++)
       {   

--- a/lib/requirements/reqMonitorOverview.php
+++ b/lib/requirements/reqMonitorOverview.php
@@ -35,7 +35,7 @@ $cfg = getCfg();
 // manageUserSubscribtion($db,$args);
 $smarty = new TLSmarty();
 
-if(count($gui->reqIDSet) > 0) 
+if(count((array)$gui->reqIDSet) > 0) 
 {
   $pathCache = null;
   $imgSet = $smarty->getImages();
@@ -113,7 +113,7 @@ if(count($gui->reqIDSet) > 0)
 
   // -------------------------------------------------------------------------------------------------- 
   // Construction of EXT-JS table starts here    
-  if(($gui->row_qty = count($rows)) > 0 ) 
+  if(($gui->row_qty = count((array)$rows)) > 0 ) 
   {
        
     /**

--- a/lib/requirements/reqOverview.php
+++ b/lib/requirements/reqOverview.php
@@ -36,7 +36,7 @@ checkRights($db,$args->user,$ctx);
 $gui->reqIDs = $tproject_mgr->get_all_requirement_ids($args->tproject_id);
 
 $smarty = new TLSmarty();
-if(count($gui->reqIDs) > 0)  {
+if(count((array)$gui->reqIDs) > 0)  {
   $chronoStart = microtime(true);
 
   $pathCache = null;
@@ -61,7 +61,7 @@ if(count($gui->reqIDs) > 0)  {
   $labels = init_labels($labels2get);
   
   $gui->cfields4req = (array)$cfield_mgr->get_linked_cfields_at_design($args->tproject_id, 1, null, 'requirement', null, 'name');
-  $gui->processCF = count($gui->cfields4req) > 0;
+  $gui->processCF = count((array)$gui->cfields4req) > 0;
 
 
   $coverageSet = null;
@@ -242,7 +242,7 @@ if(count($gui->reqIDs) > 0)  {
     
   // --------------------------------------------------------------------
   // Construction of EXT-JS table starts here    
-  if(($gui->row_qty = count($rows)) > 0 ) {
+  if(($gui->row_qty = count((array)$rows)) > 0 ) {
     $version_string = ($args->all_versions) ? $labels['number_of_versions'] : $labels['number_of_reqs'];
     $gui->pageTitle .= " - " . $version_string . ": " . $gui->row_qty;
        

--- a/lib/requirements/reqOverview.php
+++ b/lib/requirements/reqOverview.php
@@ -81,7 +81,7 @@ if(count((array)$gui->reqIDs) > 0)  {
   //
   if ( $cfg->req->expected_coverage_management ||
        $gui->processCF )  {
-    $xSet = array_keys($reqSet);
+    $xSet = array_keys((array)$reqSet);
 
     foreach($xSet as $rqID) {
       $reqVersionSet[] = $reqSet[$rqID][0]['version_id'];

--- a/lib/requirements/reqSearch.php
+++ b/lib/requirements/reqSearch.php
@@ -52,7 +52,7 @@ if ($args->tprojectID) {
   $map = (array)$db->fetchRowsIntoMap($sql,'id',database::CUMULATIVE);
 
   // dont show requirements from different testprojects than the selected one
-  if (count($map)) {
+  if (count((array)$map)) {
     $reqIDSet = array_keys($map);
     foreach ($reqIDSet as $item)  {
       $pid = $tproject_mgr->tree_manager->getTreeRoot($item);
@@ -64,7 +64,7 @@ if ($args->tprojectID) {
 }
 
 $smarty = new TLSmarty();
-$gui->row_qty = count($map);
+$gui->row_qty = count((array)$map);
 if($gui->row_qty > 0) {
   $gui->resultSet = $map;
   if($gui->row_qty <= $req_cfg->search->max_qty_for_display) {
@@ -122,7 +122,7 @@ function buildExtTable($gui, $charset) {
   //
   //
 
-  if(count($gui->resultSet) > 0) {
+  if(count((array)$gui->resultSet) > 0) {
     $columns = array();
     
     $columns[] = array('title_key' => 'req_spec');

--- a/lib/requirements/reqSearch.php
+++ b/lib/requirements/reqSearch.php
@@ -53,7 +53,7 @@ if ($args->tprojectID) {
 
   // dont show requirements from different testprojects than the selected one
   if (count((array)$map)) {
-    $reqIDSet = array_keys($map);
+    $reqIDSet = array_keys((array)$map);
     foreach ($reqIDSet as $item)  {
       $pid = $tproject_mgr->tree_manager->getTreeRoot($item);
       if ($pid != $args->tprojectID) {
@@ -68,7 +68,7 @@ $gui->row_qty = count((array)$map);
 if($gui->row_qty > 0) {
   $gui->resultSet = $map;
   if($gui->row_qty <= $req_cfg->search->max_qty_for_display) {
-    $req_set = array_keys($map);
+    $req_set = array_keys((array)$map);
     $options = array('output_format' => 'path_as_string');
     $gui->path_info = 
       $tproject_mgr->tree_manager->get_full_path_verbose($req_set,$options);
@@ -131,7 +131,7 @@ function buildExtTable($gui, $charset) {
     // Extract the relevant data and build a matrix
     $matrixData = array();
     
-    $key2loop = array_keys($gui->resultSet);
+    $key2loop = array_keys((array)$gui->resultSet);
     $img = "<img title=\"{$labels['edit']}\" src=\"{$edit_icon}\" />";
     // req_id, req_version_id
     $reqVerHref = '<a href="javascript:openLinkedReqVersionWindow(%s,%s)">' . $labels['version_revision_tag'] . ' </a>'; 

--- a/lib/requirements/reqSpecCommands.class.php
+++ b/lib/requirements/reqSpecCommands.class.php
@@ -436,7 +436,7 @@ class reqSpecCommands
     $my['filters'] = array('exclude_node_types' => $exclude_node_types);
     $my['options']['order_cfg']['type'] = $my['options']['output'] = 'rspec';
     $subtree = $this->reqMgr->tree_mgr->get_subtree($argsObj->tproject_id,$my['filters'],$my['options']);
-    if(count($subtree))
+    if(count((array)$subtree))
     {
       $obj->containers = $this->reqMgr->tree_mgr->createHierarchyMap($subtree,'dotted',array('field' => 'doc_id','format' => '%s:'));
     }
@@ -520,7 +520,7 @@ class reqSpecCommands
     $root = $this->treeMgr->get_node_hierarchy_info($argsObj->tproject_id);
     $subtree = array_merge(array($root),$this->treeMgr->get_subtree($argsObj->tproject_id,$my['filters']));
 
-    if(count($subtree))
+    if(count((array)$subtree))
     {
       $obj->containers = $this->treeMgr->createHierarchyMap($subtree);
     }
@@ -575,7 +575,7 @@ class reqSpecCommands
     $root = $this->treeMgr->get_node_hierarchy_info($argsObj->tproject_id);
     $subtree = array_merge(array($root),$this->treeMgr->get_subtree($argsObj->tproject_id,$my['filters']));
 
-    if(count($subtree))
+    if(count((array)$subtree))
     {
       $obj->containers = $this->treeMgr->createHierarchyMap($subtree);
     }
@@ -594,7 +594,7 @@ class reqSpecCommands
     $childNodes = isset($req_spec['childNodes']) ? $req_spec['childNodes'] : null ;
     if( !is_null($childNodes)) 
     {
-      $loop_qty=sizeof($childNodes); 
+      $loop_qty=sizeof((array)$childNodes); 
       for($idx = 0;$idx < $loop_qty;$idx++) 
       {
         $cNode = $childNodes[$idx];

--- a/lib/requirements/reqSpecCompareRevisions.php
+++ b/lib/requirements/reqSpecCompareRevisions.php
@@ -165,7 +165,7 @@ function getCFDiff($cfields,&$itemMgr)
 	$cfieldsRight = $cfields['right_side']['value'];
 	if( !is_null($cfieldsLeft) )
 	{
-		$key2loop = array_keys($cfieldsLeft);
+		$key2loop = array_keys((array)$cfieldsLeft);
 		$cmp = array();
 		$type_code = $itemMgr->cfield_mgr->get_available_types();
 		$key2convert = array('lvalue','rvalue');

--- a/lib/requirements/reqSpecCompareRevisions.php
+++ b/lib/requirements/reqSpecCompareRevisions.php
@@ -69,7 +69,7 @@ if ($args->doCompare)
 		
 			$gui->diff[$key]["diff"] = $differ->inline($gui->diff[$key]["left"], $gui->leftID, 
 			                                            $gui->diff[$key]["right"], $gui->rightID,$args->context);
-			$gui->diff[$key]["count"] = count($differ->changes);
+			$gui->diff[$key]["count"] = count((array)$differ->changes);
 		}
 		
 		$gui->diff[$key]["heading"] = lang_get($key);
@@ -114,7 +114,7 @@ function getItemsToCompare($leftSideID,$rightSideID,&$itemSet)
 			$ret['right_item'] = $item;
 		}
 		
-		if( count($ret) == 2 )
+		if( count((array)$ret) == 2 )
 		{
 			break;
 		}
@@ -214,7 +214,7 @@ function getCFDiff($cfields,&$itemMgr)
 			} // mega if
 		}  // foraeach		
 	}
-	return count($cmp) > 0 ? $cmp : null;	
+	return count((array)$cmp) > 0 ? $cmp : null;	
 }
 
 
@@ -261,7 +261,7 @@ function initializeGui(&$dbHandler,&$argsObj,$lbl,&$itemMgr)
 	// Truncate log message
 	if( $reqSpecCfg->log_message_len > 0 )
 	{	
-		$loop2do = count($guiObj->items);
+		$loop2do = count((array)$guiObj->items);
 		for($idx=0; $idx < $loop2do; $idx++)
 		{
 			if( strlen($guiObj->items[$idx]['log_message']) > $reqSpecCfg->log_message_len )

--- a/lib/requirements/reqSpecPrint.php
+++ b/lib/requirements/reqSpecPrint.php
@@ -68,7 +68,7 @@ if( !is_null($childrenReq) && $req_cfg->show_child_reqs_on_reqspec_print_view)
                  		  'displayLastEdit' => 1, 'docType' => SINGLE_REQ);
 
 	$text2print .= '<div><h2>' . lang_get('reqs') . '</h2></div>';
-	$loop2do = count($childrenReq);
+	$loop2do = count((array)$childrenReq);
 	for($rdx=0; $rdx < $loop2do; $rdx++)
 	{
 		$text2print .= renderReqForPrinting($db,$childrenReq[$rdx],$reqPrintOpts,

--- a/lib/requirements/reqSpecSearch.php
+++ b/lib/requirements/reqSpecSearch.php
@@ -119,7 +119,7 @@ if($gui->row_qty > 0)
   $gui->resultSet = $itemSet;
   if($gui->row_qty <= $req_cfg->search->max_qty_for_display)
   {
-    $req_set=array_keys($itemSet);
+    $req_set=array_keys((array)$itemSet);
     $options = array('output_format' => 'path_as_string');
     $gui->path_info=$tproject_mgr->tree_manager->get_full_path_verbose($req_set, $options);
   }
@@ -171,7 +171,7 @@ function buildExtTable($gui, $charset)
     $columns[] = array('title_key' => 'req_spec', 'type' => 'text', 'groupable' => 'false', 
                        'hideable' => 'false');
   
-    $key2loop = array_keys($gui->resultSet);
+    $key2loop = array_keys((array)$gui->resultSet);
     foreach($key2loop as $rspec_id)
     {
       $rowData = array();

--- a/lib/requirements/reqSpecSearch.php
+++ b/lib/requirements/reqSpecSearch.php
@@ -113,7 +113,7 @@ if ($args->tprojectID)
 }
 
 $smarty = new TLSmarty();
-$gui->row_qty=count($itemSet);
+$gui->row_qty=count((array)$itemSet);
 if($gui->row_qty > 0)
 {
   $gui->resultSet = $itemSet;
@@ -164,7 +164,7 @@ function buildExtTable($gui, $charset)
   // }
   //
   //
-  if(count($gui->resultSet) > 0) 
+  if(count((array)$gui->resultSet) > 0) 
   {
     $matrixData = array();
     $columns = array();

--- a/lib/requirements/reqTcAssign.php
+++ b/lib/requirements/reqTcAssign.php
@@ -202,7 +202,7 @@ function doBulkAssignment(&$dbHandler,&$argsObj,$targetTestCaseSet = null)
 {
   $req_mgr = new requirement_mgr($dbHandler);
   $assignmentCounter = 0;
-  $requirements = array_keys($argsObj->reqIdSet);
+  $requirements = array_keys((array)$argsObj->reqIdSet);
   if(!is_null($requirements) && count((array)$requirements) > 0)
   {
     $tcase_set = $targetTestCaseSet;
@@ -233,11 +233,11 @@ function doSingleTestCaseOperation(&$dbHandler,&$argsObj,&$guiObj,$pfn) {
 
   switch($pfn) {
     case 'assign_to_tcase':
-      $items = array_keys($argsObj->reqIdSet);
+      $items = array_keys((array)$argsObj->reqIdSet);
     break;
 
     case 'delReqVersionTCVersionLinkByID':
-      $items = array_keys($argsObj->link_id);
+      $items = array_keys((array)$argsObj->link_id);
     break;
   }
 

--- a/lib/requirements/reqTcAssign.php
+++ b/lib/requirements/reqTcAssign.php
@@ -39,7 +39,7 @@ switch($args->doAction) {
       $bulkCounter = 0;
       $bulkDone = true;
       $args->edit = 'testsuite';
-      if( !is_null($tcase_set) && count($tcase_set) > 0 ) {
+      if( !is_null($tcase_set) && count((array)$tcase_set) > 0 ) {
         $bulkCounter = doBulkAssignment($db,$args,$tcase_set);
       }
     break;  
@@ -159,7 +159,7 @@ function processTestSuite(&$dbHandler,&$argsObj,&$guiObj) {
   $guiObj->tcase_number = 0;
   $guiObj->has_req_spec = false;
 
-  if(!is_null($guiObj->req_specs) && count($guiObj->req_specs)) {  
+  if(!is_null($guiObj->req_specs) && count((array)$guiObj->req_specs)) {  
     $guiObj->has_req_spec = true;
        
     if(is_null($argsObj->idReqSpec)) {
@@ -182,7 +182,7 @@ function processTestSuite(&$dbHandler,&$argsObj,&$guiObj) {
 
 
     $tcase_set = getTargetTestCases($dbHandler,$argsObj);
-    $guiObj->tcase_number = count($tcase_set);            
+    $guiObj->tcase_number = count((array)$tcase_set);            
     if( $guiObj->tcase_number > 0 ) {
       $guiObj->bulkassign_warning_msg = 
         sprintf(lang_get('bulk_req_assign_msg'),$guiObj->tcase_number,$tsuite_info['name']);
@@ -203,7 +203,7 @@ function doBulkAssignment(&$dbHandler,&$argsObj,$targetTestCaseSet = null)
   $req_mgr = new requirement_mgr($dbHandler);
   $assignmentCounter = 0;
   $requirements = array_keys($argsObj->reqIdSet);
-  if(!is_null($requirements) && count($requirements) > 0)
+  if(!is_null($requirements) && count((array)$requirements) > 0)
   {
     $tcase_set = $targetTestCaseSet;
     if( is_null($tcase_set) )
@@ -212,7 +212,7 @@ function doBulkAssignment(&$dbHandler,&$argsObj,$targetTestCaseSet = null)
       $tcase_set = $tsuite_mgr->get_testcases_deep($argsObj->id,'only_id');
     }
 
-    if( !is_null($tcase_set) && count($tcase_set) )
+    if( !is_null($tcase_set) && count((array)$tcase_set) )
     {
       // $assignmentCounter = $req_mgr->bulk_assignment($requirements,$tcase_set,$argsObj->user->dbID);
 
@@ -241,7 +241,7 @@ function doSingleTestCaseOperation(&$dbHandler,&$argsObj,&$guiObj,$pfn) {
     break;
   }
 
-  if( count($items) == 0 ) {
+  if( count((array)$items) == 0 ) {
     $guiObj->user_feedback = lang_get('req_msg_noselect');
     return $guiObj;
   }
@@ -285,11 +285,11 @@ function doSingleTestCaseOperation(&$dbHandler,&$argsObj,&$guiObj,$pfn) {
  */
 function array_diff_byId($arrAll, $arrPart) {
 
-  if (is_null($arrAll) || !count($arrAll)) {
+  if (is_null($arrAll) || !count((array)$arrAll)) {
     return null;
   }
 
-  if (is_null($arrPart) || !count($arrPart)) {
+  if (is_null($arrPart) || !count((array)$arrPart)) {
     return $arrAll;
   }
 
@@ -315,7 +315,7 @@ function array_diff_byId($arrAll, $arrPart) {
 function processTestCase(&$dbHandler,&$argsObj,&$guiObj) {
   $tproject_mgr = new testproject($dbHandler);
   $guiObj->arrReqSpec = $tproject_mgr->genComboReqSpec($argsObj->tproject_id,'dotted',"&nbsp;");
-  $SRS_qty = count($guiObj->arrReqSpec);
+  $SRS_qty = count((array)$guiObj->arrReqSpec);
   
   if($SRS_qty > 0) {
     $tc_mgr = new testcase($dbHandler);

--- a/lib/requirements/reqView.php
+++ b/lib/requirements/reqView.php
@@ -114,7 +114,7 @@ function initialize_gui(&$dbHandler,$argsObj,&$tproject_mgr,&$req_mgr) {
 
   // 2018 $gui->req_coverage = $req_mgr->get_coverage($gui->req_id);  
   // This need to become an array.
-  $loop2do = count($gui->req_versions);
+  $loop2do = count((array)$gui->req_versions);
   $gui->current_req_coverage = array();
   $gui->other_req_coverage = array();
   for($cvx = 0 ; $cvx < $loop2do; $cvx++) {
@@ -150,7 +150,7 @@ function initialize_gui(&$dbHandler,$argsObj,&$tproject_mgr,&$req_mgr) {
     $req_mgr->getFileUploadRelativeURL($gui->req_id, $gui->req_version_id);
 
   $gui->log_target = null;
-  $loop2do = count($gui->req_versions);
+  $loop2do = count((array)$gui->req_versions);
   for($rqx = 0; $rqx < $loop2do; $rqx++) {
     $gui->log_target[] = ($gui->req_versions[$rqx]['revision_id'] > 0) ?  $gui->req_versions[$rqx]['revision_id'] :  
                           $gui->req_versions[$rqx]['version_id'];
@@ -170,9 +170,9 @@ function initialize_gui(&$dbHandler,$argsObj,&$tproject_mgr,&$req_mgr) {
   // Now CF for other Versions
   $gui->other_versions[0] = null;
   $gui->cfields_other_versions[] = null;
-  if( count($gui->req_versions) > 1 ) {
+  if( count((array)$gui->req_versions) > 1 ) {
     $gui->other_versions[0] = array_slice($gui->req_versions,1);
-    $loop2do = count($gui->other_versions[0]);
+    $loop2do = count((array)$gui->other_versions[0]);
     for($qdx=0; $qdx < $loop2do; $qdx++) {
       $target_version = $gui->other_versions[0][$qdx]['version_id'];
       $gui->cfields_other_versions[0][$qdx]= 
@@ -195,7 +195,7 @@ function initialize_gui(&$dbHandler,$argsObj,&$tproject_mgr,&$req_mgr) {
   
   if( $gui->showAllVersions ) {
     $versionSet = array();
-    $loop2do = count($gui->req_versions);    
+    $loop2do = count((array)$gui->req_versions);    
     for( $ggx=0; $ggx < $loop2do; $ggx++ ) {
       $versionSet[] = intval($gui->req_versions[$ggx]['version_id']);
     }

--- a/lib/results/baselinel1l2.php
+++ b/lib/results/baselinel1l2.php
@@ -217,7 +217,7 @@ function initializeGui(&$dbHandler,$argsObj,&$tplanMgr) {
     natsort($gui->platformSet);
   }
 
-  $gui->hasPlatforms = count($gui->platformSet) >= 1 && 
+  $gui->hasPlatforms = count((array)$gui->platformSet) >= 1 && 
                        !isset($gui->platformSet[0]);
 
   return $gui;
@@ -280,7 +280,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
                       'tcQtyKey' => 'total_assigned',
                       'source' => &$gui->statistics->overallBuildStatus);
 
-  $startingRow = count($lines2write); // MAGIC
+  $startingRow = count((array)$lines2write); // MAGIC
   foreach( $oneLevel as $target ) {
     $entity = $target['entity'];
     $dimension = $target['dimension'];
@@ -379,7 +379,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
     $nameKey = $target['nameKey'];
     $tcQtyKey = $target['tcQtyKey'];
 
-    if( count($target['source']) == 0 ) {
+    if( count((array)$target['source']) == 0 ) {
       continue;
     }
 
@@ -571,7 +571,7 @@ function initStyleSpreadsheet() {
  */
 function setCellRangeSpreadsheet() {
   $cr = range('A','Z');
-  $crLen = count($cr);
+  $crLen = count((array)$cr);
   for($idx = 0; $idx < $crLen; $idx++) {
     for($jdx = 0; $jdx < $crLen; $jdx++) {
       $cr[] = $cr[$idx] . $cr[$jdx];

--- a/lib/results/charts.php
+++ b/lib/results/charts.php
@@ -44,7 +44,7 @@ if($gui->can_use_charts == 'OK')
     									                   "&tproject_id=$args->tproject_id";
     
     $platformSet = $tplan_mgr->getPlatforms($gui->tplan_id,array('outputFormat' => 'map'));
-    $platformIDSet = is_null($platformSet) ? array(0) : array_keys($platformSet);
+    $platformIDSet = is_null($platformSet) ? array(0) : array_keys((array)$platformSet);
 
     $gui->charts = array($l18n['overall_metrics'] => $chartsUrl->overallPieChart);
     if(!is_null($platformSet))

--- a/lib/results/execTimelineStats.php
+++ b/lib/results/execTimelineStats.php
@@ -186,7 +186,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr)
 
   $objPHPExcel = new \PhpOffice\PhpSpreadsheet\Spreadsheet();
   $lines2write = xlsStepOne($objPHPExcel,$style,$lbl,$gui);
-  $startingRow = count($lines2write); // MAGIC
+  $startingRow = count((array)$lines2write); // MAGIC
   $dataHeader = array();
   foreach( $dataHeaderMetrics as $val ) {
     $dataHeader[] = $val;
@@ -322,7 +322,7 @@ function initStyleSpreadsheet() {
  */
 function setCellRangeSpreadsheet() {
   $cr = range('A','Z');
-  $crLen = count($cr);
+  $crLen = count((array)$cr);
   for($idx = 0; $idx < $crLen; $idx++) {
     for($jdx = 0; $jdx < $crLen; $jdx++) {
       $cr[] = $cr[$idx] . $cr[$jdx];

--- a/lib/results/freeTestCases.php
+++ b/lib/results/freeTestCases.php
@@ -66,7 +66,7 @@ if(!is_null($gui->freeTestCases['items']))
   	{
         $msg_key = '';    
         $tcasePrefix = $tproject_mgr->getTestCasePrefix($args->tproject_id) . $tcase_cfg->glue_character;
-        $tcaseSet = array_keys($gui->freeTestCases['items']);
+        $tcaseSet = array_keys((array)$gui->freeTestCases['items']);
         $tsuites = $tproject_mgr->tree_manager->get_full_path_verbose($tcaseSet,
         															  array('output_format' => 'path_as_string'));
   	    unset($tcaseSet);

--- a/lib/results/keywordBarChart.php
+++ b/lib/results/keywordBarChart.php
@@ -56,7 +56,7 @@ function getDataAndScale(&$dbHandler,$argsObj)
   if( !is_null($dummy) )    
   {
     $dataSet = $dummy->info;
-    $obj->canDraw = !is_null($dataSet) && (count($dataSet) > 0);
+    $obj->canDraw = !is_null($dataSet) && (count((array)$dataSet) > 0);
   }
   
   if($obj->canDraw)
@@ -91,7 +91,7 @@ function getDataAndScale(&$dbHandler,$argsObj)
   if(!is_null($totals))
   {
     // in this array position we will find minimun value after an rsort
-    $minPos = count($dataSet)-1;
+    $minPos = count((array)$dataSet)-1;
     $obj->scale->maxY = 0;
     $obj->scale->minY = 0;
     

--- a/lib/results/metricsDashboard.php
+++ b/lib/results/metricsDashboard.php
@@ -166,7 +166,7 @@ function getMetrics(&$db,$userObj,$args, $result_cfg, $labels)
 
   // Get count of testcases linked to every testplan
   // Hmm Count active and inactive ?
-  $linkedItemsQty = $tplan_mgr->count_testcases(array_keys($test_plans),null,array('output' => 'groupByTestPlan'));
+  $linkedItemsQty = $tplan_mgr->count_testcases(array_keys((array)$test_plans),null,array('output' => 'groupByTestPlan'));
   
   
   $metricsMgr = new tlTestPlanMetrics($db);

--- a/lib/results/metricsDashboard.php
+++ b/lib/results/metricsDashboard.php
@@ -31,7 +31,7 @@ list($gui->tplan_metrics,$gui->show_platforms, $platforms) = getMetrics($db,$_SE
 
 
 // new dBug($gui->tplan_metrics);
-if(count($gui->tplan_metrics) > 0) 
+if(count((array)$gui->tplan_metrics) > 0) 
 {
   $statusSetForDisplay = $result_cfg['status_label_for_exec_ui']; 
   $gui->warning_msg = '';

--- a/lib/results/neverRunByPP.php
+++ b/lib/results/neverRunByPP.php
@@ -59,7 +59,7 @@ if( $args->doAction == 'result' ) {
 }
 
 if( $args->doAction == 'result' && 
-  !is_null($metrics) and count($metrics) > 0 ) {              
+  !is_null($metrics) and count((array)$metrics) > 0 ) {              
 
   $doIt = true;
   $doChoice = false;
@@ -264,7 +264,7 @@ function initializeGui(&$dbh,&$argsObj,&$tplanMgr) {
   $guiObj->platformSet = $tplanMgr->getPlatforms($argsObj->tplan_id,$getOpt);
   
   $guiObj->show_platforms = true;
-  $pqy = count($guiObj->platformSet);
+  $pqy = count((array)$guiObj->platformSet);
   if( $pqy == 0 || ($pqy == 1) && isset($guiObj->platformSet[0])){
     $guiObj->show_platforms = false;
   }
@@ -406,7 +406,7 @@ function createSpreadsheet($gui,$args,$media) {
     $dataHeader[] = $lbl['platform'];
   }
 
-  $startingRow = count($lines2write) + 2; // MAGIC
+  $startingRow = count((array)$lines2write) + 2; // MAGIC
   $cellArea = "A{$startingRow}:";
   foreach($dataHeader as $zdx => $field) {
     $cellID = $cellRange[$zdx] . $startingRow; 
@@ -420,7 +420,7 @@ function createSpreadsheet($gui,$args,$media) {
   // Now process data  
   $colorChangeCol = 1;
   $startingRow++;
-  $qta_loops = count($gui->dataSet);
+  $qta_loops = count((array)$gui->dataSet);
   $val4color = $gui->dataSet[0][$colorChangeCol];
   for($idx = 0; $idx < $qta_loops; $idx++) {
     $line2write = $gui->dataSet[$idx];

--- a/lib/results/neverRunByPP.php
+++ b/lib/results/neverRunByPP.php
@@ -82,7 +82,7 @@ if( $args->doAction == 'result' &&
       $du = $tcase_mgr->getPathLayered(array($elem['tcase_id']));  
       $pathCache[$elem['tcase_id']] = $du[$elem['tsuite_id']]['value'];
       $levelCache[$elem['tcase_id']] = $du[$elem['tsuite_id']]['level'];
-      $ky = current(array_keys($du)); 
+      $ky = current(array_keys((array)$du)); 
       $topCache[$elem['tcase_id']] = $ky;
     }
    

--- a/lib/results/printDocOptions.php
+++ b/lib/results/printDocOptions.php
@@ -210,7 +210,7 @@ function initializeGui(&$db,$args) {
 
   $gui->outputOptions = init_checkboxes($args);
   if($gui->showOptions == false) {
-    $loop2do = count($gui->outputOptions);
+    $loop2do = count((array)$gui->outputOptions);
     for($idx = 0; $idx < $loop2do; $idx++) {
       $gui->outputOptions[$idx]['checked'] = 'y';
     }  

--- a/lib/results/printDocument.php
+++ b/lib/results/printDocument.php
@@ -95,7 +95,7 @@ switch ($doc_info->type) {
     // Changed to get ALL platform attributes.
     $getOpt = array('outputFormat' => 'mapAccessByID', 'addIfNull' => true);
     $platforms = $tplan_mgr->getPlatforms($args->tplan_id,$getOpt);   
-    $platformIDSet = array_keys($platforms);
+    $platformIDSet = array_keys((array)$platforms);
 
     $printingOptions['priority'] = $doc_info->test_priority_enabled;
     $items2use = (object) array('estimatedExecTime' => null,'realExecTime' => null);
@@ -515,10 +515,10 @@ function getStatsRealExecTime(&$tplanMgr,&$lastExecBy,$context,$decode) {
   
   if( !is_null($lastExecBy) && count((array)$lastExecBy) > 0 ) {
     // divide execution by Platform ID
-    $p2loop = array_keys($lastExecBy);
+    $p2loop = array_keys((array)$lastExecBy);
     foreach($p2loop as $platfID) {                    
       if( !is_null($lastExecBy[$platfID]) ) {
-        $i2loop = array_keys($lastExecBy[$platfID]);  
+        $i2loop = array_keys((array)$lastExecBy[$platfID]);  
         $items2use[$platfID] = null;
         foreach($i2loop as $xdx) {
           $info = &$lastExecBy[$platfID][$xdx]; 
@@ -677,7 +677,7 @@ function buildContentForTestPlanBranch(&$dbHandler,$itemsTree,$ctx,&$docInfo,$de
     
     $avalon = $tplanMgr->getLTCVNewGeneration($tplanID, $filters, $getLTCVOpt); 
     if(!is_null($avalon)) {
-      $k2l = array_keys($avalon);
+      $k2l = array_keys((array)$avalon);
       foreach($k2l as $key) {
         $linkedBy[$platform_id][$key] = $avalon[$key][$platform_id];
       } 
@@ -688,7 +688,7 @@ function buildContentForTestPlanBranch(&$dbHandler,$itemsTree,$ctx,&$docInfo,$de
     // After architecture changes on how CF design values for Test Cases are
     // managed, we need the test case version ID and not test case ID
     // In addition if we loop over Platforms we need to save this set each time!!!
-    $items2loop = !is_null($linkedBy[$platform_id]) ? array_keys($linkedBy[$platform_id]) : null;
+    $items2loop = !is_null($linkedBy[$platform_id]) ? array_keys((array)$linkedBy[$platform_id]) : null;
     if( !is_null($items2loop) ) { 
       foreach($items2loop as $rdx) {  
         $metrics->estimatedExecTime[$platform_id][] = $linkedBy[$platform_id][$rdx]['tcversion_id'];

--- a/lib/results/printDocument.php
+++ b/lib/results/printDocument.php
@@ -190,7 +190,7 @@ if ($treeForPlatform) {
   foreach ($treeForPlatform as $platform_id => $tree2work) {
     $actionContext['platform_id'] = $platform_id;
 
-    if(isset($tree2work['childNodes']) && sizeof($tree2work['childNodes']) > 0) {
+    if(isset($tree2work['childNodes']) && sizeof((array)$tree2work['childNodes']) > 0) {
       $tree2work['name'] = $args->tproject_name;
       $tree2work['id'] = $args->tproject_id;
       $tree2work['node_type_id'] = $decode['node_descr_id']['testproject'];
@@ -513,7 +513,7 @@ function getStatsRealExecTime(&$tplanMgr,&$lastExecBy,$context,$decode) {
   $executed_qty = 0;
   $items2use = array();
   
-  if( !is_null($lastExecBy) && count($lastExecBy) > 0 ) {
+  if( !is_null($lastExecBy) && count((array)$lastExecBy) > 0 ) {
     // divide execution by Platform ID
     $p2loop = array_keys($lastExecBy);
     foreach($p2loop as $platfID) {                    

--- a/lib/results/resultsBugs.php
+++ b/lib/results/resultsBugs.php
@@ -112,7 +112,7 @@ foreach ($testcase_bugs as &$row)
 }
 $arrData = array_values($testcase_bugs);
 
-if(count($arrData) > 0) 
+if(count((array)$arrData) > 0) 
 {
   // Create column headers
   $columns = getColumnsDefinition();
@@ -148,10 +148,10 @@ else
   $gui->warning_msg = $l18n['no_linked_bugs'];
 }
 
-$totalOpenBugs = count($openBugs);
-$totalResolvedBugs = count($resolvedBugs);
+$totalOpenBugs = count((array)$openBugs);
+$totalResolvedBugs = count((array)$resolvedBugs);
 $totalBugs = $totalOpenBugs + $totalResolvedBugs;
-$totalCasesWithBugs = count($arrData);
+$totalCasesWithBugs = count((array)$arrData);
 
 $gui->user = $args->user;
 $gui->printDate = '';

--- a/lib/results/resultsByStatus.php
+++ b/lib/results/resultsByStatus.php
@@ -72,7 +72,7 @@ if (!is_null($metrics) and count((array)$metrics) > 0) {
   if( $args->type != $statusCode['not_run'] ) {
     // get Custom fields definition to understand columns to be added
     $cfSet = $tcase_mgr->cfield_mgr->get_linked_cfields_at_execution($args->tproject_id,true,'testcase');
-    $execSet = array_keys($metrics);
+    $execSet = array_keys((array)$metrics);
 
 
     // go for Custom fields values of all executions on ONE SHOT!
@@ -87,7 +87,7 @@ if (!is_null($metrics) and count((array)$metrics) > 0) {
       $dummy = $tcase_mgr->getPathLayered(array($exec['tcase_id']));  
       $pathCache[$exec['tcase_id']] = $dummy[$exec['tsuite_id']]['value'];
       $levelCache[$exec['tcase_id']] = $dummy[$exec['tsuite_id']]['level'];
-      $ky = current(array_keys($dummy)); 
+      $ky = current(array_keys((array)$dummy)); 
       $topCache[$exec['tcase_id']] = $ky;
     }
     

--- a/lib/results/resultsByStatus.php
+++ b/lib/results/resultsByStatus.php
@@ -49,7 +49,7 @@ $cfOnExec = $cfSet = null;
 
 // done here in order to get some config about images
 $smarty = new TLSmarty();
-if (!is_null($metrics) and count($metrics) > 0) {              
+if (!is_null($metrics) and count((array)$metrics) > 0) {              
   if ($args->addOpAccess) {  
     $links = featureLinks($labels,$smarty->getImages());
   }  
@@ -247,7 +247,7 @@ if (!is_null($metrics) and count($metrics) > 0) {
       if($gui->bugInterfaceOn && $exec['status'] != $statusCode['not_run']) 
       {
         $bugSet = get_bugs_for_exec($db, $its, $exec['executions_id'],array('id','summary'));
-        if (count($bugSet) == 0) 
+        if (count((array)$bugSet) == 0) 
         {
           $gui->without_bugs_counter += 1;
         }
@@ -450,7 +450,7 @@ function initializeGui(&$dbh,&$argsObj,&$tplanMgr)
   // needed to decode
   $getOpt = ['outputFormat' => 'map'];
   $guiObj->platformSet = (array)$tplanMgr->getPlatforms($argsObj->tplan_id,$getOpt);  
-  $guiObj->show_platforms = count($guiObj->platformSet);
+  $guiObj->show_platforms = count((array)$guiObj->platformSet);
   // 
 
   $guiObj->its = null;  // Issue Tracker System
@@ -783,7 +783,7 @@ function createSpreadsheet($gui,$args,$media,$customFieldColumns=null)
     $dataHeader[] = $lbl['th_bugs_id_summary'];
   }  
 
-  $startingRow = count($lines2write) + 2; // MAGIC
+  $startingRow = count((array)$lines2write) + 2; // MAGIC
   $cellArea = "A{$startingRow}:";
   foreach($dataHeader as $zdx => $field) {
     $cellID = $cellRange[$zdx] . $startingRow; 
@@ -796,7 +796,7 @@ function createSpreadsheet($gui,$args,$media,$customFieldColumns=null)
 
   // Now process data  
   $startingRow++;
-  $qta_loops = count($gui->dataSet);
+  $qta_loops = count((array)$gui->dataSet);
   for ($idx = 0; $idx < $qta_loops; $idx++) {
     $line2write = $gui->dataSet[$idx];
     $colCounter = 0; 

--- a/lib/results/resultsByTSuite.php
+++ b/lib/results/resultsByTSuite.php
@@ -70,7 +70,7 @@ if(is_null($tsInf)) {
 
   // reorder data according test suite name
   natcasesort($tsInf->idNameMap);
-  $sortedKeys = array_keys($tsInf->idNameMap);
+  $sortedKeys = array_keys((array)$tsInf->idNameMap);
   $gui->dataByPlatform = new stdClass();
   $gui->dataByPlatform->testsuites = array();
   foreach ($gui->statistics->testsuites as $platId => $elem) {

--- a/lib/results/resultsByTSuite.php
+++ b/lib/results/resultsByTSuite.php
@@ -194,7 +194,7 @@ function initializeGui(&$dbHandler,$argsObj,&$tplanMgr) {
   $gui->mailFeedBack = new stdClass();
   $gui->mailFeedBack->msg = '';
 
-  $gui->hasPlatforms = count($gui->platformSet) >= 1 && 
+  $gui->hasPlatforms = count((array)$gui->platformSet) >= 1 && 
                        !isset($gui->platformSet[0]);
 
   return $gui;
@@ -257,7 +257,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
                       'tcQtyKey' => 'total_assigned',
                       'source' => &$gui->statistics->overallBuildStatus);
 
-  $startingRow = count($lines2write); // MAGIC
+  $startingRow = count((array)$lines2write); // MAGIC
   foreach( $oneLevel as $target ) {
     $entity = $target['entity'];
     $dimension = $target['dimension'];
@@ -356,7 +356,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
     $nameKey = $target['nameKey'];
     $tcQtyKey = $target['tcQtyKey'];
 
-    if( count($target['source']) == 0 ) {
+    if( count((array)$target['source']) == 0 ) {
       continue;
     }
 
@@ -548,7 +548,7 @@ function initStyleSpreadsheet() {
  */
 function setCellRangeSpreadsheet() {
   $cr = range('A','Z');
-  $crLen = count($cr);
+  $crLen = count((array)$cr);
   for($idx = 0; $idx < $crLen; $idx++) {
     for($jdx = 0; $jdx < $crLen; $jdx++) {
       $cr[] = $cr[$idx] . $cr[$jdx];

--- a/lib/results/resultsByTesterPerBuild.php
+++ b/lib/results/resultsByTesterPerBuild.php
@@ -140,7 +140,7 @@ $smartTable->toolbarShowAllColumnsButton = true;
 $gui->tableSet = array($smartTable);
 
 // show warning message instead of table if table is empty
-$gui->warning_message = (count($rows) > 0) ? '' : lang_get('no_testers_per_build');
+$gui->warning_message = (count((array)$rows) > 0) ? '' : lang_get('no_testers_per_build');
 
 $smarty = new TLSmarty();
 $smarty->assign('gui',$gui);

--- a/lib/results/resultsGeneral.php
+++ b/lib/results/resultsGeneral.php
@@ -318,7 +318,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
   $oneLevel = array();
 
   // NO PLATFORM => ID=0
-  $hasPlatforms = count($gui->platformSet) >= 1 && 
+  $hasPlatforms = count((array)$gui->platformSet) >= 1 && 
                   !isset($gui->platformSet[0]);
   if( $hasPlatforms ) {
     $oneLevel[] = array('entity' => 'platform', 
@@ -332,7 +332,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
                       'tcQtyKey' => 'total_assigned',
                       'source' => &$gui->statistics->overallBuildStatus);
 
-  $startingRow = count($lines2write); // MAGIC
+  $startingRow = count((array)$lines2write); // MAGIC
   foreach( $oneLevel as $target ) {
     $entity = $target['entity'];
     $dimension = $target['dimension'];
@@ -431,7 +431,7 @@ function createSpreadsheet($gui,$args,&$tplanMgr) {
     $nameKey = $target['nameKey'];
     $tcQtyKey = $target['tcQtyKey'];
 
-    if( count($target['source']) == 0 ) {
+    if( count((array)$target['source']) == 0 ) {
       continue;
     }
 
@@ -623,7 +623,7 @@ function initStyleSpreadsheet() {
  */
 function setCellRangeSpreadsheet() {
   $cr = range('A','Z');
-  $crLen = count($cr);
+  $crLen = count((array)$cr);
   for($idx = 0; $idx < $crLen; $idx++) {
     for($jdx = 0; $jdx < $crLen; $jdx++) {
       $cr[] = $cr[$idx] . $cr[$jdx];

--- a/lib/results/resultsImport.php
+++ b/lib/results/resultsImport.php
@@ -192,7 +192,7 @@ function saveImportedResultData(&$db,$resultData,$context,$options) {
   $resultMap = array();
   $tplan_mgr = null;
 
-  $tc_qty = sizeof($resultData);
+  $tc_qty = sizeof((array)$resultData);
   if($tc_qty) {
     $tplan_mgr=new testplan($db);
     $tproject_mgr=new testproject($db);
@@ -395,7 +395,7 @@ function saveImportedResultData(&$db,$resultData,$context,$options) {
       			$stepSet = $tcase_mgr->getStepsSimple($tcversion_id,0,
       					  array('fields2get' => 'TCSTEPS.step_number,TCSTEPS.id',
       							'accessKey' => 'step_number'));
-      			$sc = count($tcase_exec['steps']);
+      			$sc = count((array)$tcase_exec['steps']);
 
       			for($sx=0; $sx < $sc; $sx++) {
       			  $snum = $tcase_exec['steps'][$sx]['step_number'];
@@ -496,7 +496,7 @@ function importExecutionsFromXML($xmlTCExecSet) {
   $execInfoSet=null;
   if($xmlTCExecSet) { 
     $jdx=0;
-    $exec_qty=sizeof($xmlTCExecSet);
+    $exec_qty=sizeof((array)$xmlTCExecSet);
     for($idx=0; $idx < $exec_qty ; $idx++) {
       $xmlTCExec=$xmlTCExecSet[$idx];
       $execInfo = importExecutionFromXML($xmlTCExec);
@@ -538,8 +538,8 @@ function importExecutionFromXML(&$xmlTCExec) {
   $execInfo['execution_type'] = intval((int) trim($xmlTCExec->execution_type));
   $execInfo['execution_duration'] = trim($xmlTCExec->execution_duration);
 
-  $bugQty = count($xmlTCExec->bug_id);
-  if( ($bugQty = count($xmlTCExec->bug_id)) > 0 ) {
+  $bugQty = count((array)$xmlTCExec->bug_id);
+  if( ($bugQty = count((array)$xmlTCExec->bug_id)) > 0 ) {
     foreach($xmlTCExec->bug_id as $bug) {
       $execInfo['bug_id'][] = (string) $bug;  
     }

--- a/lib/results/resultsImport.php
+++ b/lib/results/resultsImport.php
@@ -177,7 +177,7 @@ function saveImportedResultData(&$db,$resultData,$context,$options) {
   $columnDef = array();
   $adodbObj = $db->get_dbmgr_object();
   $columnDef['execution_bugs'] = $adodbObj->MetaColumns($tables['execution_bugs']);
-  $keySet = array_keys($columnDef['execution_bugs']);
+  $keySet = array_keys((array)$columnDef['execution_bugs']);
   foreach($keySet as $keyName) {
     if( ($keylow=strtolower($keyName)) != $keyName ) { 
       $columnDef['execution_bugs'][$keylow] = $columnDef['execution_bugs'][$keyName];

--- a/lib/results/resultsMoreBuilds.php
+++ b/lib/results/resultsMoreBuilds.php
@@ -92,8 +92,8 @@ function initializeGui(&$dbHandler,&$argsObj,$dateFormat)
 	$everest = $tplan_mgr->getRootTestSuites($gui->tplan_id,$gui->tproject_id,array('output' => 'plain'));
     $tsuites_qty = sizeOf($argsObj->testsuitesSelected);
     
-    $userWantsAll = ($tsuits_qty == 0 || $tsuits_qty == count($everest));
-    $filters['top_level_tsuites'] = ($tsuites_qty == 0 || $tsuites_qty == count($everest)) ? null : $argsObj->testsuitesSelected;
+    $userWantsAll = ($tsuits_qty == 0 || $tsuits_qty == count((array)$everest));
+    $filters['top_level_tsuites'] = ($tsuites_qty == 0 || $tsuites_qty == count((array)$everest)) ? null : $argsObj->testsuitesSelected;
 	$gui->testsuitesSelected = array();
 	foreach($argsObj->testsuitesSelected as $dmy)
 	{
@@ -101,7 +101,7 @@ function initializeGui(&$dbHandler,&$argsObj,$dateFormat)
 	} 
 
     $filters['builds'] = null;
-    if (sizeof($argsObj->buildsSelected)) 
+    if (sizeof((array)$argsObj->buildsSelected)) 
     {
     	$filters['builds'] = implode(",", $argsObj->buildsSelected);
     }
@@ -174,7 +174,7 @@ function initializeGui(&$dbHandler,&$argsObj,$dateFormat)
     {
         $gui->keywords->items += $tplan_keywords_map; 
     }    
-    $gui->keywords->qty = count($gui->keywords->items);
+    $gui->keywords->qty = count((array)$gui->keywords->items);
     $gui->keywordSelected = $gui->keywords->items[$argsObj->keywordSelected];
     
     $gui->builds_html = $tplan_mgr->get_builds_for_html_options($gui->tplan_id);

--- a/lib/results/resultsMoreBuilds.php
+++ b/lib/results/resultsMoreBuilds.php
@@ -72,7 +72,7 @@ function initializeGui(&$dbHandler,&$argsObj,$dateFormat)
 	}
 	else
 	{
-		$filters['platforms'] = array_keys($gui->platformSet);
+		$filters['platforms'] = array_keys((array)$gui->platformSet);
 	}
    
 	// convert starttime to iso format for database usage

--- a/lib/results/resultsNavigator.php
+++ b/lib/results/resultsNavigator.php
@@ -82,7 +82,7 @@ function init_args() {
   
   if (is_null($args->format)) {
     $reports_formats = config_get('reports_formats');
-    $args->format = sizeof($reports_formats) ? key($reports_formats) : null;
+    $args->format = sizeof((array)$reports_formats) ? key($reports_formats) : null;
   }
   
   if (is_null($args->tplan_id)) {

--- a/lib/results/resultsReqs.php
+++ b/lib/results/resultsReqs.php
@@ -59,11 +59,11 @@ $testcases = array();
 // first step: get the requirements and linked testcases with which we have to work,
 // order them into $rspecSet by spec
 $gui->total_reqs = 0;
-if (count($req_ids)) 
+if (count((array)$req_ids)) 
 {   
   list($gui->total_reqs,$rspecSet,$testcases) = buildReqSpecMap($req_ids,$req_mgr,$req_spec_mgr,$tplan_mgr,
                                                                     $args->states_to_show->selected,$args);
-  if (!count($rspecSet)) 
+  if (!count((array)$rspecSet)) 
   {
     $gui->warning_msg = $labels['no_matching_reqs'];
   }
@@ -75,7 +75,7 @@ else
 
 
 // second step: walk through req spec map, count/calculate, store results
-if(count($rspecSet)) 
+if(count((array)$rspecSet)) 
 {
 
   foreach ($rspecSet as $rspec_id => $req_spec_info) 
@@ -132,7 +132,7 @@ if(count($rspecSet))
 }
 
 // last step: build the table
-if (count($rspecSet)) 
+if (count((array)$rspecSet)) 
 {
   $allStatusCode = config_get('results');
 
@@ -209,7 +209,7 @@ if (count($rspecSet))
       if ($req_cfg->expected_coverage_management) 
       {
         $expected_coverage = $req_info['expected_coverage'];
-        $current = count($req_info['linked_testcases']);
+        $current = count((array)$req_info['linked_testcases']);
         if ($expected_coverage) 
         {
           $coverage_string = "<!-- -1 -->" . $labels['na'] . " ($current/0)";
@@ -278,7 +278,7 @@ if (count($rspecSet))
 
       // show all linked tcversions incl exec result
       $linked_tcs_with_status = '';
-      if (count($req_info['linked_testcases']) > 0 ) 
+      if (count((array)$req_info['linked_testcases']) > 0 ) 
       {
         // ATTENTION HERE IS WHERE PLATFORMS AFFECTS
         foreach($req_info['linked_testcases'] as $ltcase) 
@@ -772,7 +772,7 @@ function buildReqSpecMap($reqSet,&$reqMgr,&$reqSpecMgr,&$tplanMgr,$reqStatusFilt
       }  
 
       // if there is linked (active) test case
-      if (count($req['linked_testcases']) > 0) {
+      if (count((array)$req['linked_testcases']) > 0) {
         $total++;
         $rspec[$req['srs_id']]['requirements'][$id] = $req;
 
@@ -798,7 +798,7 @@ function buildReqSpecMap($reqSet,&$reqMgr,&$reqSpecMgr,&$tplanMgr,$reqStatusFilt
   // TC3 is NOT PART OF TEST PLAN under analisys
   //
   $tcaseSet = array();
-  if (count($tc_ids)) 
+  if (count((array)$tc_ids)) 
   {
     $filters = array('tcase_id' => $tc_ids);
     $f2a = array('platform','build');

--- a/lib/results/resultsReqs.php
+++ b/lib/results/resultsReqs.php
@@ -49,7 +49,7 @@ $reqContext = array('tproject_id' => $args->tproject_id, 'tplan_id' => $args->tp
                     'platform_id' => $args->platform);
 
 $reqSetX = (array)$req_mgr->getAllByContext($reqContext);
-$req_ids = array_keys($reqSetX);
+$req_ids = array_keys((array)$reqSetX);
 
 $prefix = $tproject_mgr->getTestCasePrefix($args->tproject_id) . (config_get('testcase_cfg')->glue_character);
 
@@ -93,7 +93,7 @@ if(count((array)$rspecSet))
       foreach ($req_info['linked_testcases'] as $key => $tc_info) 
       {
         $tc_id = $tc_info['id'];
-        $plat2loop = array_keys($testcases[$tc_id]);
+        $plat2loop = array_keys((array)$testcases[$tc_id]);
         $rspecSet[$rspec_id]['requirements'][$req_id]['tc_counters']['total']++;
  
         foreach($plat2loop as $plat_id)

--- a/lib/results/resultsTC.php
+++ b/lib/results/resultsTC.php
@@ -50,7 +50,7 @@ $buildSet = array('buildSet' => $args->builds->idSet);
 
 if( ($gui->activeBuildsQty <= $gui->matrixCfg->buildQtyLimit) || 
     ($args->doAction == 'result' && 
-     count($args->builds->idSet) <= $gui->matrixCfg->buildQtyLimit) ) {
+     count((array)$args->builds->idSet) <= $gui->matrixCfg->buildQtyLimit) ) {
 
   $tpl = $templateCfg->default_template;
 
@@ -149,7 +149,7 @@ function buildMatrix(&$guiObj,&$argsObj,$forceFormat=null) {
     ['title_key' => 'title_test_case_title', 'width' => 150]
   ];
   
-  if(!is_null($guiObj->platforms) && (count($guiObj->platforms) > 0)) {
+  if(!is_null($guiObj->platforms) && (count((array)$guiObj->platforms) > 0)) {
     $columns[] = [
       'title_key' => 'platform', 
       'width' => 60, 
@@ -288,7 +288,7 @@ function initializeGui(&$dbHandler,&$argsObj,$imgSet,&$tplanMgr)
   $guiObj->matrix = [];
 
   $guiObj->platforms = (array)$tplanMgr->getPlatforms($argsObj->tplan_id,array('outputFormat' => 'map'));
-  $guiObj->show_platforms = (count($guiObj->platforms) > 0);
+  $guiObj->show_platforms = (count((array)$guiObj->platforms) > 0);
 
   $guiObj->img = new stdClass();
   $guiObj->img->exec = $imgSet['exec_icon'];
@@ -325,7 +325,7 @@ function initializeGui(&$dbHandler,&$argsObj,$imgSet,&$tplanMgr)
   $guiObj->matrixCfg  = config_get('resultMatrixReport');
   $guiObj->buildInfoSet = $tplanMgr->get_builds($argsObj->tplan_id, testplan::ACTIVE_BUILDS,null,
                                                 array('orderBy' => $guiObj->matrixCfg->buildOrderByClause)); 
-  $guiObj->activeBuildsQty = count($guiObj->buildInfoSet);
+  $guiObj->activeBuildsQty = count((array)$guiObj->buildInfoSet);
 
 
   // hmm need to understand if this can be removed
@@ -406,7 +406,7 @@ function createSpreadsheet($gui,$args,$media) {
     $lbl['title_test_case_title']
   ];
 
-  if( $showPlatforms = count($gui->platforms) > 0 )
+  if( $showPlatforms = count((array)$gui->platforms) > 0 )
   {
     $dataHeader[] = $lbl['platform'];
   }
@@ -449,7 +449,7 @@ function createSpreadsheet($gui,$args,$media) {
   $dataHeader[] = $lbl['last_execution'];
   $dataHeader[] = $lbl['latest_exec_notes'];
 
-  $startingRow = count($lines2write) + 2; // MAGIC
+  $startingRow = count((array)$lines2write) + 2; // MAGIC
   $cellArea = "A{$startingRow}:";
   foreach($dataHeader as $zdx => $field)
   {
@@ -462,7 +462,7 @@ function createSpreadsheet($gui,$args,$media) {
   $objPHPExcel->getActiveSheet()->getStyle($cellArea)->applyFromArray($style['DataHeader']);	
 
   $startingRow++;
-  $qta_loops = count($gui->matrix);
+  $qta_loops = count((array)$gui->matrix);
   for($idx = 0; $idx < $qta_loops; $idx++)
   {
 		foreach($gui->matrix[$idx] as $ldx => $field)
@@ -781,7 +781,7 @@ function initStyleSpreadsheet() {
  */
 function setCellRangeSpreadsheet() {
   $cr = range('A','Z');
-  $crLen = count($cr);
+  $crLen = count((array)$cr);
   for($idx = 0; $idx < $crLen; $idx++) {
     for($jdx = 0; $jdx < $crLen; $jdx++) {
       $cr[] = $cr[$idx] . $cr[$jdx];

--- a/lib/results/resultsTC.php
+++ b/lib/results/resultsTC.php
@@ -517,7 +517,7 @@ function setUpBuilds(&$args,&$gui) {
     $gui->buildListForExcel = '';
     $gui->filterApplied = false;
     if( !is_null($gui->buildInfoSet) ) {
-      $args->builds->idSet = array_keys($gui->buildInfoSet);
+      $args->builds->idSet = array_keys((array)$gui->buildInfoSet);
     }
   } else {
     $args->builds->idSet = array_keys(array_flip($args->build_set));
@@ -554,21 +554,21 @@ function buildDataSet(&$db,&$args,&$gui,&$exec,$labels,$forceFormat=null)
 
   $cols = $args->cols;
 
-  $tsuiteSet = array_keys($metrics);
+  $tsuiteSet = array_keys((array)$metrics);
   foreach($tsuiteSet as $tsuiteID) {
 
-    $tcaseSet = array_keys($metrics[$tsuiteID]);
+    $tcaseSet = array_keys((array)$metrics[$tsuiteID]);
     
     foreach($tcaseSet as $tcaseID) {
 
       // If there are NO PLATFORMS anyway we have the platformID=0!!!
-      $platformSet = array_keys($metrics[$tsuiteID][$tcaseID]);
+      $platformSet = array_keys((array)$metrics[$tsuiteID][$tcaseID]);
       foreach($platformSet as $platformID) {
         $rf = &$metrics[$tsuiteID][$tcaseID][$platformID];
         $rows = null;
 
         // some info does not change on different executions
-        $build2loop = array_keys($rf);
+        $build2loop = array_keys((array)$rf);
         $top = current($build2loop);
         $external_id = $args->tcPrefix . $rf[$top]['external_id'];
         $rows[$cols['tsuite']] = $rf[$top]['suiteName'];

--- a/lib/results/resultsTCAbsoluteLatest.php
+++ b/lib/results/resultsTCAbsoluteLatest.php
@@ -310,7 +310,7 @@ function initializeGui(&$dbHandler,&$argsObj,$imgSet,&$tplanMgr)
   $guiObj->buildInfoSet = 
     $tplanMgr->get_builds($argsObj->tplan_id, testplan::ACTIVE_BUILDS,null,
                           array('orderBy' => $guiObj->matrixCfg->buildOrderByClause)); 
-  $guiObj->activeBuildsQty = count($guiObj->buildInfoSet);
+  $guiObj->activeBuildsQty = count((array)$guiObj->buildInfoSet);
 
 
   foreach($cfg['results']['code_status'] as $code => $verbose) {
@@ -371,7 +371,7 @@ function createSpreadsheet($gui,$args,$media) {
   $dataHeader[] = $lbl['latest_execution'];
   $dataHeader[] = $lbl['latest_exec_notes'];
 
-  $startingRow = count($lines2write) + 2; // MAGIC
+  $startingRow = count((array)$lines2write) + 2; // MAGIC
   $cellArea = "A{$startingRow}:";
   foreach ($dataHeader as $zdx => $field) {
     $cellID = $cellRange[$zdx] . $startingRow; 
@@ -383,7 +383,7 @@ function createSpreadsheet($gui,$args,$media) {
   $objPHPExcel->getActiveSheet()->getStyle($cellArea)->applyFromArray($style['DataHeader']);	
 
   $startingRow++;
-  $qta_loops = count($gui->matrix);
+  $qta_loops = count((array)$gui->matrix);
   for($idx = 0; $idx < $qta_loops; $idx++) {
 		foreach($gui->matrix[$idx] as $ldx => $field) {
 			$cellID = $cellRange[$ldx] . $startingRow; 
@@ -618,7 +618,7 @@ function initStyleSpreadsheet() {
  */
 function setCellRangeSpreadsheet() {
   $cr = range('A','Z');
-  $crLen = count($cr);
+  $crLen = count((array)$cr);
   for($idx = 0; $idx < $crLen; $idx++) {
     for($jdx = 0; $jdx < $crLen; $jdx++) {
       $cr[] = $cr[$idx] . $cr[$jdx];

--- a/lib/results/resultsTCAbsoluteLatest.php
+++ b/lib/results/resultsTCAbsoluteLatest.php
@@ -434,7 +434,7 @@ function setUpBuilds(&$args,&$gui) {
     $gui->buildListForExcel = '';
     $gui->filterApplied = false;
     if( !is_null($gui->buildInfoSet) ) {
-      $args->builds->idSet = array_keys($gui->buildInfoSet);
+      $args->builds->idSet = array_keys((array)$gui->buildInfoSet);
     }
   } else {
     $args->builds->idSet = array_keys(array_flip($args->build_set));
@@ -477,14 +477,14 @@ function buildDataSet(&$db,&$args,&$gui,&$metrics,$labels,$forceFormat=null)
   $execVerboseCode = $execVerboseCode['status_code'];
   $execCodeVerbose = array_flip($execVerboseCode);
 
-  $itemSet = array_keys($metrics);
+  $itemSet = array_keys((array)$metrics);
   $tsuiteCache = array(); 
   $treeMgr = new tree($db);
 
   foreach($itemSet as $iidx) {
-    $tcaseSet = array_keys($metrics[$iidx]);
+    $tcaseSet = array_keys((array)$metrics[$iidx]);
     foreach($tcaseSet as $tcaseID) {
-      $platformSet = array_keys($metrics[$iidx][$tcaseID]);
+      $platformSet = array_keys((array)$metrics[$iidx][$tcaseID]);
       foreach($platformSet as $platformID) {
         $rf = &$metrics[$iidx][$tcaseID][$platformID][0];
 

--- a/lib/results/resultsTCFlat.php
+++ b/lib/results/resultsTCFlat.php
@@ -446,7 +446,7 @@ function setUpBuilds(&$args,&$gui)
     $gui->filterApplied = false;
     if( !is_null($gui->buildInfoSet) )
     {
-      $args->builds->idSet = array_keys($gui->buildInfoSet);
+      $args->builds->idSet = array_keys((array)$gui->buildInfoSet);
     }
   }  
   else

--- a/lib/results/resultsTCFlat.php
+++ b/lib/results/resultsTCFlat.php
@@ -213,7 +213,7 @@ function initializeGui(&$dbHandler,&$argsObj,$imgSet,&$tplanMgr)
   $guiObj->matrix = array();
 
   $guiObj->platforms = (array)$tplanMgr->getPlatforms($argsObj->tplan_id,array('outputFormat' => 'map'));
-  $guiObj->show_platforms = (count($guiObj->platforms) > 0);
+  $guiObj->show_platforms = (count((array)$guiObj->platforms) > 0);
 
   $guiObj->img = new stdClass();
   $guiObj->img->exec = $imgSet['exec_icon'];
@@ -252,7 +252,7 @@ function initializeGui(&$dbHandler,&$argsObj,$imgSet,&$tplanMgr)
   $guiObj->matrixCfg  = config_get('resultMatrixReport');
   $guiObj->buildInfoSet = $tplanMgr->get_builds($argsObj->tplan_id, testplan::ACTIVE_BUILDS,null,
                                                 array('orderBy' => $guiObj->matrixCfg->buildOrderByClause)); 
-  $guiObj->activeBuildsQty = count($guiObj->buildInfoSet);
+  $guiObj->activeBuildsQty = count((array)$guiObj->buildInfoSet);
 
 
   // hmm need to understand if this can be removed
@@ -300,7 +300,7 @@ function createSpreadsheet($gui,$args)
 
   // contribution to have more than 26 columns   
   $cellRange = range('A','Z');
-  $cellRangeLen = count($cellRange);
+  $cellRangeLen = count((array)$cellRange);
   for($idx = 0; $idx < $cellRangeLen; $idx++)
   {
     for($jdx = 0; $jdx < $cellRangeLen; $jdx++) 
@@ -381,7 +381,7 @@ function createSpreadsheet($gui,$args)
   $dataHeader[] = $lbl['execution_duration'];
   $dataHeader[] = $lbl['execution_type'];
 
-  $startingRow = count($lines2write) + 2; // MAGIC
+  $startingRow = count((array)$lines2write) + 2; // MAGIC
   $cellArea = "A{$startingRow}:";
   foreach($dataHeader as $zdx => $field)
   {
@@ -395,7 +395,7 @@ function createSpreadsheet($gui,$args)
   
   $startingRow++;
   
-  $qta_loops = count($gui->matrix);
+  $qta_loops = count((array)$gui->matrix);
 
   for($idx = 0; $idx < $qta_loops; $idx++)
   {
@@ -499,7 +499,7 @@ urg_imp 4       => NEED TO DECODE
 execution_type => NEED TO DECODE 
 */
 
-  $loop2do = count($metrics);
+  $loop2do = count((array)$metrics);
 
   $uk2 = array('user_id','tester_id');
 

--- a/lib/results/tcCreatedPerUserOnTestProject.php
+++ b/lib/results/tcCreatedPerUserOnTestProject.php
@@ -257,7 +257,7 @@ function initGuiForCSVDownload(&$dbHandler,$argsObj,&$guiObj) {
       }
     }
 
-    if( count($rows) == 0 ) {
+    if( count((array)$rows) == 0 ) {
       return;
     }
 

--- a/lib/results/tcNotRunAnyPlatform.php
+++ b/lib/results/tcNotRunAnyPlatform.php
@@ -51,7 +51,7 @@ $platforms_active = !is_null($gui->platforms);
 $gui->buildInfoSet = $tplan_mgr->get_builds($args->tplan_id, 1); // only active builds
 if ($gui->buildInfoSet)
 {
-	$buildIDSet = array_keys($gui->buildInfoSet);
+	$buildIDSet = array_keys((array)$gui->buildInfoSet);
 	$buildQty = sizeOf($buildIDSet);
 }
 

--- a/lib/results/testCasesWithCF.php
+++ b/lib/results/testCasesWithCF.php
@@ -105,7 +105,7 @@ if( $args->doIt )
 		}
 	}
 
-	if (count($matrixData) > 0) 
+	if (count((array)$matrixData) > 0) 
 	{
 		$table = new tlExtTable($columns, $matrixData, 'tl_table_tc_with_cf');
 		$table->addCustomBehaviour('text', array('render' => 'columnWrap'));
@@ -218,7 +218,7 @@ function buildResultSet(&$dbHandler,&$guiObj,$tproject_id,$tplan_id)
     
     // this way on caller can be used on array operations, without warnings
     $guiObj->cfields = (array)$guiObj->cfields;  
-    if( count($guiObj->cfields) > 0 )
+    if( count((array)$guiObj->cfields) > 0 )
     {
     	foreach($guiObj->cfields as $key => $values)
     	{
@@ -255,7 +255,7 @@ function buildResultSet(&$dbHandler,&$guiObj,$tproject_id,$tplan_id)
         }
     }
 
-    if(($guiObj->row_qty=count($cf_map)) == 0 )
+    if(($guiObj->row_qty=count((array)$cf_map)) == 0 )
     {
         $guiObj->warning_msg = lang_get('no_linked_tc_cf');
     }

--- a/lib/results/testCasesWithoutTester.php
+++ b/lib/results/testCasesWithoutTester.php
@@ -35,7 +35,7 @@ if($tplan_mgr->count_testcases($args->tplan_id) > 0)
   $metrics = $metricsMgr->getNotRunWoTesterAssigned($args->tplan_id,null,null,
                                                     array('output' => 'array', 'ignoreBuild' => true));
 
-  if(($gui->row_qty = count($metrics)) > 0)
+  if(($gui->row_qty = count((array)$metrics)) > 0)
   {
     $msg_key = '';
     $links = featureLinks($gui->labels,$smarty->getImages());

--- a/lib/results/testPlanWithCF.php
+++ b/lib/results/testPlanWithCF.php
@@ -79,7 +79,7 @@ if($tplan_mgr->count_testcases($args->tplan_id) > 0)
             }
         }
     }
-    if(($gui->row_qty = count($cf_map)) > 0 )
+    if(($gui->row_qty = count((array)$cf_map)) > 0 )
     {
         $gui->warning_msg = '';
         $gui->resultSet = $result;
@@ -108,7 +108,7 @@ function buildExtTable($gui,$tcase_mgr,$tplan_mgr, $tplan_id, $labels, $edit_ico
 	$title_sep = config_get('gui_title_separator_1');
 	
 	$table = null;
-	if(count($gui->resultSet) > 0) 
+	if(count((array)$gui->resultSet) > 0) 
 	{
 		$columns = array();
 		$columns[] = array('title_key' => 'test_suite');

--- a/lib/results/uncoveredTestCases.php
+++ b/lib/results/uncoveredTestCases.php
@@ -72,7 +72,7 @@ if($gui->has_requirements)
 if($gui->has_tc = (!is_null($uncovered) && count((array)$uncovered) > 0) )
 {
     // Get external  ID
-    $testSet = array_keys($uncovered);
+    $testSet = array_keys((array)$uncovered);
     $inClause = implode(',',$testSet);
     $debugMsg = 'File: ' . basename(__FILE__) . ' - Line: ' . __LINE__ . ' - ';
     $sql = "/* $debugMsg */ " .

--- a/lib/results/uncoveredTestCases.php
+++ b/lib/results/uncoveredTestCases.php
@@ -32,7 +32,7 @@ $uncovered = null;
 $gui = new stdClass();
 $gui->items = null;
 $gui->tproject_name = $args->tproject_name;
-$gui->has_reqspec = count($reqSpec) > 0;
+$gui->has_reqspec = count((array)$reqSpec) > 0;
 $gui->has_requirements = false;
 $gui->has_tc = false;
 
@@ -53,7 +53,7 @@ if($gui->has_requirements)
     $tcasesID = null; 
     $tproject_mgr->get_all_testcases_id($args->tproject_id,$tcasesID);  
     
-    if(!is_null($tcasesID) && count($tcasesID) > 0)
+    if(!is_null($tcasesID) && count((array)$tcasesID) > 0)
     {
         $debugMsg = 'File: ' . basename(__FILE__) . ' - Line: ' . __LINE__ . ' - ';
 		$sql = " /* $debugMsg */ " .
@@ -69,7 +69,7 @@ if($gui->has_requirements)
 }
 
 
-if($gui->has_tc = (!is_null($uncovered) && count($uncovered) > 0) )
+if($gui->has_tc = (!is_null($uncovered) && count((array)$uncovered) > 0) )
 {
     // Get external  ID
     $testSet = array_keys($uncovered);

--- a/lib/search/search.php
+++ b/lib/search/search.php
@@ -119,7 +119,7 @@ if( $hasTestCases ) {
 // Render Results
 if( !is_null($mapTC) ) {
   $tcase_mgr = new testcase($db);   
-  $tcase_set = array_keys($mapTC);
+  $tcase_set = array_keys((array)$mapTC);
   $options = array('output_format' => 'path_as_string');
   $gui->path_info = $treeMgr->get_full_path_verbose($tcase_set, $options);
   $gui->resultSet = $mapTC;
@@ -161,7 +161,7 @@ if(!is_null($table)) {
 $table = null;
 if( !is_null($mapRQ)) {
   $gui->resultReq = $mapRQ;
-  $req_set = array_keys($mapRQ);
+  $req_set = array_keys((array)$mapRQ);
   $options = array('output_format' => 'path_as_string');
   $gui->path_info = $treeMgr->get_full_path_verbose($req_set,$options);
 
@@ -373,7 +373,7 @@ function buildRQExtTable($gui, $charset)
     // Extract the relevant data and build a matrix
     $matrixData = array();
     
-    $key2loop = array_keys($gui->resultReq);
+    $key2loop = array_keys((array)$gui->resultReq);
     $img = "<img title=\"{$labels['edit']}\" src=\"{$edit_icon}\" />";
     $reqVerHref = '<a href="javascript:openLinkedReqVersionWindow(%s,%s)">' . $labels['version_revision_tag'] . ' </a>'; 
     $reqRevHref = '<a href="javascript:openReqRevisionWindow(%s)">' . $labels['version_revision_tag'] . ' </a>'; 

--- a/lib/search/search.php
+++ b/lib/search/search.php
@@ -38,7 +38,7 @@ $cfieldMgr = new cfield_mgr($db);
 
 
 $targetSet = cleanUpTarget($db,$args->target);
-$canUseTarget = (count($targetSet) > 0);
+$canUseTarget = (count((array)$targetSet) > 0);
 
 if($args->oneCheck == false) {
   $gui->caller = 'search';
@@ -110,7 +110,7 @@ if( $args->rq_scope || $args->rq_title || $args->rq_doc_id || ($req_cf_id > 0) )
 } 
 
   
-$hasTestCases = (!is_null($tcaseSet) && count($tcaseSet) > 0);
+$hasTestCases = (!is_null($tcaseSet) && count((array)$tcaseSet) > 0);
 if( $hasTestCases ) {
   $emptyTestProject = false;
   $mapTC = $cmdMgr->searchTestCases($tcaseSet,$targetSet,$canUseTarget,$tc_cf_id);
@@ -247,7 +247,7 @@ function buildTSExtTable($gui, $charset, $edit_icon, $history_icon)
   $designCfg = getWebEditorCfg('design');
   $designType = $designCfg['type'];
   
-  if(count($gui->resultTestSuite) > 0) 
+  if(count((array)$gui->resultTestSuite) > 0) 
   {
     $labels = array('test_suite' => lang_get('test_suite'), 
                     'details' => lang_get('details'));
@@ -299,7 +299,7 @@ function buildRSExtTable($gui, $charset, $edit_icon, $history_icon)
   $designCfg = getWebEditorCfg('design');
   $designType = $designCfg['type'];
   
-  if(count($gui->resultReqSpec) > 0) 
+  if(count((array)$gui->resultReqSpec) > 0) 
   {
     $labels = array('req_spec' => lang_get('req_spec'), 
                     'scope' => lang_get('scope'));
@@ -361,7 +361,7 @@ function buildRQExtTable($gui, $charset)
   $labels = init_labels($lbl);
   $edit_icon = TL_THEME_IMG_DIR . "edit_icon.png";
   
-  if(count($gui->resultReq) > 0) 
+  if(count((array)$gui->resultReq) > 0) 
   {
     $columns = array();
     

--- a/lib/search/searchCommands.class.php
+++ b/lib/search/searchCommands.class.php
@@ -481,7 +481,7 @@ class searchCommands
       }  
     }
 
-    $this->gui->filter_by['custom_fields'] = !is_null($this->gui->cf) && count($this->gui->cf) > 0;
+    $this->gui->filter_by['custom_fields'] = !is_null($this->gui->cf) && count((array)$this->gui->cf) > 0;
 
     $this->gui->keywords = $this->tprojectMgr->getKeywordSet($this->args->tproject_id);
     $this->gui->filter_by['keyword'] = !is_null($this->gui->keywords);
@@ -567,7 +567,7 @@ class searchCommands
 
     $reqSet = $this->getReqIDSet($args->tproject_id);
 
-    $noItems = is_null($reqSet) || count($reqSet) == 0;
+    $noItems = is_null($reqSet) || count((array)$reqSet) == 0;
     $bye = $noItems || (!$canUseTarget && $req_cf_id <= 0); 
     if( $bye )
     {  
@@ -726,7 +726,7 @@ class searchCommands
 
     $mapTS = null;
     $tsuiteSet = $this->getTestSuiteIDSet($args->tproject_id);
-    if(is_null($tsuiteSet) || count($tsuiteSet) == 0)
+    if(is_null($tsuiteSet) || count((array)$tsuiteSet) == 0)
     {
       return null;
     }  
@@ -810,7 +810,7 @@ class searchCommands
     $filterSpecial = null;
 
 
-    if( is_null($tcaseSet) || count($tcaseSet) == 0)
+    if( is_null($tcaseSet) || count((array)$tcaseSet) == 0)
     {
       return null;
     }  
@@ -928,7 +928,7 @@ class searchCommands
 
 
     $otherFilters = '';  
-    if(!is_null($filterSpecial) && count($filterSpecial) > 1)
+    if(!is_null($filterSpecial) && count((array)$filterSpecial) > 1)
     {
       $otherFilters = " AND (/* filterSpecial */ " . 
                       implode("",$filterSpecial) . ")";

--- a/lib/testcases/containerEdit.php
+++ b/lib/testcases/containerEdit.php
@@ -174,7 +174,7 @@ if( $doIt ) {
       $gui->tproject_id = $args->tprojectID;
       $gui->containerType = $level;
       $gui->refreshTree = $args->refreshTree;
-      $gui->hasKeywords = (count($opt_cfg->from->map) > 0) || (count($opt_cfg->to->map) > 0);
+      $gui->hasKeywords = (count((array)$opt_cfg->from->map) > 0) || (count((array)$opt_cfg->to->map) > 0);
 
       $gui->cancelActionJS = 'location.href=fRoot+' . 
                              "'lib/testcases/archiveData.php?id=" . intval($args->containerID);
@@ -669,7 +669,7 @@ function deleteTestSuite(&$smartyObj,&$argsObj,&$tsuiteMgr,&$treeMgr,&$tcaseMgr,
     $map_msg['link_msg'] = null;
     $map_msg['delete_msg'] = null;
 
-    if(is_null($testcases) || count($testcases) == 0) {
+    if(is_null($testcases) || count((array)$testcases) == 0) {
       $can_delete = 1;
     }
     else {
@@ -799,7 +799,7 @@ function  reorderTestSuiteViewer(&$smartyObj,&$treeMgr,$argsObj)
     $object_name = $object_info['name'];
 
 
-    if (!sizeof($children))
+    if (!sizeof((array)$children))
     {  
       $children = null;
     }
@@ -1008,7 +1008,7 @@ function moveTestCasesViewer(&$dbHandler,&$smartyObj,&$tprojectMgr,&$treeMgr,
 
   // check if operation can be done
   $user_feedback = $feedback;
-  if(!is_null($children) && (sizeof($children) > 0) && sizeof($testsuites)) {
+  if(!is_null($children) && (sizeof((array)$children) > 0) && sizeof((array)$testsuites)) {
     $op_ok = true;
   } else {
     $children = null;
@@ -1065,7 +1065,7 @@ returns: -
 function copyTestCases(&$smartyObj,$template_dir,&$tsuiteMgr,&$tcaseMgr,$argsObj)
 {
   $op = array('refreshTree' => false, 'userfeedback' => '');
-  if( ($qty=sizeof($argsObj->tcaseSet)) > 0)
+  if( ($qty=sizeof((array)$argsObj->tcaseSet)) > 0)
   {
     $msg_id = $qty == 1 ? 'one_testcase_copied' : 'testcase_set_copied';
     $op['userfeedback'] = sprintf(lang_get($msg_id),$qty);
@@ -1105,7 +1105,7 @@ returns: -
 function moveTestCases(&$smartyObj,$template_dir,&$tsuiteMgr,&$treeMgr,$argsObj)
 {
   $lbl = $argsObj->l10n; 
-  if (sizeof($argsObj->tcaseSet) > 0) {
+  if (sizeof((array)$argsObj->tcaseSet) > 0) {
     $status_ok = $treeMgr->change_parent($argsObj->tcaseSet,$argsObj->containerID);
     $user_feedback= $status_ok ? '' : lang_get('move_testcases_failed');
 
@@ -1201,7 +1201,7 @@ function deleteTestCasesViewer(&$dbHandler,&$smartyObj,&$tprojectMgr,&$treeMgr,&
     $tcasePrefix = $tprojectMgr->getTestCasePrefix($argsObj->tprojectID);
     $hasExecutedTC = false;
 
-    if( !is_null($guiObj->testCaseSet) && count($guiObj->testCaseSet) > 0)
+    if( !is_null($guiObj->testCaseSet) && count((array)$guiObj->testCaseSet) > 0)
     {
       foreach($guiObj->testCaseSet as &$child)
       {
@@ -1257,7 +1257,7 @@ function deleteTestCasesViewer(&$dbHandler,&$smartyObj,&$tprojectMgr,&$treeMgr,&
     }
     // check if operation can be done
     $guiObj->user_feedback = $feedback;
-    if(!is_null($guiObj->testCaseSet) && (sizeof($guiObj->testCaseSet) > 0) )
+    if(!is_null($guiObj->testCaseSet) && (sizeof((array)$guiObj->testCaseSet) > 0) )
     {
       $guiObj->op_ok = true;
       $guiObj->user_feedback = '';
@@ -1292,7 +1292,7 @@ returns: -
 */
 function doDeleteTestCases(&$dbHandler,$tcaseSet,&$tcaseMgr)
 {
-  if( count($tcaseSet) > 0 )
+  if( count((array)$tcaseSet) > 0 )
   {
     foreach($tcaseSet as $victim)
     {
@@ -1320,7 +1320,7 @@ function reorderTestCasesByCriteria($argsObj,&$tsuiteMgr,&$treeMgr) {
 function reorderTestCasesDictionary($argsObj,&$tsuiteMgr,&$treeMgr)
 {
   $tcaseSet = (array)$tsuiteMgr->get_children_testcases($argsObj->testsuiteID,'simple');
-  if( ($loop2do = count($tcaseSet)) > 0 )
+  if( ($loop2do = count((array)$tcaseSet)) > 0 )
   {
     for($idx=0; $idx < $loop2do; $idx++)
     {
@@ -1363,7 +1363,7 @@ function reorderTestSuitesDictionary($args,$treeMgr,$parent_id)
 {
   $exclude_node_types = array('testplan' => 1, 'requirement' => 1, 'testcase' => 1, 'requirement_spec' => 1);
   $itemSet = (array)$treeMgr->get_children($parent_id,$exclude_node_types);
-  if( ($loop2do = count($itemSet)) > 0 )
+  if( ($loop2do = count((array)$itemSet)) > 0 )
   {
     for($idx=0; $idx < $loop2do; $idx++)
     {
@@ -1414,7 +1414,7 @@ function initializeGui(&$objMgr,$id,$argsObj,$lbl=null) {
  */
 function doBulkSet(&$dbHandler,$argsObj,$tcaseSet,&$tcaseMgr)
 {
-  if( count($tcaseSet) > 0 )
+  if( count((array)$tcaseSet) > 0 )
   {
     $k2s = array('tc_status' => 'setStatus',
                  'importance' => 'setImportance',

--- a/lib/testcases/containerEdit.php
+++ b/lib/testcases/containerEdit.php
@@ -1227,17 +1227,17 @@ function deleteTestCasesViewer(&$dbHandler,&$smartyObj,&$tprojectMgr,&$treeMgr,&
       // key level 2 : Test Plan  ID
       // key level 3 : Platform ID
 
-      $itemSet = array_keys($guiObj->exec_status_quo);
+      $itemSet = array_keys((array)$guiObj->exec_status_quo);
       foreach($itemSet as $mainKey)
       {
         $guiObj->display_platform[$mainKey] = false;
         if(!is_null($guiObj->exec_status_quo[$mainKey]) )
         {
-          $versionSet = array_keys($guiObj->exec_status_quo[$mainKey]);
+          $versionSet = array_keys((array)$guiObj->exec_status_quo[$mainKey]);
           $stop = false;
           foreach($versionSet as $version_id)
           {
-            $tplanSet = array_keys($guiObj->exec_status_quo[$mainKey][$version_id]);
+            $tplanSet = array_keys((array)$guiObj->exec_status_quo[$mainKey][$version_id]);
             foreach($tplanSet as $tplan_id)
             {
               if( ($guiObj->display_platform[$mainKey] = !isset($guiObj->exec_status_quo[$mainKey][$version_id][$tplan_id][0])) )
@@ -1327,7 +1327,7 @@ function reorderTestCasesDictionary($argsObj,&$tsuiteMgr,&$treeMgr)
       $a2sort[$tcaseSet[$idx]['id']] = strtolower($tcaseSet[$idx]['name']);
     }
     natsort($a2sort);
-    $a2sort = array_keys($a2sort);
+    $a2sort = array_keys((array)$a2sort);
     $treeMgr->change_order_bulk($a2sort);
   }
 }
@@ -1370,7 +1370,7 @@ function reorderTestSuitesDictionary($args,$treeMgr,$parent_id)
       $a2sort[$itemSet[$idx]['id']] = strtolower($itemSet[$idx]['name']);
     }
     natsort($a2sort);
-    $a2sort = array_keys($a2sort);
+    $a2sort = array_keys((array)$a2sort);
     $treeMgr->change_order_bulk($a2sort);
   }
 }
@@ -1453,7 +1453,7 @@ function doBulkSet(&$dbHandler,$argsObj,$tcaseSet,&$tcaseMgr)
     if( !is_null($cf_map) )
     {
       // get checkboxes from $_REQUEST
-      $k2i = array_keys($_REQUEST);
+      $k2i = array_keys((array)$_REQUEST);
       $cfval = null;
       foreach($k2i as $val)
       { 

--- a/lib/testcases/scriptDelete.php
+++ b/lib/testcases/scriptDelete.php
@@ -66,7 +66,7 @@ function initEnv(&$dbHandler)
   $args->script_id = trim($args->script_id);
   
   $scriptArray = explode("&&", $args->script_id);
-  if(count($scriptArray) > 0)
+  if(count((array)$scriptArray) > 0)
   {
     $args->project_key = $scriptArray[0];
     $args->repository_name = $scriptArray[1];

--- a/lib/testcases/tcAssign2Tplan.php
+++ b/lib/testcases/tcAssign2Tplan.php
@@ -51,7 +51,7 @@ if( !is_null($tcase_all_info) )
 $link_info = $tcase_mgr->get_linked_versions($args->tcase_id);
 if( !is_null($tplanSet = $tproject_mgr->get_all_testplans($args->tproject_id,array('plan_status' => 1))) )
 {
-  $has_links = array_fill_keys(array_keys($tplanSet),false);
+  $has_links = array_fill_keys(array_keys((array)$tplanSet),false);
   $linked_tplans = null;
   if( !is_null($link_info) )
   {
@@ -86,7 +86,7 @@ if( !is_null($tplanSet = $tproject_mgr->get_all_testplans($args->tproject_id,arr
     // if a version of this Test Case has been linked to test plan, get it.
     if( $has_links[$tplan_id] )
     {
-      $linked_platforms = array_flip(array_keys($linked_tplans[$tplan_id]));
+      $linked_platforms = array_flip(array_keys((array)$linked_tplans[$tplan_id]));
       $dummy = current($linked_tplans[$tplan_id]);
       $target_version_number = $dummy['version'];
       $target_version_id = $dummy['tcversion_id'];

--- a/lib/testcases/tcAssignedToUser.php
+++ b/lib/testcases/tcAssignedToUser.php
@@ -61,7 +61,7 @@ if( $doIt )
   $execCfg = config_get('exec_cfg');
 
   $tables = tlObjectWithDB::getDBTables(array('nodes_hierarchy'));
-  $tplanSet=array_keys($gui->resultSet);
+  $tplanSet=array_keys((array)$gui->resultSet);
   $sql="SELECT name,id FROM {$tables['nodes_hierarchy']} " .
        "WHERE id IN (" . implode(',',$tplanSet) . ")";
   $gui->tplanNames=$db->fetchRowsIntoMap($sql,'id');

--- a/lib/testcases/tcAssignedToUser.php
+++ b/lib/testcases/tcAssignedToUser.php
@@ -191,7 +191,7 @@ if( $doIt )
 		$matrix->setGroupByColumnName(lang_get($columns[0]['title_key']));
 		
 		// make table collapsible if more than 1 table is shown and surround by frame
-		if (count($tplanSet) > 1) {
+		if (count((array)$tplanSet) > 1) {
 			$matrix->collapsible = true;
 			$matrix->frame = true;
 		}

--- a/lib/testcases/tcCompareVersions.php
+++ b/lib/testcases/tcCompareVersions.php
@@ -64,7 +64,7 @@ if ($args->compare_selected_versions)
 		
 		  $gui->diff[$key]['diff'] = $diffEngine->inline($gui->diff[$key]['left'], $gui->leftID, 
 			                                               $gui->diff[$key]['right'], $gui->rightID,$args->context);
-			$gui->diff[$key]['count'] = count($diffEngine->changes);
+			$gui->diff[$key]['count'] = count((array)$diffEngine->changes);
 		}
 		
 		// are there any changes? then display! if not, nothing to show here

--- a/lib/testcases/tcCompareVersions.php
+++ b/lib/testcases/tcCompareVersions.php
@@ -145,7 +145,7 @@ function buildDiff($items,$argsObj)
   $attrKeys = array();  
   $attrKeys['simple'] = array('summary','preconditions');
   $attrKeys['complex'] = array('steps' => 'actions', 'expected_results' => 'expected_results');
-  $dummy = array_merge($attrKeys['simple'],array_keys($attrKeys['complex'])); 
+  $dummy = array_merge($attrKeys['simple'],array_keys((array)$attrKeys['complex'])); 
   foreach($dummy as $gx)
   {
     foreach($panel as $side)

--- a/lib/testcases/tcCreateFromIssue.php
+++ b/lib/testcases/tcCreateFromIssue.php
@@ -148,7 +148,7 @@ function importTestCaseDataFromXML(&$db,$fileName,$parentID,$tproject_id,$userID
       if ($xmlKeywords)
       {
         $tproject = new testproject($db);
-        $loop2do = sizeof($xmlKeywords);
+        $loop2do = sizeof((array)$xmlKeywords);
         for($idx = 0; $idx < $loop2do ;$idx++)
         {
           $tproject->importKeywordsFromSimpleXML($tproject_id,$xmlKeywords[$idx]);
@@ -252,14 +252,14 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
     $tprojectHas['customFields']=!is_null($linkedCustomFields);                   
 
     $reqSpecSet = $tproject_mgr->getReqSpec($tproject_id,null,array('RSPEC.id','NH.name AS title','RSPEC.doc_id as rspec_doc_id', 'REQ.req_doc_id'),'req_doc_id');
-    $tprojectHas['reqSpec'] = (!is_null($reqSpecSet) && count($reqSpecSet) > 0);
+    $tprojectHas['reqSpec'] = (!is_null($reqSpecSet) && count((array)$reqSpecSet) > 0);
 
     $getVersionOpt = array('output' => 'minimun');
     $tcasePrefix = $tproject_mgr->getTestCasePrefix($tproject_id);
   }
   
   $resultMap = array();
-  $tc_qty = sizeof($tcData);
+  $tc_qty = sizeof((array)$tcData);
   $userIDCache = array();
   
   for($idx = 0; $idx <$tc_qty ; $idx++)
@@ -352,7 +352,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
 
       if( !is_null($info) )
       {
-        $tcase_qty = count($info);
+        $tcase_qty = count((array)$info);
        switch($tcase_qty)
        {
            case 1:
@@ -392,7 +392,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
         { 
           // Get full path of existent Test Cases
           $stain = $tcase_mgr->tree_manager->get_path($item_id,null, 'name');
-          $n = count($stain);         
+          $n = count((array)$stain);         
           $stain[$n-1] = $tcasePrefix . config_get('testcase_cfg')->glue_character . $externalid . ':' . $stain[$n-1];
           $stain = implode('/',$stain);
           
@@ -478,7 +478,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
 function buildKeywordList($kwMap,$keywords)
 {
   $items = array();
-  $loop2do = sizeof($keywords);
+  $loop2do = sizeof((array)$keywords);
   for($jdx = 0; $jdx <$loop2do ; $jdx++)
   {
     $items[] = $kwMap[trim($keywords[$jdx]['name'])]; 
@@ -657,7 +657,7 @@ function processRequirements(&$dbHandler,&$reqMgr,$tcaseName,$tcaseId,$tcReq,$re
                      " AND REQ.srs_id={$req_spec_id} ";     
                    
               $rsx=$dbHandler->get_recordset($sql);
-              if( $useit=((!is_null($rsx) && count($rsx) > 0) ? true : false) )
+              if( $useit=((!is_null($rsx) && count((array)$rsx) > 0) ? true : false) )
               {
                 $cachedReqSpec[$value['req_spec_title']]['req'][$value['doc_id']]=$rsx[0]['id'];
               }  
@@ -726,7 +726,7 @@ function getTestCaseSetFromSimpleXMLObj($xmlTCs)
   }
     
   $jdx = 0;
-  $loops2do=sizeof($xmlTCs);
+  $loops2do=sizeof((array)$xmlTCs);
   $tcaseSet = array();
   
   // $tcXML['elements'] = array('string' => array("summary","preconditions"),
@@ -796,7 +796,7 @@ function getStepsFromSimpleXMLObj($simpleXMLItems)
     // need to do this due to (maybe) a wrong name choice for XML element
   if( !is_null($items) )
   {
-    $loop2do = count($items);
+    $loop2do = count((array)$items);
     for($idx=0; $idx < $loop2do; $idx++)
     {
       $items[$idx]['expected_results'] = '';
@@ -924,7 +924,7 @@ function importTestSuitesFromSimpleXML(&$dbHandler,&$xml,$parentID,$tproject_id,
     }
 
     $childrenNodes = $xml->children();  
-    $loop2do = sizeof($childrenNodes);
+    $loop2do = sizeof((array)$childrenNodes);
     
     for($idx = 0; $idx < $loop2do; $idx++)
     {

--- a/lib/testcases/tcCreateFromIssueMantisXML.php
+++ b/lib/testcases/tcCreateFromIssueMantisXML.php
@@ -206,14 +206,14 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
     $tprojectHas['customFields']=!is_null($linkedCustomFields);                   
 
     $reqSpecSet = $tproject_mgr->getReqSpec($tproject_id,null,array('RSPEC.id','NH.name AS title','RSPEC.doc_id as rspec_doc_id', 'REQ.req_doc_id'),'req_doc_id');
-    $tprojectHas['reqSpec'] = (!is_null($reqSpecSet) && count($reqSpecSet) > 0);
+    $tprojectHas['reqSpec'] = (!is_null($reqSpecSet) && count((array)$reqSpecSet) > 0);
 
     $getVersionOpt = array('output' => 'minimun');
     $tcasePrefix = $tproject_mgr->getTestCasePrefix($tproject_id);
   }
   
   $resultMap = array();
-  $tc_qty = sizeof($tcData);
+  $tc_qty = sizeof((array)$tcData);
   $userIDCache = array();
   
   for($idx = 0; $idx <$tc_qty ; $idx++)
@@ -306,7 +306,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
 
       if( !is_null($info) )
       {
-        $tcase_qty = count($info);
+        $tcase_qty = count((array)$info);
        switch($tcase_qty)
        {
            case 1:
@@ -346,7 +346,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
         { 
           // Get full path of existent Test Cases
           $stain = $tcase_mgr->tree_manager->get_path($item_id,null, 'name');
-          $n = count($stain);         
+          $n = count((array)$stain);         
           $stain[$n-1] = $tcasePrefix . config_get('testcase_cfg')->glue_character . $externalid . ':' . $stain[$n-1];
           $stain = implode('/',$stain);
           
@@ -449,7 +449,7 @@ function getTestCaseSetFromIssueSimpleXMLObj($xmlObj)
 
   $jdx = 0;
   $xmlIssue = $xmlObj->issue;
-  $loops2do=sizeof($xmlIssue);
+  $loops2do=sizeof((array)$xmlIssue);
  
   $XMLDef['elements'] = array('string' => array('summary' => null,'description' => null,
                                                 'additional_information' => null,

--- a/lib/testcases/tcEdit.php
+++ b/lib/testcases/tcEdit.php
@@ -85,7 +85,7 @@ switch($args->doAction) {
   case "create":  
   case "edit":  
   case "doCreate":  
-    $op = $commandMgr->$pfn($args,$opt_cfg,array_keys($testCaseEditorKeys),$_REQUEST);
+    $op = $commandMgr->$pfn($args,$opt_cfg,array_keys((array)$testCaseEditorKeys),$_REQUEST);
     $doRender = true;
   break;
     

--- a/lib/testcases/tcEdit.php
+++ b/lib/testcases/tcEdit.php
@@ -194,7 +194,7 @@ if($args->delete_tc_version) {
   $the_xx[$the_tc_node['parent_id']] .= ' (' . lang_get('current') . ')';
   $tc_info = $tcase_mgr->get_by_id($args->tcase_id);
   
-  $container_qty = count($the_xx);
+  $container_qty = count((array)$the_xx);
   $gui->move_enabled = 1;
   if ($container_qty == 1) {
     // move operation is nonsense

--- a/lib/testcases/tcExport.php
+++ b/lib/testcases/tcExport.php
@@ -74,7 +74,7 @@ if( $check_children ) {
                                           "requirement" => "exclude_me"));
 
   $gui->nothing_todo_msg='';
-  if(count($children)==0) {
+  if(count((array)$children)==0) {
     $gui->do_it = 0 ;
   }
 }

--- a/lib/testcases/tcImport.php
+++ b/lib/testcases/tcImport.php
@@ -138,7 +138,7 @@ function importTestCaseDataFromXML(&$db,$fileName,$parentID,$tproject_id,$userID
       $kwMap = null;
       if ($xmlKeywords) {
         $tproject = new testproject($db);
-        $loop2do = sizeof($xmlKeywords);
+        $loop2do = sizeof((array)$xmlKeywords);
         for($idx = 0; $idx < $loop2do ;$idx++) {
           $tproject->importKeywordsFromSimpleXML($tproject_id,$xmlKeywords[$idx]);
         }
@@ -255,7 +255,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
 
     $reqSpecSet = getReqSpecSet($db,$tproject_id);
 
-    $tprojectHas['reqSpec'] = (!is_null($reqSpecSet) && count($reqSpecSet) > 0);
+    $tprojectHas['reqSpec'] = (!is_null($reqSpecSet) && count((array)$reqSpecSet) > 0);
 
     $getVersionOpt = array('output' => 'minimun');
     $tcasePrefix = $tproject_mgr->getTestCasePrefix($tproject_id);
@@ -263,7 +263,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
   }
   
   $resultMap = array();
-  $tc_qty = sizeof($tcData);
+  $tc_qty = sizeof((array)$tcData);
   $userIDCache = array();
   
   for($idx = 0; $idx <$tc_qty ; $idx++) {
@@ -302,7 +302,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
 
     // Check for skip, to avoid useless processing
     if( $duplicatedLogic['actionOnHit'] == 'skip' && !is_null($dupInfo) &&
-        count($dupInfo) > 0 ) {
+        count((array)$dupInfo) > 0 ) {
       $resultMap[] = array($name,$messages['already_exists_skipped']);
       continue;
     }
@@ -390,7 +390,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
     if( $duplicatedLogic['actionOnHit'] == 'update_last_version' && 
         !is_null($dupInfo) ) {
         
-        $tcase_qty = count($dupInfo);
+        $tcase_qty = count((array)$dupInfo);
     
         switch($tcase_qty) {
            case 1:
@@ -442,7 +442,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
         if( $owner != $container_id) { 
           // Get full path of existent Test Cases
           $stain = $tcase_mgr->tree_manager->get_path($item_id,null, 'name');
-          $n = count($stain);         
+          $n = count((array)$stain);         
           $stain[$n-1] = $tcasePrefix . config_get('testcase_cfg')->glue_character . $externalid . ':' . $stain[$n-1];
           $stain = implode('/',$stain);
           
@@ -548,7 +548,7 @@ function saveImportedTCData(&$db,$tcData,$tproject_id,$container_id,
 */
 function buildKeywordList($kwMap,$keywords) {
   $items = array();
-  $loop2do = sizeof($keywords);
+  $loop2do = sizeof((array)$keywords);
   for($jdx = 0; $jdx <$loop2do ; $jdx++) {
     // change Map keys (keyword) to lowercase to be case insensitive
     $items[] = $kwMap[strtolower(trim($keywords[$jdx]['name']))];
@@ -733,7 +733,7 @@ function processRequirements(&$dbHandler,&$reqMgr,$tcaseName,$tcIDCard,
                " AND REQ.srs_id={$req_spec_id} ";     
                    
         $rsx = $dbHandler->get_recordset($sql);
-        if( $useit=((!is_null($rsx) && count($rsx) > 0) ? true : false) ) {
+        if( $useit=((!is_null($rsx) && count((array)$rsx) > 0) ? true : false) ) {
           $cachedReqSpec[$value['req_spec_title']]['req'][$value['doc_id']]=$rsx[0]['id'];
         }  
       }
@@ -796,7 +796,7 @@ function processAttachments( &$dbHandler, $isTestCase, $tcaseName, $xmlInternalI
                    
 			$rsx=$dbHandler->get_recordset($sql);
 			// allow attachment import only if no record with the same signature have been found in database
-			$addAttachment = ( is_null($rsx) || count($rsx) < 1 );
+			$addAttachment = ( is_null($rsx) || count((array)$rsx) < 1 );
 			if( $addAttachment === false ){ // inform user that the attachment has been skipped
 			  if( !isset($duplicateAttachment[$value['id']]) ) {
 				  $duplicateAttachment[$value['id']]=sprintf($messages['attachment'],$value['name']);  
@@ -862,7 +862,7 @@ function getTestCaseSetFromSimpleXMLObj($xmlTCs)
   }
     
   $jdx = 0;
-  $loops2do=sizeof($xmlTCs);
+  $loops2do=sizeof((array)$xmlTCs);
   $tcaseSet = array();
   
   // $tcXML['elements'] = array('string' => array("summary","preconditions"),
@@ -958,7 +958,7 @@ function getStepsFromSimpleXMLObj($simpleXMLItems)
     // need to do this due to (maybe) a wrong name choice for XML element
   if( !is_null($items) )
   {
-    $loop2do = count($items);
+    $loop2do = count((array)$items);
     for($idx=0; $idx < $loop2do; $idx++)
     {
       $items[$idx]['expected_results'] = '';
@@ -1115,7 +1115,7 @@ function importTestSuitesFromSimpleXML(&$dbHandler,&$xml,$parentID,$tproject_id,
     }
 
     $childrenNodes = $xml->children();  
-    $loop2do = sizeof($childrenNodes);
+    $loop2do = sizeof((array)$childrenNodes);
     
     for($idx = 0; $idx < $loop2do; $idx++) {
 

--- a/lib/testcases/tcSearch.php
+++ b/lib/testcases/tcSearch.php
@@ -300,7 +300,7 @@ function buildExtTable($gui, $charset, $edit_icon, $history_icon)  {
   $designCfg = getWebEditorCfg('design');
   $designType = $designCfg['type'];
   
-  if(null != $gui->resultSet && count($gui->resultSet) > 0)  {
+  if(null != $gui->resultSet && count((array)$gui->resultSet) > 0)  {
     $labels = array('test_suite' => lang_get('test_suite'), 'test_case' => lang_get('test_case'));
     $columns = array();
     

--- a/lib/testcases/tcSearch.php
+++ b/lib/testcases/tcSearch.php
@@ -265,7 +265,7 @@ if($gui->row_qty > 0)
   if ($map)
   {
     $tcase_mgr = new testcase($db);   
-    $tcase_set = array_keys($map);
+    $tcase_set = array_keys((array)$map);
     $options = array('output_format' => 'path_as_string');
     $gui->path_info = $tproject_mgr->tree_manager->get_full_path_verbose($tcase_set, $options);
     $gui->resultSet = $map;

--- a/lib/testcases/testcaseCommands.class.php
+++ b/lib/testcases/testcaseCommands.class.php
@@ -516,11 +516,11 @@ class testcaseCommands {
       // key level 2 : Test Plan  ID
       // key level 3 : Platform ID
       
-      $versionSet = array_keys($guiObj->exec_status_quo);
+      $versionSet = array_keys((array)$guiObj->exec_status_quo);
       $stop = false;
       foreach($versionSet as $version_id)
       {
-        $tplanSet = array_keys($guiObj->exec_status_quo[$version_id]);
+        $tplanSet = array_keys((array)$guiObj->exec_status_quo[$version_id]);
         foreach($tplanSet as $tplan_id)
         {
           if( ($guiObj->display_platform = !isset($guiObj->exec_status_quo[$version_id][$tplan_id][0])) )
@@ -627,7 +627,7 @@ class testcaseCommands {
     $guiObj->tcversion_id = $argsObj->tcversion_id;
 
     $guiObj->step_set = $this->tcaseMgr->get_step_numbers($argsObj->tcversion_id);
-    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys($guiObj->step_set));
+    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys((array)$guiObj->step_set));
     $guiObj->loadOnCancelURL = sprintf($guiObj->loadOnCancelURL,$argsObj->tcase_id,$argsObj->tcversion_id);
         
     // Get all existent steps
@@ -682,7 +682,7 @@ class testcaseCommands {
       $guiObj->step_number = $max_step;
 
       $guiObj->step_set = $this->tcaseMgr->get_step_numbers($argsObj->tcversion_id);
-      $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys($guiObj->step_set));
+      $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys((array)$guiObj->step_set));
       $guiObj->loadOnCancelURL = sprintf($guiObj->loadOnCancelURL,$argsObj->tcase_id,$argsObj->tcversion_id);
 
       $templateCfg = templateConfiguration('tcStepEdit');
@@ -745,7 +745,7 @@ class testcaseCommands {
     $guiObj->tcaseSteps = $this->tcaseMgr->get_steps($argsObj->tcversion_id);
 
     $guiObj->step_set = $this->tcaseMgr->get_step_numbers($argsObj->tcversion_id);
-    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys($guiObj->step_set));
+    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys((array)$guiObj->step_set));
 
     $templateCfg = templateConfiguration('tcStepEdit');
     $guiObj->template=$templateCfg->default_template;
@@ -899,7 +899,7 @@ class testcaseCommands {
     $guiObj->step_id = $argsObj->step_id;
 
     $guiObj->step_set = $this->tcaseMgr->get_step_numbers($argsObj->tcversion_id);
-    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys($guiObj->step_set));
+    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys((array)$guiObj->step_set));
     $guiObj->loadOnCancelURL = sprintf($guiObj->loadOnCancelURL,$argsObj->tcase_id,$argsObj->tcversion_id);
 
     $templateCfg = templateConfiguration('tcStepEdit');
@@ -978,7 +978,7 @@ class testcaseCommands {
     $guiObj->step_id = $op['id'];
 
     $guiObj->step_set = $this->tcaseMgr->get_step_numbers($argsObj->tcversion_id);
-    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys($guiObj->step_set));
+    $guiObj->step_set = is_null($guiObj->step_set) ? '' : implode(",",array_keys((array)$guiObj->step_set));
     $guiObj->loadOnCancelURL = sprintf($guiObj->loadOnCancelURL,$argsObj->tcase_id,$argsObj->tcversion_id);
     $templateCfg = templateConfiguration('tcStepEdit');
     $guiObj->template=$templateCfg->default_template;

--- a/lib/testcases/testcaseCommands.class.php
+++ b/lib/testcases/testcaseCommands.class.php
@@ -924,7 +924,7 @@ class testcaseCommands {
     // Get all existent steps - info needed to do renumbering
     $stepNumberSet = array();
     $existentSteps = $this->tcaseMgr->get_steps($argsObj->tcversion_id);
-    $stepsQty = count($existentSteps);
+    $stepsQty = count((array)$existentSteps);
     for($idx=0; $idx < $stepsQty; $idx++)
     {
       $stepNumberSet[$idx] = $existentSteps[$idx]['step_number'];
@@ -956,7 +956,7 @@ class testcaseCommands {
         // if not nothing needs to be done
         // if yes need to loop
         $startFrom = $hitPos +1;
-        $endOn = count($stepNumberSet);
+        $endOn = count((array)$stepNumberSet);
         for($jdx = $startFrom; $jdx < $endOn; $jdx++)
         {
           if( $stepNumberSet[$jdx] == $just_renumbered['value'] )
@@ -1007,7 +1007,7 @@ class testcaseCommands {
       // Get all existent steps - info needed to do renumbering
       $stepNumberSet = array();
       $stepSet = $this->tcaseMgr->get_steps($argsObj->tcversion_id);
-      $stepsQty = count($stepSet);
+      $stepsQty = count((array)$stepSet);
       for($idx=0; $idx < $stepsQty; $idx++) {
         $renumbered[$stepSet[$idx]['id']] = $idx+1; 
       }
@@ -1441,7 +1441,7 @@ class testcaseCommands {
     $this->initTestCaseBasicInfo($argsObj,$guiObj,array('accessByStepID' => false));
 
     $tcExternalID = $guiObj->testcase['tc_external_id'];
-    if( null != $argsObj->free_keywords && count($argsObj->free_keywords) > 0) {
+    if( null != $argsObj->free_keywords && count((array)$argsObj->free_keywords) > 0) {
       $this->tcaseMgr->addKeywords($guiObj->tcase_id,
                                    $guiObj->tcversion_id,
                                    $argsObj->free_keywords);

--- a/lib/usermanagement/rolesEdit.php
+++ b/lib/usermanagement/rolesEdit.php
@@ -274,7 +274,7 @@ function complete_gui(&$dbHandler,&$guiObj,&$argsObj,&$roleObj,&$webEditorObj)
     $webEditorObj->Value = $roleObj->description;
 
     // build checked attribute for checkboxes
-    if(sizeof($roleObj->rights))
+    if(sizeof((array)$roleObj->rights))
     {
       foreach($roleObj->rights as $key => $right)
       {

--- a/lib/usermanagement/rolesEdit.php
+++ b/lib/usermanagement/rolesEdit.php
@@ -99,7 +99,7 @@ function doOperation(&$dbHandler,$argsObj,$operation)
 
     case 'doCreate':
     case 'doUpdate':
-      $rights = implode("','",array_keys($argsObj->grant));
+      $rights = implode("','",array_keys((array)$argsObj->grant));
       $op->role->rights = tlRight::getAll($dbHandler,"WHERE description IN ('{$rights}')");
       $op->role->name = $argsObj->rolename;
       $op->role->description = $argsObj->notes;

--- a/lib/usermanagement/rolesView.php
+++ b/lib/usermanagement/rolesView.php
@@ -32,7 +32,7 @@ switch ($args->doAction)
     if ($role)
     {
       $gui->affectedUsers = $role->getAllUsersWithRole($db);
-      $doDelete = (sizeof($gui->affectedUsers) == 0);
+      $doDelete = (sizeof((array)$gui->affectedUsers) == 0);
     }
   break;
 

--- a/lib/usermanagement/usersAssign.php
+++ b/lib/usermanagement/usersAssign.php
@@ -278,7 +278,7 @@ function getTestProjectEffectiveRoles($dbHandler,&$objMgr,&$argsObj,$users) {
   // has right enough to assign user role.
   //
   $features = array();
-  $idSet = $key2loop = array_keys($testprojects);
+  $idSet = $key2loop = array_keys((array)$testprojects);
   $rolesCache = null;
   foreach($idSet as $tk) {
     // $rolesCache[$testprojects[$tk]['effective_role']][] = $tk;  
@@ -312,7 +312,7 @@ function getTestProjectEffectiveRoles($dbHandler,&$objMgr,&$argsObj,$users) {
 	
 	// get private/public status for feature2check
 	$featureIsPublic = 1;
-	$key2loop = array_keys($testprojects);
+	$key2loop = array_keys((array)$testprojects);
   foreach($key2loop as $ppx) {
 		if( $testprojects[$ppx]['id'] == $argsObj->featureID ) {
 			$featureIsPublic = $testprojects[$ppx]['is_public'];
@@ -349,7 +349,7 @@ function getTestPlanEffectiveRoles(&$dbHandler,&$tplanMgr,$tprojectMgr,&$argsObj
                                                               
     // we want to change map key, from testplan id to a sequential index
     // to maintain old logic
-    $activeKeys = array_keys($activeTestplans);
+    $activeKeys = array_keys((array)$activeTestplans);
     $myKeys = array_keys((array)$myAccessibleSet);
     $key2remove = $key2remove_diff = array_diff($activeKeys,$myKeys);
      if( !is_null($key2remove) ) {
@@ -364,7 +364,7 @@ function getTestPlanEffectiveRoles(&$dbHandler,&$tplanMgr,$tprojectMgr,&$argsObj
       $features = $activeTestplans;
     } else {
       $features = array();
-      $key2loop = array_keys($activeTestplans);
+      $key2loop = array_keys((array)$activeTestplans);
       foreach($key2loop as $idx) {
         if($argsObj->user->hasRight($dbHandler,"testplan_user_role_assignment",null,$activeTestplans[$idx]['id']) == "yes") {
           $features[$idx] = $activeTestplans[$idx];
@@ -377,7 +377,7 @@ function getTestPlanEffectiveRoles(&$dbHandler,&$tplanMgr,$tprojectMgr,&$argsObj
     if (!$argsObj->featureID) {
       if (sizeof((array)$features)) {
         if ($argsObj->testplanID) {
-          $key2loop = array_keys($features);
+          $key2loop = array_keys((array)$features);
           foreach($key2loop as $idx) {
             if ($argsObj->testplanID == $features[$idx]['id']) {
               $argsObj->featureID = $argsObj->testplanID;
@@ -428,7 +428,7 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
     //new dBug($myAccessibleSet);
    
     // we want to change map key, from testplan id to a sequential index to maintain old logic
-    $activeKeys = array_keys($activeTestplans);
+    $activeKeys = array_keys((array)$activeTestplans);
     $myKeys = array_keys((array)$myAccessibleSet);
 	  $key2remove = $key2remove_diff = array_diff($activeKeys,$myKeys);
     if( !is_null($key2remove) )
@@ -463,7 +463,7 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
 		  //$loop2do = sizeof((array)$activeTestplans);
 			//for($idx = 0; $idx < $loop2do; $idx++)
 			$features = array();
-		  $key2loop = array_keys($activeTestplans);
+		  $key2loop = array_keys((array)$activeTestplans);
 			foreach($key2loop as $idx)
 			{
         // Humm!!, think we need to check testplan_user_role_assignment and not "testplan_planning"
@@ -484,7 +484,7 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
 				{
 				  // $loop2do = sizeof((array)$features);
 					// for($idx = 0; $idx < $loop2do; $idx++)
-					$key2loop = array_keys($features);
+					$key2loop = array_keys((array)$features);
 					foreach($key2loop as $idx)
 					{
 						if ($argsObj->testplanID == $features[$idx]['id'])
@@ -515,7 +515,7 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
     // can manege roles on current selected test plan.
     // why I did not find this before ???
     $features = array();
-    $key2loop = array_keys($activeTestplans);
+    $key2loop = array_keys((array)$activeTestplans);
     foreach($key2loop as $idx)
     {
       $answer = $rolesCache[$testprojects[$idx]['effective_role']]->hasRight("user_role_assignment");
@@ -552,7 +552,7 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
 function doUpdate(&$dbHandler,&$argsObj,&$featureMgr)
 {
 	$featureMgr->deleteUserRoles($argsObj->featureID,
-                               array_keys($argsObj->map_userid_roleid));
+                               array_keys((array)$argsObj->map_userid_roleid));
 	foreach($argsObj->map_userid_roleid as $user_id => $role_id)
 	{
 		if ($role_id)

--- a/lib/usermanagement/usersAssign.php
+++ b/lib/usermanagement/usersAssign.php
@@ -115,7 +115,7 @@ $gui->grants = getGrantsForUserMgmt($db,$args->user,$target->testprojectID,-1);
 $gui->accessTypeImg = '';
 
 
-if(is_null($gui->features) || count($gui->features) == 0) {
+if(is_null($gui->features) || count((array)$gui->features) == 0) {
   $gui->features = null;
   if( $gui->user_feedback == '' ) {
 		$gui->user_feedback = $gui->not_for_you;
@@ -304,7 +304,7 @@ function getTestProjectEffectiveRoles($dbHandler,&$objMgr,&$argsObj,$users) {
 	if (!$argsObj->featureID) {
 		if ($argsObj->testprojectID) {
 			$argsObj->featureID = $argsObj->testprojectID;
-		} else if (sizeof($features)) {
+		} else if (sizeof((array)$features)) {
 		  $xx = current($features);
 			$argsObj->featureID = $xx['id'];
 		}	
@@ -375,7 +375,7 @@ function getTestPlanEffectiveRoles(&$dbHandler,&$tplanMgr,$tprojectMgr,&$argsObj
     // if nothing special was selected, 
     // use the one in the session or the first
     if (!$argsObj->featureID) {
-      if (sizeof($features)) {
+      if (sizeof((array)$features)) {
         if ($argsObj->testplanID) {
           $key2loop = array_keys($features);
           foreach($key2loop as $idx) {
@@ -460,7 +460,7 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
 		}
 		else
 		{
-		  //$loop2do = sizeof($activeTestplans);
+		  //$loop2do = sizeof((array)$activeTestplans);
 			//for($idx = 0; $idx < $loop2do; $idx++)
 			$features = array();
 		  $key2loop = array_keys($activeTestplans);
@@ -478,11 +478,11 @@ function getTestPlanEffectiveRolesNEW(&$dbHandler,&$tplanMgr,$tprojectMgr,&$args
 		//if nothing special was selected, use the one in the session or the first
 		if (!$argsObj->featureID)
 		{
-			if (sizeof($features))
+			if (sizeof((array)$features))
 			{
 				if ($argsObj->testplanID)
 				{
-				  // $loop2do = sizeof($features);
+				  // $loop2do = sizeof((array)$features);
 					// for($idx = 0; $idx < $loop2do; $idx++)
 					$key2loop = array_keys($features);
 					foreach($key2loop as $idx)

--- a/lib/usermanagement/usersEdit.php
+++ b/lib/usermanagement/usersEdit.php
@@ -441,7 +441,7 @@ function initializeGui(&$dbHandler,&$argsObj)
   $guiObj->auth_method_opt = array(lang_get('default_auth_method') . 
                              "(" . $guiObj->authCfg['domain'][$guiObj->authCfg['method']]['description'] . ")" => '');
 
-  $dummy = array_keys($guiObj->authCfg['domain']);
+  $dummy = array_keys((array)$guiObj->authCfg['domain']);
   foreach($dummy as $xc)
   {
     // description => html option value

--- a/lib/usermanagement/usersView.php
+++ b/lib/usermanagement/usersView.php
@@ -180,7 +180,7 @@ function buildMatrix(&$guiObj,&$argsObj)
                            'th_last_name' => null,'expiration' => null,
                            'th_email' => null));
 
-  $loop2do = count($guiObj->matrix);
+  $loop2do = count((array)$guiObj->matrix);
  
   // login added as workaround for SORTING, because the whole string is used then user_id
   // in url takes precedence over the login displayed 
@@ -249,7 +249,7 @@ function getAllUsersForGrid(&$dbHandler)
 
   // because we need to render this on EXT-JS, we have issues with <no rights> role
   // due to <, then we are going to escape values in description column
-  $loop2do = count($users);
+  $loop2do = count((array)$users);
   $dummy = '';
   for($idx=0; $idx < $loop2do; $idx++)
   {
@@ -291,7 +291,7 @@ function getAllUsersForGrid(&$dbHandler)
  
 	if( config_get('demoMode') )
 	{
-  	$loop2do = count($users);
+  	$loop2do = count((array)$users);
 	  $specialK = array_flip((array)config_get('demoSpecialUsers'));
   	for($idx=0; $idx < $loop2do; $idx++)
 	  {

--- a/lib/usermanagement/usersView.php
+++ b/lib/usermanagement/usersView.php
@@ -276,7 +276,7 @@ function getAllUsersForGrid(&$dbHandler)
     foreach($users as $row)
     {
       $cr = array();
-      $elem = array_keys($row);
+      $elem = array_keys((array)$row);
       foreach($elem as $accessKey)
       {
         if(!is_numeric($accessKey))

--- a/third_party/Zend/Http/Client.php
+++ b/third_party/Zend/Http/Client.php
@@ -1284,7 +1284,7 @@ class Zend_Http_Client
         }
 
         // If we have POST parameters or files, encode and add them to the body
-        if (count($this->paramsPost) > 0 || count($this->files) > 0) {
+        if (count((array)$this->paramsPost) > 0 || count((array)$this->files) > 0) {
             switch($this->enctype) {
                 case self::ENC_FORMDATA:
                     // Encode body as multipart/form-data

--- a/third_party/Zend/Http/Client/Adapter/Socket.php
+++ b/third_party/Zend/Http/Client/Adapter/Socket.php
@@ -421,7 +421,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             // If we got more than one Content-Length header (see ZF-9404) use
             // the last value sent
             if (is_array($headers['content-length'])) {
-                $contentLength = $headers['content-length'][count($headers['content-length']) - 1];
+                $contentLength = $headers['content-length'][count((array)$headers['content-length']) - 1];
             } else {
                 $contentLength = $headers['content-length'];
             }

--- a/third_party/Zend/Http/Client/Adapter/Test.php
+++ b/third_party/Zend/Http/Client/Adapter/Test.php
@@ -178,7 +178,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      */
     public function read()
     {
-        if ($this->responseIndex >= count($this->responses)) {
+        if ($this->responseIndex >= count((array)$this->responses)) {
             $this->responseIndex = 0;
         }
         return $this->responses[$this->responseIndex++];
@@ -228,7 +228,7 @@ class Zend_Http_Client_Adapter_Test implements Zend_Http_Client_Adapter_Interfac
      */
     public function setResponseIndex($index)
     {
-        if ($index < 0 || $index >= count($this->responses)) {
+        if ($index < 0 || $index >= count((array)$this->responses)) {
             require_once 'Zend/Http/Client/Adapter/Exception.php';
             throw new Zend_Http_Client_Adapter_Exception(
                 'Index out of range of response buffer size');

--- a/third_party/Zend/Http/Cookie.php
+++ b/third_party/Zend/Http/Cookie.php
@@ -322,7 +322,7 @@ class Zend_Http_Cookie
             }
 
             $keyValue = explode('=', $part, 2);
-            if (count($keyValue) == 2) {
+            if (count((array)$keyValue) == 2) {
                 list($k, $v) = $keyValue;
                 switch (strtolower($k))    {
                     case 'expires':

--- a/third_party/Zend/Http/CookieJar.php
+++ b/third_party/Zend/Http/CookieJar.php
@@ -369,7 +369,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      */
     public function count()
     {
-        return count($this->_rawCookies);
+        return count((array)$this->_rawCookies);
     }
 
     /**
@@ -389,7 +389,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      */
     public function isEmpty()
     {
-        return count($this) == 0;
+        return count((array)$this) == 0;
     }
 
     /**

--- a/third_party/Zend/Http/Response.php
+++ b/third_party/Zend/Http/Response.php
@@ -161,7 +161,7 @@ class Zend_Http_Response
         foreach ($headers as $name => $value) {
             if (is_int($name)) {
                 $header = explode(":", $value, 2);
-                if (count($header) != 2) {
+                if (count((array)$header) != 2) {
                     require_once 'Zend/Http/Exception.php';
                     throw new Zend_Http_Exception("'{$value}' is not a valid HTTP header");
                 }

--- a/third_party/Zend/Http/UserAgent/AbstractDevice.php
+++ b/third_party/Zend/Http/UserAgent/AbstractDevice.php
@@ -430,7 +430,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
             $result['product_version'] = trim($match[4]);
             $result['browser_version'] = trim($match[4]);
         }
-        if (count($comment) && !empty($comment[0])) {
+        if (count((array)$comment) && !empty($comment[0])) {
             $result['comment']['full']     = trim($match[7]);
             $result['comment']['detail']   = $comment;
             $result['compatibility_flag']  = trim($comment[0]);
@@ -447,7 +447,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
         }
         if ($match2) {
             $i = 0;
-            $max = count($match2[0]);
+            $max = count((array)$match2[0]);
             for ($i = 0; $i < $max; $i ++) {
                 if (!empty($match2[0][$i])) {
                     $result['others']['detail'][] = array(
@@ -557,7 +557,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
                 $result['browser_language'] = trim($comment[3]);
                 if (isset($result['others']['detail'][1])) {
                     $result['browser_version']  = $result['others']['detail'][1][2];
-                } elseif (count($result['others']['detail'])) {
+                } elseif (count((array)$result['others']['detail'])) {
                     $result['browser_version']  = $result['others']['detail'][0][2];
                 }
                 if (!empty($result['others']['detail'][2])) {
@@ -577,13 +577,13 @@ abstract class Zend_Http_UserAgent_AbstractDevice
                 if (isset($result['others']['detail'][1]) && $result['others']['detail'][1][1] == 'Version') {
                     $result['browser_version'] = $result['others']['detail'][1][2];
                 } else {
-                    $result['browser_version'] = $result['others']['detail'][count($result['others']['detail']) - 1][2];
+                    $result['browser_version'] = $result['others']['detail'][count((array)$result['others']['detail']) - 1][2];
                 }
                 if (isset($comment[3])) {
                      $result['browser_language'] = trim($comment[3]);
                 }
 
-                $last = $result['others']['detail'][count($result['others']['detail']) - 1][1];
+                $last = $result['others']['detail'][count((array)$result['others']['detail']) - 1][1];
 
                 if (empty($result['others']['detail'][2][1]) || $result['others']['detail'][2][1] == 'Safari') {
                     if (isset($result['others']['detail'][1])) {
@@ -630,13 +630,13 @@ abstract class Zend_Http_UserAgent_AbstractDevice
             // Gecko (Firefox or compatible)
             if ($result['others']['detail'][0][1] == 'Gecko') {
                 $searchRV = true;
-                if (!empty($result['others']['detail'][1][1]) && !empty($result['others']['detail'][count($result['others']['detail']) - 1][2]) || strpos(strtolower($result['others']['full']), 'opera') !== false) {
+                if (!empty($result['others']['detail'][1][1]) && !empty($result['others']['detail'][count((array)$result['others']['detail']) - 1][2]) || strpos(strtolower($result['others']['full']), 'opera') !== false) {
                     $searchRV = false;
                     $result['browser_engine'] = $result['others']['detail'][0][1];
 
                     // the name of the application is at the end indepenently
                     // of quantity of information in $result['others']['detail']
-                    $last = count($result['others']['detail']) - 1;
+                    $last = count((array)$result['others']['detail']) - 1;
 
                     // exception : if the version of the last information is
                     // empty we take the previous one
@@ -716,7 +716,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
         // UA ends with 'Opera X.XX'
         if (isset($result['browser_name']) && isset($result['browser_engine'])) {
             if ($result['browser_name'] == 'Opera' && $result['browser_engine'] == 'Gecko' && empty($result['browser_version'])) {
-                $result['browser_version'] = $result['others']['detail'][count($result['others']['detail']) - 1][1];
+                $result['browser_version'] = $result['others']['detail'][count((array)$result['others']['detail']) - 1][1];
             }
         }
 

--- a/third_party/Zend/Loader/Autoloader.php
+++ b/third_party/Zend/Loader/Autoloader.php
@@ -353,7 +353,7 @@ class Zend_Loader_Autoloader
 
         // Add non-namespaced autoloaders
         $autoloadersNonNamespace = $this->getNamespaceAutoloaders('');
-        if (count($autoloadersNonNamespace)) {
+        if (count((array)$autoloadersNonNamespace)) {
             foreach ($autoloadersNonNamespace as $ns) {
                 $autoloaders[] = $ns;
             }
@@ -536,7 +536,7 @@ class Zend_Loader_Autoloader
         }
 
         $parts = explode('.', $version);
-        $count = count($parts);
+        $count = count((array)$parts);
         if (1 == $count) {
             return 'major';
         }

--- a/third_party/Zend/Loader/Autoloader/Resource.php
+++ b/third_party/Zend/Loader/Autoloader/Resource.php
@@ -157,7 +157,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
             }
         }
 
-        if (count($segments) < 2) {
+        if (count((array)$segments) < 2) {
             // assumes all resources have a component and class name, minimum
             return false;
         }
@@ -171,7 +171,7 @@ class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interfac
             if (isset($this->_components[$component])) {
                 $lastMatch = $component;
             }
-        } while (count($segments));
+        } while (count((array)$segments));
 
         if (!$lastMatch) {
             return false;

--- a/third_party/Zend/Validate/Hostname.php
+++ b/third_party/Zend/Validate/Hostname.php
@@ -507,7 +507,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
 
         // Check input against DNS hostname schema
         $domainParts = explode('.', $value);
-        if ((count($domainParts) > 1) && (strlen($value) >= 4) && (strlen($value) <= 254)) {
+        if ((count((array)$domainParts) > 1) && (strlen($value) >= 4) && (strlen($value) <= 254)) {
             $status = false;
 
             $origenc = iconv_get_encoding('internal_encoding');
@@ -596,7 +596,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
                     }
 
                     // If one of the labels doesn't match, the hostname is invalid
-                    if ($check !== count($domainParts)) {
+                    if ($check !== count((array)$domainParts)) {
                         $this->_error(self::INVALID_HOSTNAME_SCHEMA);
                         $status = false;
                     }
@@ -668,7 +668,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
             return false;
         }
 
-        $lengthd = count($decoded);
+        $lengthd = count((array)$decoded);
         $lengthe = strlen($encoded);
 
         // decoding

--- a/third_party/Zend/XmlRpc/Client.php
+++ b/third_party/Zend/XmlRpc/Client.php
@@ -340,7 +340,7 @@ class Zend_XmlRpc_Client
                         continue;
                     }
 
-                    if (count($signatures) > 1) {
+                    if (count((array)$signatures) > 1) {
                         $type = Zend_XmlRpc_Value::getXmlRpcTypeByValue($param);
                         foreach ($signatures as $signature) {
                             if (!is_array($signature)) {

--- a/third_party/Zend/XmlRpc/Client/ServerIntrospection.php
+++ b/third_party/Zend/XmlRpc/Client/ServerIntrospection.php
@@ -99,7 +99,7 @@ class Zend_XmlRpc_Client_ServerIntrospection
             throw new Zend_XmlRpc_Client_IntrospectException($error);
         }
 
-        if (count($serverSignatures) != count($methods)) {
+        if (count((array)$serverSignatures) != count((array)$methods)) {
             $error = 'Bad number of signatures received from multicall';
             require_once 'Zend/XmlRpc/Client/IntrospectException.php';
             throw new Zend_XmlRpc_Client_IntrospectException($error);

--- a/third_party/Zend/XmlRpc/Request.php
+++ b/third_party/Zend/XmlRpc/Request.php
@@ -412,7 +412,7 @@ class Zend_XmlRpc_Request
                   ->openElement('methodName', $method)
                   ->closeElement('methodName');
 
-        if (is_array($args) && count($args)) {
+        if (is_array($args) && count((array)$args)) {
             $generator->openElement('params');
 
             foreach ($args as $arg) {

--- a/third_party/Zend/XmlRpc/Server.php
+++ b/third_party/Zend/XmlRpc/Server.php
@@ -566,7 +566,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
         $info     = $this->_table->getMethod($method);
         $params   = $request->getParams();
         $argv     = $info->getInvokeArguments();
-        if (0 < count($argv) and $this->sendArgumentsToAllMethods()) {
+        if (0 < count((array)$argv) and $this->sendArgumentsToAllMethods()) {
             $params = array_merge($params, $argv);
         }
 
@@ -574,8 +574,8 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
         $matched    = false;
         $sigCalled  = $request->getTypes();
 
-        $sigLength  = count($sigCalled);
-        $paramsLen  = count($params);
+        $sigLength  = count((array)$sigCalled);
+        $paramsLen  = count((array)$params);
         if ($sigLength < $paramsLen) {
             for ($i = $sigLength; $i < $paramsLen; ++$i) {
                 $xmlRpcValue = Zend_XmlRpc_Value::getXmlRpcValue($params[$i]);

--- a/third_party/Zend/XmlRpc/Value.php
+++ b/third_party/Zend/XmlRpc/Value.php
@@ -269,7 +269,7 @@ abstract class Zend_XmlRpc_Value
             }
             return self::getXmlRpcTypeByValue(get_object_vars($value));
         } elseif (is_array($value)) {
-            if (!empty($value) && is_array($value) && (array_keys($value) !== range(0, count($value) - 1))) {
+            if (!empty($value) && is_array($value) && (array_keys($value) !== range(0, count((array)$value) - 1))) {
                 return self::XMLRPC_TYPE_STRUCT;
             }
             return self::XMLRPC_TYPE_ARRAY;

--- a/third_party/ckeditorWrapper/CKEditorPHPWrapper.php
+++ b/third_party/ckeditorWrapper/CKEditorPHPWrapper.php
@@ -389,7 +389,7 @@ class CKEditor
 				if (empty($handlers)) {
 					continue;
 				}
-				else if (count($handlers) == 1) {
+				else if (count((array)$handlers) == 1) {
 					$_config['on'][$eventName] = '@@'.$handlers[0];
 				}
 				else {
@@ -529,7 +529,7 @@ class CKEditor
 			return str_replace(',', '.', $val);
 		}
 		if (is_array($val) || is_object($val)) {
-			if (is_array($val) && (array_keys($val) === range(0,count($val)-1))) {
+			if (is_array($val) && (array_keys($val) === range(0,count((array)$val)-1))) {
 				return '[' . implode(',', array_map(array($this, 'jsEncode'), $val)) . ']';
 			}
 			$temp = array();

--- a/third_party/dBug/dBug.php
+++ b/third_party/dBug/dBug.php
@@ -97,7 +97,7 @@ class dBug {
 		$arrInclude = array("include","include_once","require","require_once");
 		
 		//check for any included/required files. if found, get array of the last included file (they contain the right line numbers)
-		for($i=count($arrBacktrace)-1; $i>=0; $i--) {
+		for($i=count((array)$arrBacktrace)-1; $i>=0; $i--) {
 			$arrCurrent = $arrBacktrace[$i];
 			if(array_key_exists("function", $arrCurrent) && 
 				(in_array($arrCurrent["function"], $arrInclude) || (0 != strcasecmp($arrCurrent["function"], "dbug"))))
@@ -302,7 +302,7 @@ class dBug {
 		echo "<tr><td class=\"dBug_resourceKey\">&nbsp;</td>";
 		for($i=0;$i<$numfields;$i++) {
 			$field_header = "";
-			for($j=0; $j<count($arrFields); $j++) {
+			for($j=0; $j<count((array)$arrFields); $j++) {
 				$db_func = $db."_field_".$arrFields[$j];
 				if(function_exists($db_func)) {
 					$fheader = call_user_func($db_func, $var, $i). " ";
@@ -400,7 +400,7 @@ class dBug {
 		$this->xmlSData[$this->xmlCount].='$this->makeTDHeader("xml","xmlName");';
 		$this->xmlSData[$this->xmlCount].='echo "<strong>'.$this->xmlName[$this->xmlCount].'</strong>".$this->closeTDRow();';
 		$this->xmlSData[$this->xmlCount].='$this->makeTDHeader("xml","xmlAttributes");';
-		if(count($attribs)>0)
+		if(count((array)$attribs)>0)
 			$this->xmlSData[$this->xmlCount].='$this->varIsArray($this->xmlAttrib['.$this->xmlCount.']);';
 		else
 			$this->xmlSData[$this->xmlCount].='echo "&nbsp;";';

--- a/third_party/daisydiff/src/Diff.php
+++ b/third_party/daisydiff/src/Diff.php
@@ -59,7 +59,7 @@ class WikiDiff3 {
     public function diff(/*array*/ $from, /*array*/ $to){
         //remember initial lengths
         $m = sizeof($from);
-        $n = count($to);
+        $n = count((array)$to);
 
         $this->heuristicUsed = false;
 
@@ -110,8 +110,8 @@ class WikiDiff3 {
 
         unset($shared, $from, $to);
 
-        $this->m = count($this->from);
-        $this->n = count($this->to);
+        $this->m = count((array)$this->from);
+        $this->n = count((array)$this->to);
 
         $this->removed = $this->m > 0 ? array_fill(0, $this->m, true) : array();
         $this->added = $this->n > 0 ? array_fill(0, $this->n, true) : array();

--- a/third_party/daisydiff/src/HTMLDiff.php
+++ b/third_party/daisydiff/src/HTMLDiff.php
@@ -109,7 +109,7 @@ class DomTreeBuilder {
      */
     public function endDocument() {
         $this->endWord();
-        HTMLDiffer::diffDebug( count($this->textNodes) . " text nodes in document.\n" );
+        HTMLDiffer::diffDebug( count((array)$this->textNodes) . " text nodes in document.\n" );
     }
 
     public function startElement($parser, $name, /*array*/ $attributes) {
@@ -320,7 +320,7 @@ class TextNodeDiffer {
         $junk1 = $junk2 = null;
         $deletedNodes = $root->getMinimalDeletedSet($this->deletedID, $junk1, $junk2);
 
-        HTMLDiffer::diffDebug( "Minimal set of deleted nodes of size " . count($deletedNodes) . "\n" );
+        HTMLDiffer::diffDebug( "Minimal set of deleted nodes of size " . count((array)$deletedNodes) . "\n" );
 
         // Set prevLeaf to the leaf after which the old HTML needs to be
         // inserted
@@ -329,11 +329,11 @@ class TextNodeDiffer {
         }
         // Set nextLeaf to the leaf before which the old HTML needs to be
         // inserted
-        if ($before < count($this->textNodes)) {
+        if ($before < count((array)$this->textNodes)) {
             $nextLeaf = $this->textNodes[$before];
         }
 
-        while (count($deletedNodes) > 0) {
+        while (count((array)$deletedNodes) > 0) {
             if (isset($prevLeaf)) {
                 $prevResult = $prevLeaf->getLastCommonParent($deletedNodes[0]);
             } else {
@@ -342,7 +342,7 @@ class TextNodeDiffer {
                 $prevResult->indexInLastCommonParent = -1;
             }
             if (isset($nextLeaf)) {
-                $nextResult = $nextLeaf->getLastCommonParent($deletedNodes[count($deletedNodes) - 1]);
+                $nextResult = $nextLeaf->getLastCommonParent($deletedNodes[count((array)$deletedNodes) - 1]);
             } else {
                 $nextResult = new LastCommonParentResult();
                 $nextResult->parent = $this->bodyNode;
@@ -351,7 +351,7 @@ class TextNodeDiffer {
 
             if ($prevResult->lastCommonParentDepth == $nextResult->lastCommonParentDepth) {
                 // We need some metric to choose which way to add-...
-                if ($deletedNodes[0]->parent === $deletedNodes[count($deletedNodes) - 1]->parent
+                if ($deletedNodes[0]->parent === $deletedNodes[count((array)$deletedNodes) - 1]->parent
                         && $prevResult->parent === $nextResult->parent) {
                     // The difference is not in the parent
                     $prevResult->lastCommonParentDepth = $prevResult->lastCommonParentDepth + 1;
@@ -359,7 +359,7 @@ class TextNodeDiffer {
                     // The difference is in the parent, so compare them
                     // now THIS is tricky
                     $distancePrev = $deletedNodes[0]->parent->getMatchRatio($prevResult->parent);
-                    $distanceNext = $deletedNodes[count($deletedNodes) - 1]->parent->getMatchRatio($nextResult->parent);
+                    $distanceNext = $deletedNodes[count((array)$deletedNodes) - 1]->parent->getMatchRatio($nextResult->parent);
 
                     if ($distancePrev <= $distanceNext) {
                         $prevResult->lastCommonParentDepth = $prevResult->lastCommonParentDepth + 1;
@@ -390,8 +390,8 @@ class TextNodeDiffer {
                         $nextResult->indexInLastCommonParent = $nextResult->indexInLastCommonParent + 1;
                     }
                 }
-                $nextLeaf = $deletedNodes[count($deletedNodes) - 1]->copyTree();
-                unset($deletedNodes[count($deletedNodes) - 1]);
+                $nextLeaf = $deletedNodes[count((array)$deletedNodes) - 1]->copyTree();
+                unset($deletedNodes[count((array)$deletedNodes) - 1]);
                 $deletedNodes = array_values($deletedNodes);
                 $nextLeaf->setParent($nextResult->parent);
                 $nextResult->parent->addChildAbsolute($nextLeaf,$nextResult->indexInLastCommonParent);
@@ -405,11 +405,11 @@ class TextNodeDiffer {
     }
 
     public function lengthNew(){
-        return count($this->textNodes);
+        return count((array)$this->textNodes);
     }
 
     public function lengthOld(){
-        return count($this->oldTextNodes);
+        return count((array)$this->oldTextNodes);
     }
 }
 
@@ -496,13 +496,13 @@ class HTMLDiffer {
         $output = new HTMLOutput('htmldiff');
 
         //return $output->parse($textNodeDiffer->bodyNode);
-        return array($output->parse($textNodeDiffer->bodyNode), count($differences));
+        return array($output->parse($textNodeDiffer->bodyNode), count((array)$differences));
     }
 
     private function preProcess(/*array*/ $differences) {
         $newRanges = array();
 
-        $nbDifferences = count($differences);
+        $nbDifferences = count((array)$differences);
         for ($i = 0; $i < $nbDifferences; ++$i) {
             $leftStart = $differences[$i]->leftstart;
             $leftEnd = $differences[$i]->leftend;
@@ -547,7 +547,7 @@ class HTMLDiffer {
             $d += $number;
 
         }
-        return $d / (1.5 * count($numbers));
+        return $d / (1.5 * count((array)$numbers));
     }
 
     /**
@@ -588,8 +588,8 @@ class TextOnlyComparator {
     }
 
     public function getMatchRatio(TextOnlyComparator $other) {
-        $nbOthers = count($other->leafs);
-        $nbThis = count($this->leafs);
+        $nbOthers = count((array)$other->leafs);
+        $nbThis = count((array)$this->leafs);
         if($nbOthers == 0 || $nbThis == 0){
             return -log(0);
         }
@@ -625,7 +625,7 @@ class AncestorComparator {
         $diffengine = new WikiDiff3(10000, 1.35);
         $differences = $diffengine->diff_range($other->ancestorsText,$this->ancestorsText);
 
-        if (count($differences) == 0){
+        if (count((array)$differences) == 0){
             return null;
         }
         $changeTxt = new ChangeTextGenerator($this, $other);
@@ -650,11 +650,11 @@ class ChangeTextGenerator {
     public function getChanged(/*array*/ $differences) {
         $txt = new ChangeText;
         $rootlistopened = false;
-        if (count($differences) > 1) {
+        if (count((array)$differences) > 1) {
             $txt->addHtml('<ul class="changelist">');
             $rootlistopened = true;
         }
-        $nbDifferences = count($differences);
+        $nbDifferences = count((array)$differences);
         for ($j = 0; $j < $nbDifferences; ++$j) {
             $d = $differences[$j];
             $lvl1listopened = false;
@@ -799,14 +799,14 @@ class TagToString {
     }
 
     protected function addAttributes(ChangeText $txt, array $attributes) {
-        if (count($attributes) < 1) {
+        if (count((array)$attributes) < 1) {
             return;
         }
 
         $keys = array_keys($attributes);
         $txt->addHtml(Sanitizer::normalizeCharReferences( ' with "' . $keys[0] . '" attribute as "' . $attributes[$keys[0]] . '"'));
 
-        $nbAttributes_min_1 = count($attributes)-1;
+        $nbAttributes_min_1 = count((array)$attributes)-1;
         for ($i=1;$i<$nbAttributes_min_1;$i++) {
             $key = $keys[$i];
             $attr = $attributes[$key];

--- a/third_party/daisydiff/src/Nodes.php
+++ b/third_party/daisydiff/src/Nodes.php
@@ -60,8 +60,8 @@ class Node {
 
         $i = 1;
         $isSame = true;
-        $nbMyParents = count($myParents);
-        $nbOtherParents = count($otherParents);
+        $nbMyParents = count((array)$myParents);
+        $nbOtherParents = count((array)$otherParents);
         
         while ($isSame && $i < $nbMyParents && $i < $nbOtherParents) {
             if ($myParents[$i]->toDiffTag !== $otherParents[$i]->toDiffTag ||
@@ -150,7 +150,7 @@ class TagNode extends Node {
     }
 
     public function getNbChildren() {
-        return count($this->children);
+        return count((array)$this->children);
     }
 
     public function getMinimalDeletedSet($id, &$allDeleted, &$somethingDeleted) {

--- a/third_party/daisydiff/src/Sanitizer.php
+++ b/third_party/daisydiff/src/Sanitizer.php
@@ -709,7 +709,7 @@ class Sanitizer {
 
             $attribs[] = "$encAttribute=\"$encValue\"";
         }
-        return count( $attribs ) ? ' ' . implode( ' ', $attribs ) : '';
+        return count((array)$attribs) ? ' ' . implode( ' ', $attribs ) : '';
     }
 
     /**

--- a/third_party/fayp-jira-rest/Jira.php
+++ b/third_party/fayp-jira-rest/Jira.php
@@ -467,7 +467,7 @@ class Jira
         $opt = 'expand=projects.issuetypes.fields';
         $items = $this->getCreateIssueMetadata($projectKeys,$opt);
         $ret = null;
-        if(!is_null($items) && count($items->projects) > 0)
+        if(!is_null($items) && count((array)$items->projects) > 0)
         {
             $ro = &$items->projects;
             foreach($ro as $ele)

--- a/third_party/kint/decorators/plain.php
+++ b/third_party/kint/decorators/plain.php
@@ -87,7 +87,7 @@ class Kint_Decorators_Plain
 	public static function decorateTrace( $traceData )
 	{
 		$output   = self::_title( 'TRACE' );
-		$lastStep = count( $traceData );
+		$lastStep = count((array)$traceData);
 		foreach ( $traceData as $stepNo => $step ) {
 			$title = str_pad( ++$stepNo . ': ', 4, ' ' );
 

--- a/third_party/kint/inc/kintParser.class.php
+++ b/third_party/kint/inc/kintParser.class.php
@@ -289,7 +289,7 @@ abstract class kintParser extends kintVariableData
 		}
 
 		$variableData->type = 'array';
-		$variableData->size = count( $variable );
+		$variableData->size = count((array)$variable);
 
 		if ( $variableData->size === 0 ) {
 			return;
@@ -415,7 +415,7 @@ abstract class kintParser extends kintVariableData
 
 		$castedArray        = (array) $variable;
 		$variableData->type = get_class( $variable );
-		$variableData->size = count( $castedArray );
+		$variableData->size = count((array)$castedArray);
 
 		if ( isset( self::$_objects[ $hash ] ) ) {
 			$variableData->value = '*RECURSION*';

--- a/third_party/kint/inc/kintVariableData.class.php
+++ b/third_party/kint/inc/kintVariableData.class.php
@@ -62,7 +62,7 @@ class kintVariableData
 	 */
 	protected static function _isSequential( array $array )
 	{
-		return array_keys( $array ) === range( 0, count( $array ) - 1 );
+		return array_keys( $array ) === range( 0, count((array)$array) - 1 );
 	}
 
 	protected static function _strlen( $string, $encoding = null )

--- a/third_party/kint/parsers/custom/classstatics.php
+++ b/third_party/kint/parsers/custom/classstatics.php
@@ -44,6 +44,6 @@ class Kint_Parsers_ClassStatics extends kintParser
 
 		$this->value = $extendedValue;
 		$this->type  = 'Static class properties';
-		$this->size  = count( $extendedValue );
+		$this->size  = count((array)$extendedValue);
 	}
 }

--- a/third_party/kint/parsers/custom/color.php
+++ b/third_party/kint/parsers/custom/color.php
@@ -82,16 +82,16 @@ class Kint_Parsers_Color extends kintParser
 			$color            = self::$_css3Named[ $color ];
 		}
 
-		if ( $color{0} === '#' ) {
+		if ( $color[0] === '#' ) {
 			$variants['hex'] = $color;
 			$color           = substr( $color, 1 );
 			if ( strlen( $color ) === 6 ) {
 				$colors = str_split( $color, 2 );
 			} else {
 				$colors = array(
-					$color{0} . $color{0},
-					$color{1} . $color{1},
-					$color{2} . $color{2},
+					$color[0] . $color[0],
+					$color[1] . $color[1],
+					$color[2] . $color[2],
 				);
 			}
 

--- a/third_party/kint/parsers/custom/json.php
+++ b/third_party/kint/parsers/custom/json.php
@@ -6,7 +6,7 @@ class Kint_Parsers_Json extends kintParser
 	{
 		if ( !KINT_PHP53
 			|| !is_string( $variable )
-			|| !isset( $variable{0} ) || ( $variable{0} !== '{' && $variable{0} !== '[' )
+			|| !isset( $variable[0] ) || ( $variable[0] !== '{' && $variable[0] !== '[' )
 			|| ( $json = json_decode( $variable, true ) ) === null
 		) return false;
 

--- a/third_party/kint/parsers/custom/microtime.php
+++ b/third_party/kint/parsers/custom/microtime.php
@@ -22,7 +22,7 @@ class Kint_Parsers_Microtime extends kintParser
 		$this->value = @date( 'Y-m-d H:i:s', $sec ) . '.' . substr( $usec, 2, 4 );
 
 		$numberOfCalls = count( self::$_times );
-		if ( $numberOfCalls > 0 ) { # meh, faster than count($times) > 1
+		if ( $numberOfCalls > 0 ) { # meh, faster than count((array)$times) > 1
 			$lap           = $time - end( self::$_times );
 			self::$_laps[] = $lap;
 

--- a/third_party/kint/parsers/custom/objectiterateable.php
+++ b/third_party/kint/parsers/custom/objectiterateable.php
@@ -17,6 +17,6 @@ class Kint_Parsers_objectIterateable extends kintParser
 
 		$this->value = kintParser::factory( $arrayCopy )->extendedValue;
 		$this->type  = 'Iterator contents';
-		$this->size  = count( $arrayCopy );
+		$this->size  = count((array)$arrayCopy);
 	}
 }

--- a/third_party/user_contribution/migrate_cf_links.php
+++ b/third_party/user_contribution/migrate_cf_links.php
@@ -41,10 +41,10 @@ $sql = " SELECT CFDV.*, NHITEM.node_type_id, NHVERSION.id AS version_node_id" .
 
 $workingSet = $db->get_recordset($sql);
 
-echo 'Records to process: '.count($workingSet).'<br>';
+echo 'Records to process: '.count((array)$workingSet).'<br>';
 if( !is_null($workingSet) )
 {
-	echo "Working - Custom Fields Migration - Records to process:" .  count($workingSet) . "<br>";
+	echo "Working - Custom Fields Migration - Records to process:" .  count((array)$workingSet) . "<br>";
 	foreach($workingSet as $target)
 	{
 		// $values[] = "( {$target['field_id']}, {$target['version_node_id']}, '{$target['value']}' )";

--- a/third_party/xml-rpc/class-IXR.php
+++ b/third_party/xml-rpc/class-IXR.php
@@ -32,7 +32,7 @@ class IXR_Value {
             }
         }
         if ($type == 'array') {
-            for ($i = 0, $j = count($this->data); $i < $j; $i++) {
+            for ($i = 0, $j = count((array)$this->data); $i < $j; $i++) {
                 $this->data[$i] = new IXR_Value($this->data[$i]);
             }
         }
@@ -251,14 +251,14 @@ class IXR_Message {
                 break;
         }
         if ($valueFlag) {
-            if (count($this->_arraystructs) > 0) {
+            if (count((array)$this->_arraystructs) > 0) {
                 // Add value to struct or array
-                if ($this->_arraystructstypes[count($this->_arraystructstypes)-1] == 'struct') {
+                if ($this->_arraystructstypes[count((array)$this->_arraystructstypes)-1] == 'struct') {
                     // Add to struct
-                    $this->_arraystructs[count($this->_arraystructs)-1][$this->_currentStructName[count($this->_currentStructName)-1]] = $value;
+                    $this->_arraystructs[count((array)$this->_arraystructs)-1][$this->_currentStructName[count((array)$this->_currentStructName)-1]] = $value;
                 } else {
                     // Add to array
-                    $this->_arraystructs[count($this->_arraystructs)-1][] = $value;
+                    $this->_arraystructs[count((array)$this->_arraystructs)-1][] = $value;
                 }
             } else {
                 // Just add as a paramater
@@ -335,7 +335,7 @@ EOD;
         }
         $method = $this->callbacks[$methodname];
         // Perform the callback and send the response
-        if (count($args) == 1) {
+        if (count((array)$args) == 1) {
             // If only one paramater just send that instead of the whole array
             $args = $args[0];
         }
@@ -728,13 +728,13 @@ class IXR_IntrospectionServer extends IXR_Server {
         $signature = $this->signatures[$methodname];
         $returnType = array_shift($signature);
         // Check the number of arguments
-        if (count($args) != count($signature)) {
+        if (count((array)$args) != count((array)$signature)) {
             return new IXR_Error(-32602, 'server error. wrong number of method parameters');
         }
         // Check the argument types
         $ok = true;
         $argsbackup = $args;
-        for ($i = 0, $j = count($args); $i < $j; $i++) {
+        for ($i = 0, $j = count((array)$args); $i < $j; $i++) {
             $arg = array_shift($args);
             $type = array_shift($signature);
             switch ($type) {

--- a/third_party/youtrackclient/src/connection.php
+++ b/third_party/youtrackclient/src/connection.php
@@ -247,7 +247,7 @@ class Connection {
   }
 
   public function import_users($users) {
-    if (count($users) <= 0) {
+    if (count((array)$users) <= 0) {
       return;
     }
     $xml = "<list>\n";


### PR DESCRIPTION
---
  Title:
  fix(php8): PHP 8 compatibility fixes — count/sizeof/array_keys null safety, typo corrections, SQL guard
  
  ---
  Body:

  ## Summary
  
  This PR fixes a series of PHP 8 compatibility issues that cause fatal errors
  or broken behaviour when running TestLink 1.9.20 on PHP 8.0+. All fixes were
  validated against a running PHP 8.1 + MySQL 8.0 environment (Docker Compose).

  ---

  ## Problem
  
  PHP 8 introduced strict type enforcement that breaks several patterns which
  were silently tolerated in PHP 7:

  | PHP 7 behaviour | PHP 8 behaviour |
  |---|---|
  | `count(null)` → `0` | `TypeError` fatal |
  | `sizeof(null)` → `0` | `TypeError` fatal |
  | `array_keys(null)` → `[]` | `TypeError` fatal |
  | `$var{N}` string offset | Removed — parse error |
  | Undefined constant used as string | `Error` fatal |

  In addition, two non-PHP-8 bugs were found and fixed:
  - A typo `(arrya)` cast in `xmlrpc.class.php` caused HTTP 500 on all XMLRPC
    API calls invoking `getPlatforms()`
  - An empty `$users` array in `deleteUserRoles()` generated `IN()` which is
    invalid SQL and crashed the query

  ---
  
  ## Changes

  ### 1. Curly brace string offsets → bracket syntax
  **Files:** `third_party/kint/`

  PHP 8.0 removed `$var{N}` syntax for string offset access. Replaced all
  occurrences with `$var[N]`.

  ---

  ### 2. `count()` / `sizeof()` null safety — `lib/`
  **Files:** 149 files across `lib/`

  Wrapped variable and property-chain arguments with `(array)` cast:
  ```php
  // Before
  count($someVariable)

  // After
  count((array)$someVariable)
  Preserves PHP 7 behaviour (returns 0 for null) without changing logic
  for non-null values.

  ---
  3. Typo fix: (arrya) → (array) in xmlrpc.class.php
  
  File: lib/api/xmlrpc/v1/xmlrpc.class.php

  The cast (arrya) is a typo that PHP 8 treats as an undefined constant,
  throwing a fatal Error. This caused HTTP 500 on any XMLRPC API call that
  invokes getPlatforms(). Fixed to (array).

  ---
  4. Bare constant lib → quoted string in REST example
  
  File: lib/api/rest/v3/custom/api/RestApiCustomExample.class.php

  PHP 8 removed silent treatment of undefined constants as strings. The
  expression $ds. lib .$ds used lib as a bare word. Quoted as 'lib'.

  ---
  5. count() null safety — third_party/
  
  Files: 31 files across third_party/ (Zend, XML-RPC IXR, kint, daisydiff, etc.)

  Same (array) cast guard applied to the bundled third-party libraries
  for consistent PHP 8 compatibility.

  ---
  6. array_keys() null safety — lib/
  
  Files: 75 files across lib/

  array_keys(null) throws TypeError in PHP 8. Applied (array) cast
  across all variable and property-chain argument patterns in lib/.

  ---
  7. array_keys() on method call returns — testplan.class.php

  File: lib/functions/testplan.class.php

  getPlatforms() and get_builds() can return null when no data exists.
  Guards added specifically for method-call patterns not covered by bulk fix:
  // Before
  array_keys($this->getPlatforms(...))

  // After
  array_keys((array)$this->getPlatforms(...))

  ---
  8. array_keys() on method call return — treeMenu.inc.php

  File: lib/functions/treeMenu.inc.php

  Same guard for $tplan_mgr->get_builds() which returns null when a test
  plan has no builds.

  ---
  9. array_keys() targeted fixes — 3 files
  
  Files: requirement_mgr.class.php, cfieldsTprojectAssign.php, planImport.php

  Three specific locations with non-standard patterns not covered by the bulk
  regex pass:
  - array_keys(current($rs)) — $rs may be null
  - array_keys($argsObj->$serviceInput) — dynamic property access
  - array_keys($linkedVersions[...]) — nested array element access

  ---
  10. deleteUserRoles — guard against empty IN() SQL

  File: lib/functions/testplan.class.php

  When $users is an empty array the generated SQL becomes WHERE user_id IN()
  which is invalid and causes a database error. Added !empty($users) alongside
  the existing !is_null($users) guard so the query is skipped for empty sets:
  // Before
  if (!is_null($users))
  
  // After
  if (!is_null($users) && !empty($users))

  ---
  11. Docker / containerised install: installUtils.php wildcard host

  File: install/installUtils.php

  When running in Docker or any setup where the application connects via a
  bridge/proxy IP, MySQL CREATE USER and GRANT statements using the exact
  hostname fail with Access denied. Changed host from '$safeDBHost' /
  'localhost' to '%' to allow connections from any host — standard practice
  for containerised deployments.

  ---
  Testing
  
  - PHP version: 8.1
  - MySQL version: 8.0
  - Environment: Docker Compose (php:8.1-apache + mysql:8.0)
  - Tested flows: installation, login, test project creation, test case CRUD,
  test plan execution, XMLRPC API (getPlatforms, getTestCases),
  user management, requirements management, report generation

  All previously failing endpoints return HTTP 200. No regressions observed
  in tested flows.

  ---
  Related
  
  - Issue #399 — PHP 8.x adjustments (Part 1)
  - PR #403 / #407 — (arrya) typo fix (this PR includes the same fix)

  ---

  A few tips before you open the PR:
  - Target branch: `testlink_1_9_20_fixed` (not `main`)
  - The upstream maintainer (`fmancardi`) is active — last commit Dec 2025, so expect a response
  - Fix #11 (Docker host) may get pushback since it weakens MySQL security — be ready to explain the Docker networking
  context
